### PR TITLE
Use environment variables for secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SECRET_KEY=your-secret-key
+SUPABASE_URL=your-supabase-url
+SUPABASE_SERVICE_KEY=your-supabase-service-key
+USER_PASSWORD=user-password
+ADMIN_PASSWORD=admin-password

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -13,7 +13,7 @@ def create_app():
         template_folder="../templates",
         static_folder="../static",
     )
-    app.secret_key = "dev-secret-key"
+    app.secret_key = os.environ["SECRET_KEY"]
 
     supabase = create_client(
         os.environ["SUPABASE_URL"],

--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -1,10 +1,13 @@
+import os
+
 from flask import Blueprint, render_template, request, redirect, url_for, session, flash
+from werkzeug.security import check_password_hash, generate_password_hash
 
 auth_bp = Blueprint('auth', __name__)
 
 USERS = {
-    'USER': 'fuji',
-    'ADMIN': 'MasterAdmin',
+    'USER': generate_password_hash(os.environ["USER_PASSWORD"]),
+    'ADMIN': generate_password_hash(os.environ["ADMIN_PASSWORD"]),
 }
 
 
@@ -14,7 +17,7 @@ def login():
     if request.method == 'POST':
         username = request.form.get('username')
         password = request.form.get('password')
-        if USERS.get(username) == password:
+        if username in USERS and check_password_hash(USERS[username], password):
             session['username'] = username
             return redirect(url_for('main.home'))
         flash('Invalid credentials.')


### PR DESCRIPTION
## Summary
- Load Flask `SECRET_KEY` from environment
- Source user passwords from environment and verify using Werkzeug hashes
- Document required environment variables in `.env.example`

## Testing
- `python -m py_compile app/__init__.py app/auth/routes.py`
- `SECRET_KEY=testkey USER_PASSWORD=foo ADMIN_PASSWORD=bar SUPABASE_URL=url SUPABASE_SERVICE_KEY=key python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af4b7e2a7483259293f4503e21f5e4