### PR TITLE
Support chart descriptions in PPM analysis

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -217,6 +217,7 @@ function collectChartConfig() {
 function collectParamsForSave() {
   return {
     title: document.getElementById('chart-title').value || '',
+    description: document.getElementById('chart-description').value || '',
     start_date: document.getElementById('start-date').value || '',
     end_date: document.getElementById('end-date').value || '',
     transform_expression: document.getElementById('transform-expression').value || '',
@@ -232,6 +233,7 @@ function collectParamsForSave() {
 
 function loadParamsIntoBuilder(params) {
   document.getElementById('chart-title').value = params.title || '';
+  document.getElementById('chart-description').value = params.description || '';
   document.getElementById('start-date').value = params.start_date || '';
   document.getElementById('end-date').value = params.end_date || '';
   document.getElementById('transform-expression').value = params.transform_expression || '';
@@ -297,6 +299,7 @@ function getDateInputs() {
 
 function runChart() {
   const title = document.getElementById('chart-title').value.trim();
+  const description = document.getElementById('chart-description').value.trim();
   runPresetChart()
     .then((result) => {
       const cfg = collectChartConfig();
@@ -344,12 +347,13 @@ function runChart() {
 
       if (ppmChartInstance) ppmChartInstance.destroy();
       // eslint-disable-next-line no-undef
-      ppmChartInstance = new Chart(ctx, { type: chartType, data: { labels, datasets }, options, plugins: (result.kind==='line-control' ? [controlLinesPlugin] : []) });
-      currentData = { labels, values: datasets[0]?.data || [], datasets };
-      window.currentChartMeta = { labels, datasets, type: chartType, options };
-      updateInfo(labels, datasets[0]?.data || []);
-      if (title) document.getElementById('modal-title').textContent = title;
-    })
+        ppmChartInstance = new Chart(ctx, { type: chartType, data: { labels, datasets }, options, plugins: (result.kind==='line-control' ? [controlLinesPlugin] : []) });
+        currentData = { labels, values: datasets[0]?.data || [], datasets };
+        window.currentChartMeta = { labels, datasets, type: chartType, options };
+        updateInfo(labels, datasets[0]?.data || []);
+        if (title) document.getElementById('modal-title').textContent = title;
+        document.getElementById('chart-description-result').textContent = description;
+      })
     .catch(() => { document.getElementById('ppm-info').textContent = 'Failed to build chart.'; });
 }
 

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -21,6 +21,13 @@
         </div>
       </div>
 
+      <div class="field-row">
+        <div class="field">
+          <label for="chart-description">Chart Description</label>
+          <textarea id="chart-description" placeholder="Describe this chart"></textarea>
+        </div>
+      </div>
+
     <div class="section-title" style="margin-top:10px;">Data Range</div>
     <div class="field-row">
       <div class="field">
@@ -166,9 +173,10 @@
         <canvas id="ppmChart"></canvas>
       </div>
       <div id="ppm-info" class="preview-info" style="margin-top:4px;"></div>
+      <div id="chart-description-result" class="preview-info" style="margin-top:4px;"></div>
       <small>Control limits shown: mean (blue), UCL/LCL (red/green).</small>
     </div>
-</div>
+  </div>
 
 <!-- Modal for Expanded View + Data Table -->
 <div id="chart-modal" class="modal-overlay">


### PR DESCRIPTION
## Summary
- add chart description textarea and result display to PPM analysis page
- persist description in saved chart parameters and reload into builder
- show description with chart results after running a chart

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b08887ea18832587c70923a6256b69