### PR TITLE
Use model name labels for line-control charts

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -777,9 +777,9 @@ async function runPresetChart() {
         partsSum: Number(row[cols.totalParts] ?? 0),
       };
       const val = activePreset.calc ? activePreset.calc(agg) : 0;
-      const label = cols.date && row[cols.date]
-        ? String(row[cols.date]).slice(0, 10)
-        : String(row[cols.model] ?? 'Unknown');
+      const label = cols.model && row[cols.model] !== undefined
+        ? String(row[cols.model])
+        : (cols.date && row[cols.date] ? String(row[cols.date]).slice(0, 10) : 'Unknown');
       labels.push(label);
       values.push(val);
       metaLookup[idx] = {


### PR DESCRIPTION
## Summary
- In line-control charts without model grouping, display model names on the x-axis instead of dates, preserving date-based sorting.

## Testing
- ⚠️ `npm test` *(package.json missing)*
- ⚠️ `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1c0eb71948325805f681f9d40f390