### PR TITLE
Add AOI and FI yield previews on home screen

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -96,9 +96,69 @@ function renderPreview(endpoint, canvasId, infoId) {
     });
 }
 
+function renderYieldPreview(endpoint, canvasId, infoId) {
+  fetch(endpoint)
+    .then((res) => res.json())
+    .then((data) => {
+      const ctx = document.getElementById(canvasId).getContext('2d');
+
+      // eslint-disable-next-line no-undef
+      new Chart(ctx, {
+        type: 'line',
+        data: {
+          labels: data.labels,
+          datasets: [
+            {
+              data: data.yields,
+              borderColor: '#000',
+              backgroundColor: '#000',
+              pointBackgroundColor: '#000',
+              pointBorderColor: '#000',
+              pointRadius: 3,
+              fill: false,
+              tension: 0,
+              borderWidth: 2,
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: { enabled: false },
+          },
+          elements: {
+            line: { borderWidth: 2 },
+          },
+          scales: {
+            x: { display: false, grid: { display: false }, ticks: { display: false } },
+            y: { beginAtZero: true, display: false, grid: { display: false }, ticks: { display: false } },
+          },
+        },
+      });
+
+      const infoEl = document.getElementById(infoId);
+      if (infoEl) {
+        const avg = data.avg_yield ? data.avg_yield.toFixed(1) : '0';
+        infoEl.textContent = `${data.start_date} to ${data.end_date} | Avg Yield: ${avg}%`;
+      }
+    })
+    .catch((err) => {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load preview', err);
+    });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('moatChart')) {
     renderPreview('/moat_preview', 'moatChart', 'moat-info');
+  }
+  if (document.getElementById('aoiChart')) {
+    renderYieldPreview('/aoi_preview', 'aoiChart', 'aoi-info');
+  }
+  if (document.getElementById('fiChart')) {
+    renderYieldPreview('/fi_preview', 'fiChart', 'fi-info');
   }
   // Auto-hide navbar on scroll down; reveal on scroll up
   const nav = document.querySelector('.navbar');

--- a/templates/home.html
+++ b/templates/home.html
@@ -11,6 +11,24 @@
     <canvas id="moatChart"></canvas>
   </div>
 </div>
+<div id="aoi-preview" class="preview-wrapper">
+  <div class="preview-info">
+    <div id="aoi-title" style="font-size:14px;">AOI Yield Preview</div>
+    <div id="aoi-info" style="font-size:12px;color:#333;"></div>
+  </div>
+  <div class="preview-card">
+    <canvas id="aoiChart"></canvas>
+  </div>
+</div>
+<div id="fi-preview" class="preview-wrapper">
+  <div class="preview-info">
+    <div id="fi-title" style="font-size:14px;">FI Yield Preview</div>
+    <div id="fi-info" style="font-size:12px;color:#333;"></div>
+  </div>
+  <div class="preview-card">
+    <canvas id="fiChart"></canvas>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- add reusable `_yield_preview` endpoint and routes for AOI and FI daily yield snapshots
- show AOI and FI yield preview charts on the home page and load them via new `renderYieldPreview`
- update home template to display new preview cards

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1a92d49c4832584b150a4c2748f51