### PR TITLE
Configure Flask template and static directories

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -5,8 +5,12 @@ from .main.routes import main_bp
 
 
 def create_app():
-    app = Flask(__name__)
-    app.secret_key = 'dev-secret-key'
+    app = Flask(
+        __name__,
+        template_folder="../templates",
+        static_folder="../static",
+    )
+    app.secret_key = "dev-secret-key"
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)


### PR DESCRIPTION
## Summary
- Configure `create_app` to load templates and static assets from project-level folders

## Testing
- `python -m py_compile app/__init__.py`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68af44e852d48325a1df2a9770be96f7