### PR TITLE
Add chart and CSV export to PPM analysis modal

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -931,6 +931,37 @@ async function copyChartImage() {
   }
 }
 
+function downloadExpandedChart() {
+  const canvas = document.getElementById('ppmChartExpanded');
+  if (!canvas) return;
+  const link = document.createElement('a');
+  const title = document.getElementById('chart-title').value || 'chart';
+  link.download = `${title}.png`;
+  link.href = canvas.toDataURL('image/png');
+  link.click();
+}
+
+function downloadTableCSV() {
+  const rows = document.querySelectorAll('#data-tbody tr');
+  const lines = ['Date,Value'];
+  rows.forEach((tr) => {
+    const cols = tr.querySelectorAll('td');
+    const date = cols[0]?.textContent ?? '';
+    const val = cols[1]?.textContent ?? '';
+    const esc = (s) => `"${String(s).replace(/"/g, '""')}"`;
+    lines.push(`${esc(date)},${esc(val)}`);
+  });
+  const csv = lines.join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const title = document.getElementById('chart-title').value || 'data';
+  link.href = url;
+  link.download = `${title}.csv`;
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
 function downloadPDF() {
   const meta = window.currentChartMeta;
   if (!meta) return;
@@ -983,6 +1014,8 @@ document.addEventListener('DOMContentLoaded', () => {
   document.getElementById('modal-close').addEventListener('click', () => expandModal(false));
   document.getElementById('download-pdf').addEventListener('click', downloadPDF);
   document.getElementById('copy-image').addEventListener('click', copyChartImage);
+  document.getElementById('modal-download-chart').addEventListener('click', downloadExpandedChart);
+  document.getElementById('modal-download-csv').addEventListener('click', downloadTableCSV);
 
   // Initialize filters and saved preset list
   initFiltersUI();

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -188,6 +188,10 @@
     <div class="modal-chart-box">
       <canvas id="ppmChartExpanded"></canvas>
     </div>
+    <div class="field-row" style="margin-top:10px;">
+      <button type="button" id="modal-download-chart">Download Chart</button>
+      <button type="button" id="modal-download-csv">Download CSV</button>
+    </div>
     <div style="margin-top:10px;" class="section-title">Data</div>
     <table class="data-table">
       <thead><tr><th>Date</th><th>Value</th></tr></thead>


### PR DESCRIPTION
## Summary
- add buttons to download expanded chart or table data
- implement PNG and CSV export utilities in ppm.js
- bind new utilities to modal buttons

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08a570f488325a9c468a0b461a170