### PR TITLE
Show chart title in results

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -299,6 +299,7 @@ function getDateInputs() {
 
 function runChart() {
   const title = document.getElementById('chart-title').value.trim();
+  document.getElementById('result-chart-name').textContent = title || '(untitled)';
   const description = document.getElementById('chart-description').value.trim();
   runPresetChart()
     .then((result) => {

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -163,7 +163,7 @@
 
   <!-- Bottom Right: Results -->
     <div class="analysis-bottom-right section-card">
-      <div class="section-title">Results</div>
+      <div class="section-title">Results: <span id="result-chart-name"></span></div>
       <div class="field-row" style="margin-bottom:6px;">
         <button type="button" id="expand-chart">Expand</button>
         <button type="button" id="download-pdf">Download PDF</button>


### PR DESCRIPTION
## Summary
- show the current chart title beside the results header
- default the results header to '(untitled)' when the title field is blank

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b0896c70248325b23f8c19fc4d9a74