### PR TITLE
Limit insert operations to admins and expose read routes

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,5 +1,23 @@
-from flask import Blueprint, render_template, session, redirect, url_for, abort
+from flask import (
+    Blueprint,
+    render_template,
+    session,
+    redirect,
+    url_for,
+    abort,
+    request,
+    jsonify,
+)
 from functools import wraps
+
+from app.db import (
+    fetch_aoi_reports,
+    fetch_fi_reports,
+    fetch_moat,
+    insert_aoi_report,
+    insert_fi_report,
+    insert_moat,
+)
 
 main_bp = Blueprint('main', __name__)
 
@@ -24,3 +42,63 @@ def admin_required(view):
 @admin_required
 def admin_panel():
     return render_template('admin.html', username=session.get('username'))
+
+
+@main_bp.route('/aoi_reports', methods=['GET'])
+def get_aoi_reports():
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    data, error = fetch_aoi_reports()
+    if error:
+        abort(500, description=error)
+    return jsonify(data)
+
+
+@main_bp.route('/aoi_reports', methods=['POST'])
+@admin_required
+def add_aoi_report():
+    payload = request.get_json() or {}
+    data, error = insert_aoi_report(payload)
+    if error:
+        abort(500, description=error)
+    return jsonify(data), 201
+
+
+@main_bp.route('/fi_reports', methods=['GET'])
+def get_fi_reports():
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    data, error = fetch_fi_reports()
+    if error:
+        abort(500, description=error)
+    return jsonify(data)
+
+
+@main_bp.route('/fi_reports', methods=['POST'])
+@admin_required
+def add_fi_report():
+    payload = request.get_json() or {}
+    data, error = insert_fi_report(payload)
+    if error:
+        abort(500, description=error)
+    return jsonify(data), 201
+
+
+@main_bp.route('/moat', methods=['GET'])
+def get_moat_data():
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    data, error = fetch_moat()
+    if error:
+        abort(500, description=error)
+    return jsonify(data)
+
+
+@main_bp.route('/moat', methods=['POST'])
+@admin_required
+def add_moat_data():
+    payload = request.get_json() or {}
+    data, error = insert_moat(payload)
+    if error:
+        abort(500, description=error)
+    return jsonify(data), 201


### PR DESCRIPTION
## Summary
- add JSON routes for AOI, FI, and MOAT data
- restrict insert operations with `@admin_required`
- allow non-admin users to fetch data

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af51c127048325bf80d8479a1e09f2