### PR TITLE
Ensure x-axis type refreshes with loaded params

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -269,6 +269,7 @@ function loadParamsIntoBuilder(row) {
     document.getElementById('y-title').value = params.options.yTitle || '';
     document.getElementById('show-tooltips').value = params.options.showTooltips ? 'yes' : 'no';
   }
+  updateXTypeUI();
 }
 
 function filterSavedList() {
@@ -929,11 +930,27 @@ function populateSelect(sel, items, withNone=false) {
 
 function updateXTypeUI() {
   const xCol = document.getElementById('x-column').value;
-  const t = columnTypes[xCol] || 'categorical';
-  const hint = document.getElementById('x-type-hint');
-  hint.textContent = `Type: ${t}`;
-  document.getElementById('x-binning-wrap').style.display = (t === 'temporal') ? '' : 'none';
-  document.getElementById('x-cat-sort-wrap').style.display = (t === 'categorical') ? '' : 'none';
+  const apply = () => {
+    const t = columnTypes[xCol] || 'categorical';
+    const hint = document.getElementById('x-type-hint');
+    hint.textContent = `Type: ${t}`;
+    document.getElementById('x-binning-wrap').style.display = (t === 'temporal') ? '' : 'none';
+    document.getElementById('x-cat-sort-wrap').style.display = (t === 'categorical') ? '' : 'none';
+  };
+
+  if (!columnTypes[xCol]) {
+    fetch('/moat')
+      .then((res) => res.json())
+      .then((rows) => {
+        const { cols, types } = inferTypes(rows);
+        allColumns = cols;
+        columnTypes = types;
+        apply();
+      })
+      .catch(apply);
+  } else {
+    apply();
+  }
 }
 
 function initColumnsUI() {


### PR DESCRIPTION
## Summary
- Call `updateXTypeUI` after applying saved chart parameters so the builder reflects the loaded X column
- Refresh column type inference in `updateXTypeUI` to mark temporal fields like "Report Date" correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1acd79e10832594dfee5cb0938640