### PR TITLE
Make filter inputs text and show percentage stats

### DIFF
--- a/templates/aoi_daily_reports.html
+++ b/templates/aoi_daily_reports.html
@@ -33,28 +33,28 @@
       <div class="section-title" style="margin-top:10px;">Filters</div>
       <div class="field-row">
         <div class="field">
-          <label for="filter-job">Job Numbers</label>
-          <select id="filter-job" multiple></select>
+          <label for="filter-job">Job Number</label>
+          <input id="filter-job" placeholder="e.g. 12345,67890" />
         </div>
         <div class="field">
-          <label for="filter-rev">Rev Numbers</label>
-          <select id="filter-rev" multiple></select>
+          <label for="filter-rev">Revision</label>
+          <input id="filter-rev" placeholder="e.g. A,B" />
         </div>
       </div>
       <div class="field-row">
         <div class="field">
           <label for="filter-assembly">Assembly Number</label>
-          <select id="filter-assembly" multiple></select>
+          <input id="filter-assembly" placeholder="e.g. ASM1,ASM2" />
         </div>
         <div class="field">
-          <label for="filter-customer">Customer</label>
-          <select id="filter-customer" multiple></select>
+          <label>Customer</label>
+          <div id="customer-wrapper"></div>
         </div>
       </div>
       <div class="field-row">
         <div class="field">
-          <label for="filter-operator">Operator</label>
-          <select id="filter-operator" multiple></select>
+          <label>Operator</label>
+          <div id="operator-wrapper"></div>
         </div>
       </div>
 
@@ -112,7 +112,7 @@
     </div>
     <div style="margin-top:10px;" class="section-title">Data</div>
     <table class="data-table">
-      <thead><tr><th>Operator</th><th>Accepted</th><th>Rejected</th></tr></thead>
+      <thead><tr><th>Operator</th><th>Accepted</th><th>Rejected</th><th>Accepted %</th><th>Rejected %</th></tr></thead>
       <tbody id="data-tbody"></tbody>
     </table>
   </div>


### PR DESCRIPTION
## Summary
- Replace Job, Rev, and Assembly selectors with comma-separated text fields
- Add dynamic customer/operator dropdowns that grow as selections are made
- Include accepted/rejected percentages in AOI report chart and data table

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b0a919a95483258278b8ba5b1bf037