### PR TITLE
Display axes with titles on yield preview charts

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -132,8 +132,21 @@ function renderYieldPreview(endpoint, canvasId, infoId) {
             line: { borderWidth: 2 },
           },
           scales: {
-            x: { display: false, grid: { display: false }, ticks: { display: false } },
-            y: { beginAtZero: true, display: false, grid: { display: false }, ticks: { display: false } },
+            x: {
+              display: true,
+              title: { display: true, text: 'Date' },
+              grid: { display: false },
+              ticks: { display: true },
+              border: { display: true },
+            },
+            y: {
+              beginAtZero: true,
+              display: true,
+              title: { display: true, text: 'Yield' },
+              grid: { display: false },
+              ticks: { display: true },
+              border: { display: true },
+            },
           },
         },
       });


### PR DESCRIPTION
## Summary
- Show x and y axes with titles on yield preview charts
- Keep gridlines hidden while displaying axis lines and tick labels

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1aeff1bc88325a60d4bc2d572a913