### PR TITLE
Add AOI Daily Reports analytics page

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -159,3 +159,54 @@ def update_saved_query(name: str, data: dict):
         return response.data, None
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to update saved query: {exc}"
+
+
+def fetch_saved_aoi_queries():
+    """Retrieve saved chart queries for the AOI Daily Reports page.
+
+    Expects a Supabase table named ``aoi_saved_queries`` with at least the
+    following columns:
+      - id (uuid) [optional]
+      - name (text)
+      - description (text)
+      - start_date (date)
+      - end_date (date)
+      - params (json)
+      - created_at (timestamptz)
+    """
+    supabase = _get_client()
+    try:
+        response = (
+            supabase.table("aoi_saved_queries")
+            .select("id,name,description,start_date,end_date,params,created_at")
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch AOI saved queries: {exc}"
+
+
+def insert_saved_aoi_query(data: dict):
+    """Insert a saved AOI chart query definition into Supabase."""
+    supabase = _get_client()
+    try:
+        response = supabase.table("aoi_saved_queries").insert(data).execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to save AOI chart query: {exc}"
+
+
+def update_saved_aoi_query(name: str, data: dict):
+    """Update or upsert a saved AOI chart query by ``name``."""
+    supabase = _get_client()
+    try:
+        payload = {**data, "name": name}
+        response = (
+            supabase.table("aoi_saved_queries")
+            .upsert(payload, on_conflict="name")
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to update AOI saved query: {exc}"

--- a/static/js/aoi.js
+++ b/static/js/aoi.js
@@ -1,0 +1,252 @@
+let aoiChartInstance = null;
+let aoiChartExpandedInstance = null;
+let currentData = { labels: [], accepted: [], rejected: [] };
+let savedQueriesCache = [];
+
+function uniqueSorted(arr) {
+  return Array.from(new Set(arr.filter((x) => x != null && x !== ''))).sort();
+}
+
+function populateSelect(id, values) {
+  const sel = document.getElementById(id);
+  sel.innerHTML = '';
+  values.forEach((v) => {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v;
+    sel.appendChild(opt);
+  });
+}
+
+function initFiltersUI() {
+  fetch('/aoi_reports')
+    .then((r) => r.json())
+    .then((rows) => {
+      if (!Array.isArray(rows)) return;
+      populateSelect('filter-job', uniqueSorted(rows.map((r) => r['Job Number'])));
+      populateSelect('filter-rev', uniqueSorted(rows.map((r) => r['Rev'])));
+      populateSelect('filter-assembly', uniqueSorted(rows.map((r) => r['Assembly'])));
+      populateSelect('filter-customer', uniqueSorted(rows.map((r) => r['Customer'])));
+      populateSelect('filter-operator', uniqueSorted(rows.map((r) => r['Operator'])));
+    });
+}
+
+function getSelectedValues(id) {
+  const sel = document.getElementById(id);
+  return Array.from(sel.selectedOptions).map((o) => o.value);
+}
+
+function renderChart(targetId, labels, accepted, rejected) {
+  const ctx = document.getElementById(targetId).getContext('2d');
+  const data = {
+    labels,
+    datasets: [
+      { label: 'Accepted', data: accepted, backgroundColor: 'rgba(54,162,235,0.6)', stack: 'stack' },
+      { label: 'Rejected', data: rejected, backgroundColor: 'rgba(255,99,132,0.6)', stack: 'stack' },
+    ],
+  };
+  const options = {
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      x: { stacked: true },
+      y: { stacked: true, beginAtZero: true },
+    },
+  };
+  if (targetId === 'aoiChart' && aoiChartInstance) aoiChartInstance.destroy();
+  if (targetId === 'aoiChartExpanded' && aoiChartExpandedInstance) aoiChartExpandedInstance.destroy();
+  // eslint-disable-next-line no-undef
+  const inst = new Chart(ctx, { type: 'bar', data, options });
+  if (targetId === 'aoiChart') aoiChartInstance = inst; else aoiChartExpandedInstance = inst;
+}
+
+function fillTable(labels, accepted, rejected) {
+  const tbody = document.getElementById('data-tbody');
+  tbody.innerHTML = '';
+  labels.forEach((lab, i) => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${lab}</td><td>${accepted[i]}</td><td>${rejected[i]}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+function expandModal(show) {
+  const overlay = document.getElementById('chart-modal');
+  overlay.style.display = show ? 'flex' : 'none';
+  if (show) {
+    renderChart('aoiChartExpanded', currentData.labels, currentData.accepted, currentData.rejected);
+    fillTable(currentData.labels, currentData.accepted, currentData.rejected);
+  }
+}
+
+document.getElementById('expand-chart').addEventListener('click', () => expandModal(true));
+document.getElementById('modal-close').addEventListener('click', () => expandModal(false));
+
+document.getElementById('modal-download-chart').addEventListener('click', () => {
+  const canvas = document.getElementById('aoiChartExpanded');
+  const link = document.createElement('a');
+  link.href = canvas.toDataURL('image/png');
+  link.download = 'chart.png';
+  link.click();
+});
+
+document.getElementById('modal-download-csv').addEventListener('click', () => {
+  const { labels, accepted, rejected } = currentData;
+  let csv = 'Operator,Accepted,Rejected\n';
+  labels.forEach((lab, i) => { csv += `${lab},${accepted[i]},${rejected[i]}\n`; });
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'data.csv';
+  link.click();
+  URL.revokeObjectURL(url);
+});
+
+function runChart() {
+  const params = {
+    start_date: document.getElementById('start-date').value,
+    end_date: document.getElementById('end-date').value,
+    job_numbers: getSelectedValues('filter-job').join(','),
+    rev_numbers: getSelectedValues('filter-rev').join(','),
+    assemblies: getSelectedValues('filter-assembly').join(','),
+    customers: getSelectedValues('filter-customer').join(','),
+    operators: getSelectedValues('filter-operator').join(','),
+  };
+  const qs = new URLSearchParams(params).toString();
+  fetch(`/analysis/aoi/data?${qs}`)
+    .then((r) => r.json())
+    .then((res) => {
+      currentData = { labels: res.labels || [], accepted: res.accepted || [], rejected: res.rejected || [] };
+      renderChart('aoiChart', currentData.labels, currentData.accepted, currentData.rejected);
+      document.getElementById('result-chart-name').textContent = document.getElementById('chart-title').value || '';
+      document.getElementById('chart-description-result').textContent = document.getElementById('chart-description').value || '';
+    });
+}
+
+document.getElementById('run-chart').addEventListener('click', runChart);
+
+async function copyChartImage() {
+  const canvas = document.getElementById('aoiChart');
+  if (!navigator.clipboard || !navigator.clipboard.write) { alert('Clipboard API not supported.'); return; }
+  try {
+    const blob = await new Promise((resolve) => canvas.toBlob(resolve));
+    await navigator.clipboard.write([new ClipboardItem({ [blob.type]: blob })]);
+    alert('Chart image copied to clipboard.');
+  } catch (e) {
+    alert('Failed to copy image.');
+  }
+}
+
+document.getElementById('copy-image').addEventListener('click', copyChartImage);
+
+document.getElementById('download-pdf').addEventListener('click', () => {
+  const { jsPDF } = window.jspdf;
+  const canvas = document.getElementById('aoiChart');
+  const dataURL = canvas.toDataURL('image/png', 1.0);
+  const pdf = new jsPDF();
+  const imgProps = pdf.getImageProperties(dataURL);
+  const pdfWidth = pdf.internal.pageSize.getWidth();
+  const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+  pdf.addImage(dataURL, 'PNG', 0, 0, pdfWidth, pdfHeight);
+  const title = document.getElementById('chart-title').value || 'chart';
+  pdf.save(`${title}.pdf`);
+});
+
+function defaultPresets() {
+  return [
+    {
+      name: 'Operator Reject Rate',
+      description: 'Boards accepted vs rejected per operator',
+      params: { start_date: '', end_date: '', job_numbers: [], rev_numbers: [], assemblies: [], customers: [], operators: [] },
+    },
+  ];
+}
+
+function renderSavedList() {
+  const q = (document.getElementById('saved-search').value || '').toLowerCase();
+  const list = document.getElementById('saved-list');
+  list.innerHTML = '';
+  savedQueriesCache.filter((r) => (r.name || '').toLowerCase().includes(q)).forEach((row) => {
+    const li = document.createElement('li');
+    li.textContent = row.name;
+    li.addEventListener('click', () => loadParams(row));
+    list.appendChild(li);
+  });
+}
+
+document.getElementById('saved-search').addEventListener('input', renderSavedList);
+
+function setSelectValues(id, values) {
+  const sel = document.getElementById(id);
+  Array.from(sel.options).forEach((opt) => { opt.selected = values.includes(opt.value); });
+}
+
+function loadParams(row) {
+  const p = row.params || {};
+  document.getElementById('chart-title').value = row.name || '';
+  document.getElementById('chart-description').value = row.description || '';
+  document.getElementById('start-date').value = p.start_date || '';
+  document.getElementById('end-date').value = p.end_date || '';
+  setSelectValues('filter-job', p.job_numbers || []);
+  setSelectValues('filter-rev', p.rev_numbers || []);
+  setSelectValues('filter-assembly', p.assemblies || []);
+  setSelectValues('filter-customer', p.customers || []);
+  setSelectValues('filter-operator', p.operators || []);
+  document.getElementById('result-chart-name').textContent = row.name || '';
+  document.getElementById('chart-description-result').textContent = row.description || '';
+  runChart();
+}
+
+function loadSavedQueries() {
+  fetch('/analysis/aoi/saved')
+    .then((r) => r.json())
+    .then((rows) => {
+      savedQueriesCache = defaultPresets().concat(Array.isArray(rows) ? rows : []);
+      renderSavedList();
+      if (savedQueriesCache[0]) loadParams(savedQueriesCache[0]);
+    })
+    .catch(() => {
+      savedQueriesCache = defaultPresets();
+      renderSavedList();
+      if (savedQueriesCache[0]) loadParams(savedQueriesCache[0]);
+    });
+}
+
+function collectParams() {
+  return {
+    start_date: document.getElementById('start-date').value || '',
+    end_date: document.getElementById('end-date').value || '',
+    job_numbers: getSelectedValues('filter-job'),
+    rev_numbers: getSelectedValues('filter-rev'),
+    assemblies: getSelectedValues('filter-assembly'),
+    customers: getSelectedValues('filter-customer'),
+    operators: getSelectedValues('filter-operator'),
+  };
+}
+
+function saveQuery() {
+  const name = document.getElementById('save-name').value.trim();
+  if (!name) { alert('Please provide a name for this chart.'); return; }
+  const existing = savedQueriesCache.find((q) => q.name === name);
+  if (existing && !confirm('Overwrite existing chart?')) return;
+  const description = document.getElementById('chart-description').value.trim();
+  const payload = {
+    name,
+    description,
+    start_date: document.getElementById('start-date').value || '',
+    end_date: document.getElementById('end-date').value || '',
+    params: collectParams(),
+  };
+  const method = existing ? 'PUT' : 'POST';
+  fetch('/analysis/aoi/saved', { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+    .then((res) => { if (!res.ok) throw new Error('save failed'); return res.json(); })
+    .then(() => { document.getElementById('save-name').value=''; loadSavedQueries(); })
+    .catch(() => alert('Failed to save chart. Ensure Supabase table exists.'));
+}
+
+document.getElementById('save-chart').addEventListener('click', saveQuery);
+
+// Initialize on load
+initFiltersUI();
+loadSavedQueries();

--- a/templates/aoi_daily_reports.html
+++ b/templates/aoi_daily_reports.html
@@ -1,0 +1,126 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>AOI Daily Reports</h2>
+
+  <div class="analysis-grid">
+    <!-- Left: Builder -->
+    <div class="analysis-left section-card">
+      <div class="section-title">Chart Builder</div>
+      <div class="field-row">
+        <div class="field">
+          <label for="chart-title">Chart Title</label>
+          <input id="chart-title" placeholder="Chart title" />
+        </div>
+        <div class="field">
+          <label for="chart-description">Chart Description</label>
+          <textarea id="chart-description" placeholder="Describe this chart"></textarea>
+        </div>
+      </div>
+
+      <div class="section-title" style="margin-top:10px;">Data Range</div>
+      <div class="field-row">
+        <div class="field">
+          <label for="start-date">Start Date</label>
+          <input type="date" id="start-date" />
+        </div>
+        <div class="field">
+          <label for="end-date">End Date</label>
+          <input type="date" id="end-date" />
+        </div>
+      </div>
+
+      <div class="section-title" style="margin-top:10px;">Filters</div>
+      <div class="field-row">
+        <div class="field">
+          <label for="filter-job">Job Numbers</label>
+          <select id="filter-job" multiple></select>
+        </div>
+        <div class="field">
+          <label for="filter-rev">Rev Numbers</label>
+          <select id="filter-rev" multiple></select>
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label for="filter-assembly">Assembly Number</label>
+          <select id="filter-assembly" multiple></select>
+        </div>
+        <div class="field">
+          <label for="filter-customer">Customer</label>
+          <select id="filter-customer" multiple></select>
+        </div>
+      </div>
+      <div class="field-row">
+        <div class="field">
+          <label for="filter-operator">Operator</label>
+          <select id="filter-operator" multiple></select>
+        </div>
+      </div>
+
+      <div class="field-row" style="margin-top:12px;">
+        <div class="field" style="flex:1;">
+          <label for="save-name">Save As</label>
+          <input id="save-name" placeholder="Chart name" />
+        </div>
+        <button type="button" id="save-chart">Save</button>
+        <button type="button" id="run-chart">Run</button>
+      </div>
+    </div>
+
+    <!-- Top Right: Saved Queries + Search -->
+    <div class="analysis-top-right section-card">
+      <div class="section-title">Saved Charts</div>
+      <div class="field-row" style="margin-bottom:8px;">
+        <div class="field" style="flex:1;">
+          <label for="saved-search">Search</label>
+          <input id="saved-search" placeholder="Filter saved charts" />
+        </div>
+      </div>
+      <ul id="saved-list" style="margin:0;padding-left:16px;"></ul>
+      <small>Select a preset to load its metric.</small>
+    </div>
+
+    <!-- Bottom Right: Results -->
+    <div class="analysis-bottom-right section-card">
+      <div class="section-title">Results: <span id="result-chart-name"></span></div>
+      <div class="field-row" style="margin-bottom:6px;">
+        <button type="button" id="expand-chart">Expand</button>
+        <button type="button" id="download-pdf">Download PDF</button>
+        <button type="button" id="copy-image">Copy Image</button>
+      </div>
+      <div class="preview-card" style="height: 300px;">
+        <canvas id="aoiChart"></canvas>
+      </div>
+      <div id="chart-description-result" class="preview-info" style="margin-top:4px;"></div>
+    </div>
+  </div>
+
+<!-- Modal for Expanded View + Data Table -->
+<div id="chart-modal" class="modal-overlay">
+  <div class="modal">
+    <div class="modal-header">
+      <div id="modal-title">Chart Detail</div>
+      <button id="modal-close" class="modal-close">Close</button>
+    </div>
+    <div class="modal-chart-box">
+      <canvas id="aoiChartExpanded"></canvas>
+    </div>
+    <div class="field-row" style="margin-top:10px;">
+      <button type="button" id="modal-download-chart">Download Chart</button>
+      <button type="button" id="modal-download-csv">Download CSV</button>
+    </div>
+    <div style="margin-top:10px;" class="section-title">Data</div>
+    <table class="data-table">
+      <thead><tr><th>Operator</th><th>Accepted</th><th>Rejected</th></tr></thead>
+      <tbody id="data-tbody"></tbody>
+    </table>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="{{ url_for('static', filename='js/aoi.js') }}"></script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -16,7 +16,7 @@
           <div class="dropdown">
             <a href="{{ url_for('main.ppm_analysis') }}">PPM analysis</a>
             <a href="#">AOI Grades</a>
-            <a href="#">AOI Daily Reports</a>
+            <a href="{{ url_for('main.aoi_daily_reports') }}">AOI Daily Reports</a>
             <a href="#">FI Daily Reports</a>
           </div>
         </li>


### PR DESCRIPTION
## Summary
- Add AOI Daily Reports analysis page mirroring PPM layout
- Provide stacked bar chart by operator showing accepted vs rejected boards
- Support saving AOI chart configurations and expose navigation link

## Testing
- `python -m pytest`
- `python -m py_compile app/db.py app/main/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b0a3fd2e3483259dd86999d3981eda