### PR TITLE
Add save controls and overwrite support for PPM analysis

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -122,3 +122,18 @@ def insert_saved_query(data: dict):
         return response.data, None
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to save chart query: {exc}"
+
+
+def update_saved_query(name: str, data: dict):
+    """Update or upsert a saved chart query definition by ``name``."""
+    supabase = _get_client()
+    try:
+        payload = {**data, "name": name}
+        response = (
+            supabase.table("ppm_saved_queries")
+            .upsert(payload, on_conflict="name")
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to update saved query: {exc}"

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -144,6 +144,11 @@
     </div>
 
     <div class="field-row" style="margin-top:12px;">
+      <div class="field" style="flex:1;">
+        <label for="save-name">Save As</label>
+        <input id="save-name" placeholder="Chart name" />
+      </div>
+      <button type="button" id="save-chart">Save</button>
       <button type="button" id="run-chart">Run</button>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Add save-name field and Save button to PPM chart builder
- Support overwriting saved queries with confirm prompt and server-side upsert
- Reload saved query cache after saving to avoid duplicates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08cfad6608325aa36bead68af68c6