### PR TITLE
Restrict home previews to wrapper elements

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -154,10 +154,10 @@ document.addEventListener('DOMContentLoaded', () => {
   if (document.getElementById('moatChart')) {
     renderPreview('/moat_preview', 'moatChart', 'moat-info');
   }
-  if (document.getElementById('aoiChart')) {
+  if (document.getElementById('aoi-preview')) {
     renderYieldPreview('/aoi_preview', 'aoiChart', 'aoi-info');
   }
-  if (document.getElementById('fiChart')) {
+  if (document.getElementById('fi-preview')) {
     renderYieldPreview('/fi_preview', 'fiChart', 'fi-info');
   }
   // Auto-hide navbar on scroll down; reveal on scroll up


### PR DESCRIPTION
## Summary
- Only render AOI/FI preview charts when their home page wrappers are present.
- Avoid interfering with AOI/FI daily report canvases by checking `#aoi-preview` and `#fi-preview` wrappers.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b1ae5efd648325988383a538501ab5