### PR TITLE
Add description support for saved PPM queries

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -98,6 +98,7 @@ def fetch_saved_queries():
       - id (uuid) [optional]
       - name (text)
       - type (text)
+      - description (text)
       - params (json)
       - created_at (timestamptz)
     """
@@ -105,7 +106,7 @@ def fetch_saved_queries():
     try:
         response = (
             supabase.table("ppm_saved_queries")
-            .select("id,name,type,params,created_at")
+            .select("id,name,type,description,params,created_at")
             .order("created_at", desc=True)
             .execute()
         )
@@ -115,7 +116,10 @@ def fetch_saved_queries():
 
 
 def insert_saved_query(data: dict):
-    """Insert a saved chart query definition into Supabase."""
+    """Insert a saved chart query definition into Supabase.
+
+    ``data`` should include ``name``, ``type``, ``params`` and optional ``description``.
+    """
     supabase = _get_client()
     try:
         response = supabase.table("ppm_saved_queries").insert(data).execute()
@@ -125,7 +129,11 @@ def insert_saved_query(data: dict):
 
 
 def update_saved_query(name: str, data: dict):
-    """Update or upsert a saved chart query definition by ``name``."""
+    """Update or upsert a saved chart query definition by ``name``.
+
+    ``data`` may include ``type``, ``params`` and ``description`` which will be
+    merged with the provided ``name``.
+    """
     supabase = _get_client()
     try:
         payload = {**data, "name": name}

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -231,6 +231,7 @@ def ppm_saved_queries():
         return jsonify(data)
 
     payload = request.get_json() or {}
+    payload = {k: payload.get(k) for k in ["name", "type", "params", "description"] if k in payload}
     overwrite = request.method == 'PUT' or request.args.get('overwrite')
     if overwrite:
         name = payload.get('name')

--- a/migrations/20240605_add_description_to_ppm_saved_queries.sql
+++ b/migrations/20240605_add_description_to_ppm_saved_queries.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ppm_saved_queries ADD COLUMN description text;


### PR DESCRIPTION
## Summary
- add migration for `description` column on `ppm_saved_queries`
- expose `description` through database helpers and API route
- send and display query descriptions in PPM analysis UI

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b08e8bc42c83259274f8f2482e9091