### PR TITLE
Add PPM report upload to MOAT analysis

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -105,6 +105,16 @@ def insert_moat(data: dict):
         return None, f"Failed to insert MOAT data: {exc}"
 
 
+def insert_moat_bulk(rows: list[dict]):
+    """Insert multiple MOAT records at once."""
+    supabase = _get_client()
+    try:
+        response = supabase.table("moat").insert(rows).execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to insert MOAT data: {exc}"
+
+
 def fetch_saved_queries():
     """Retrieve saved chart queries for PPM analysis.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 flask
 supabase
 dotenv
+openpyxl

--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -1049,6 +1049,41 @@ function downloadPDF() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
+  // Tab switching for Chart Builder / Upload
+  document.querySelectorAll('.tab').forEach((tab) => {
+    tab.addEventListener('click', () => {
+      document.querySelectorAll('.tab').forEach((t) => t.classList.remove('active'));
+      tab.classList.add('active');
+      document.querySelectorAll('.tab-content').forEach((c) => { c.style.display = 'none'; });
+      const target = document.getElementById(tab.dataset.target);
+      if (target) target.style.display = 'block';
+    });
+  });
+
+  // Handle XLSX upload
+  const uploadForm = document.getElementById('upload-form');
+  if (uploadForm) {
+    uploadForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fileInput = document.getElementById('upload-xlsx');
+      if (!fileInput.files.length) { alert('Please select a file.'); return; }
+      const fd = new FormData();
+      fd.append('file', fileInput.files[0]);
+      try {
+        const res = await fetch('/ppm_reports/upload', { method: 'POST', body: fd });
+        if (!res.ok) {
+          const text = await res.text();
+          throw new Error(text || 'Upload failed');
+        }
+        const data = await res.json();
+        alert(`Uploaded ${data.inserted} rows`);
+        fileInput.value = '';
+      } catch (err) {
+        alert(err.message || 'Upload failed');
+      }
+    });
+  }
+
   // Default preset or use URL preset
   const url = new URL(window.location.href);
   const preset = url.searchParams.get('preset');

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -4,8 +4,16 @@
 <h2>PPM Analysis</h2>
 
   <div class="analysis-grid">
-    <!-- Left: Builder -->
+    <!-- Left: Builder / Upload Tabs -->
     <div class="analysis-left section-card">
+      <div class="tab-bar">
+        <div class="tab active" data-target="builder-tab">Chart Builder</div>
+        {% if username == 'ADMIN' %}
+        <div class="tab" data-target="upload-tab">Upload</div>
+        {% endif %}
+      </div>
+
+      <div id="builder-tab" class="tab-content" style="display:block;">
       <div class="section-title">Chart Builder</div>
       <div class="field-row">
         <div class="field">
@@ -143,15 +151,29 @@
       </div>
     </div>
 
-    <div class="field-row" style="margin-top:12px;">
-      <div class="field" style="flex:1;">
-        <label for="save-name">Save As</label>
-        <input id="save-name" placeholder="Chart name" />
+      <div class="field-row" style="margin-top:12px;">
+        <div class="field" style="flex:1;">
+          <label for="save-name">Save As</label>
+          <input id="save-name" placeholder="Chart name" />
+        </div>
+        <button type="button" id="save-chart">Save</button>
+        <button type="button" id="run-chart">Run</button>
       </div>
-      <button type="button" id="save-chart">Save</button>
-      <button type="button" id="run-chart">Run</button>
+    </div> <!-- end builder-tab -->
+    {% if username == 'ADMIN' %}
+    <div id="upload-tab" class="tab-content" style="display:none;">
+      <form id="upload-form">
+        <div class="field-row">
+          <div class="field" style="flex:1;">
+            <label for="upload-xlsx">XLSX File</label>
+            <input type="file" id="upload-xlsx" accept=".xlsx" />
+          </div>
+        </div>
+        <button type="submit" id="upload-button">Upload</button>
+      </form>
     </div>
-  </div>
+    {% endif %}
+    </div>
 
   <!-- Top Right: Saved Queries + Search -->
   <div class="analysis-top-right section-card">


### PR DESCRIPTION
## Summary
- Allow admins to upload SPC PPM reports in XLSX format from the PPM Analysis page
- Parse report rows and insert data into Supabase `moat` table
- Add bulk insert helper for MOAT records and OpenPyXL dependency

## Testing
- `python -m py_compile app/db.py app/main/routes.py`


------
https://chatgpt.com/codex/tasks/task_e_68b19b4fff548325a555d8801b49ba1d