### PR TITLE
Add MOAT false-call preview chart to home

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -1,4 +1,5 @@
 from flask import current_app
+from datetime import datetime, timedelta
 
 
 def _get_client():
@@ -38,6 +39,22 @@ def fetch_moat():
         return response.data, None
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to fetch MOAT data: {exc}"
+
+
+def fetch_recent_moat(days: int = 7):
+    """Retrieve MOAT data for the past ``days`` days."""
+    supabase = _get_client()
+    start_date = (datetime.utcnow() - timedelta(days=days)).date().isoformat()
+    try:
+        response = (
+            supabase.table("moat")
+            .select("*")
+            .gte("Report Date", start_date)
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch recent MOAT data: {exc}"
 
 
 def insert_aoi_report(data: dict):

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -14,6 +14,7 @@ from app.db import (
     fetch_aoi_reports,
     fetch_fi_reports,
     fetch_moat,
+    fetch_recent_moat,
     insert_aoi_report,
     insert_fi_report,
     insert_moat,
@@ -102,3 +103,52 @@ def add_moat_data():
     if error:
         abort(500, description=error)
     return jsonify(data), 201
+
+
+@main_bp.route('/moat_preview', methods=['GET'])
+def moat_preview():
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    data, error = fetch_recent_moat()
+    if error:
+        abort(500, description=error)
+    if not data:
+        return jsonify({
+            "models": [],
+            "avg_false_calls": [],
+            "overall_avg": 0,
+            "start_date": None,
+            "end_date": None,
+        })
+    from collections import defaultdict
+
+    grouped = defaultdict(lambda: {"falsecall": 0, "boards": 0})
+    dates = []
+    for row in data:
+        fc = row.get('FalseCall Parts') or row.get('falsecall_parts') or 0
+        boards = row.get('Total Boards') or row.get('total_boards') or 0
+        model = row.get('Model Name') or row.get('model_name') or 'Unknown'
+        date = row.get('Report Date') or row.get('report_date')
+        if date:
+            dates.append(str(date))
+        grouped[model]["falsecall"] += fc
+        grouped[model]["boards"] += boards
+
+    models, averages = [], []
+    total_avg = 0
+    for model, vals in grouped.items():
+        avg = (vals["falsecall"] / vals["boards"]) if vals["boards"] else 0
+        models.append(model)
+        averages.append(avg)
+        total_avg += avg
+
+    overall_avg = total_avg / len(averages) if averages else 0
+    start_date = min(dates) if dates else None
+    end_date = max(dates) if dates else None
+    return jsonify({
+        "models": models,
+        "avg_false_calls": averages,
+        "overall_avg": overall_avg,
+        "start_date": start_date,
+        "end_date": end_date,
+    })

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -139,3 +139,17 @@ body {
   list-style: none;
   padding: 0;
 }
+
+.preview-wrapper {
+  margin-top: 20px;
+}
+
+.preview-card {
+  border: 2px solid #000;
+  padding: 10px;
+}
+
+.preview-info {
+  font-weight: bold;
+  margin-bottom: 5px;
+}

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,1 +1,47 @@
-// Placeholder for future JavaScript
+function renderPreview(endpoint, canvasId, infoId) {
+  fetch(endpoint)
+    .then((res) => res.json())
+    .then((data) => {
+      const ctx = document.getElementById(canvasId).getContext('2d');
+      // eslint-disable-next-line no-undef
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.models,
+          datasets: [
+            {
+              label: 'Avg False Calls',
+              data: data.avg_false_calls,
+              borderColor: 'rgba(75, 192, 192, 1)',
+              backgroundColor: 'rgba(75, 192, 192, 0.2)',
+              fill: false,
+              tension: 0,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          scales: {
+            y: { beginAtZero: true },
+          },
+        },
+      });
+
+      const infoEl = document.getElementById(infoId);
+      if (infoEl) {
+        const avg = data.overall_avg ? data.overall_avg.toFixed(2) : '0';
+        infoEl.textContent = `${data.start_date} to ${data.end_date} | Avg False Calls: ${avg}`;
+      }
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load preview', err);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  if (document.getElementById('moatChart')) {
+    renderPreview('/moat_preview', 'moatChart', 'moat-info');
+  }
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -51,5 +51,6 @@
     {% block content %}{% endblock %}
   </div>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,5 +2,14 @@
 
 {% block content %}
 <h1>Welcome to MOAA</h1>
-<p>Home page content will go here.</p>
+<div id="moat-preview" class="preview-wrapper">
+  <div id="moat-info" class="preview-info"></div>
+  <div class="preview-card">
+    <canvas id="moatChart"></canvas>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- fetch latest 7 days of MOAT data from Supabase and compute average false-call metrics
- expose `/moat_preview` API and render interactive control chart on the home page
- add generic preview styles and scripts to support future dashboard previews

## Testing
- `python -m py_compile app/db.py app/main/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68af594102ec8325b36dc8bcc3078809