### PR TITLE
Add Supabase integration and helper

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,7 @@
-from flask import Flask
+import os
+
+from flask import Flask, current_app
+from supabase import create_client
 
 from .auth.routes import auth_bp
 from .main.routes import main_bp
@@ -12,7 +15,17 @@ def create_app():
     )
     app.secret_key = "dev-secret-key"
 
+    supabase = create_client(
+        os.environ["SUPABASE_URL"],
+        os.environ["SUPABASE_SERVICE_KEY"],
+    )
+    app.config["SUPABASE"] = supabase
+
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)
 
     return app
+
+
+def get_supabase():
+    return current_app.config["SUPABASE"]


### PR DESCRIPTION
## Summary
- Integrate Supabase client into the Flask app using environment variables
- Provide `get_supabase()` helper for easier access to the Supabase client

## Testing
- `python -m py_compile app/__init__.py`
- `pytest -q` (no tests found)
- ⚠️ `pip install supabase` (failed: Cannot connect to proxy)


------
https://chatgpt.com/codex/tasks/task_e_68af4a51564883259b616f0cbd5db73f