### PR TITLE
Add admin role with dedicated panel and updated passwords

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -4,7 +4,7 @@ auth_bp = Blueprint('auth', __name__)
 
 USERS = {
     'USER': 'fuji',
-    'ADMIN': 'fujiadmin',
+    'ADMIN': 'MasterAdmin',
 }
 
 

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,5 @@
-from flask import Blueprint, render_template, session, redirect, url_for
+from flask import Blueprint, render_template, session, redirect, url_for, abort
+from functools import wraps
 
 main_bp = Blueprint('main', __name__)
 
@@ -8,3 +9,18 @@ def home():
     if 'username' not in session:
         return redirect(url_for('auth.login'))
     return render_template('home.html', username=session.get('username'))
+
+
+def admin_required(view):
+    @wraps(view)
+    def wrapped_view(**kwargs):
+        if session.get('username') != 'ADMIN':
+            abort(403)
+        return view(**kwargs)
+    return wrapped_view
+
+
+@main_bp.route('/admin')
+@admin_required
+def admin_panel():
+    return render_template('admin.html', username=session.get('username'))

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1>Admin Control Panel</h1>
+<p>Only administrators can view this page.</p>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -41,8 +41,10 @@
       <span class="user-text">user:{{ username }}</span>
       {% endif %}
       <a href="#">Docs</a>
+      {% if username == 'ADMIN' %}
+      <a href="{{ url_for('main.admin_panel') }}">Settings</a>
+      {% endif %}
       <a href="{{ url_for('auth.logout') }}">Logout</a>
-      <a href="#">Settings</a>
       <a href="#">Light</a>
       <a href="#">Dark</a>
     </div>


### PR DESCRIPTION
## Summary
- Update login credentials so ADMIN uses `MasterAdmin` and USER uses `fuji`
- Add role-based access control with an admin-only panel and decorator
- Show user identity in navbar and restrict Settings link to ADMIN

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af467e29688325b1ef79e66ee102c4