### PR TITLE
Add shift comparison saved chart for AOI daily reports

### DIFF
--- a/migrations/20240717_add_shift_saved_query.sql
+++ b/migrations/20240717_add_shift_saved_query.sql
@@ -1,0 +1,8 @@
+INSERT INTO aoi_saved_queries (name, description, start_date, end_date, params)
+VALUES (
+  'Shift Reject Rate',
+  'Accepted vs rejected per shift by date',
+  NULL,
+  NULL,
+  '{"start_date":"","end_date":"","job_numbers":[],"rev_numbers":[],"assemblies":[],"customers":[],"operators":[],"view":"shift"}'
+);

--- a/templates/aoi_daily_reports.html
+++ b/templates/aoi_daily_reports.html
@@ -93,6 +93,7 @@
         <canvas id="aoiChart"></canvas>
       </div>
       <div id="chart-description-result" class="preview-info" style="margin-top:4px;"></div>
+      <div id="aoi-info" class="preview-info" style="margin-top:4px;"></div>
     </div>
   </div>
 
@@ -112,7 +113,7 @@
     </div>
     <div style="margin-top:10px;" class="section-title">Data</div>
     <table class="data-table">
-      <thead><tr><th>Operator</th><th>Accepted</th><th>Rejected</th><th>Accepted %</th><th>Rejected %</th></tr></thead>
+      <thead><tr><th id="data-label-header">Operator</th><th>Accepted</th><th>Rejected</th><th>Accepted %</th><th>Rejected %</th></tr></thead>
       <tbody id="data-tbody"></tbody>
     </table>
   </div>


### PR DESCRIPTION
## Summary
- add default "Shift Reject Rate" preset for AOI daily reports
- support shift-by-date aggregation and expose average reject rates per shift
- seed new preset in database migrations

## Testing
- `python -m pytest`
- `flake8` *(fails: command not found; pip install failed: Could not find a version, proxy error)*

------
https://chatgpt.com/codex/tasks/task_e_68b0c54f39bc832581bc40f474a275a3