### PR TITLE
Add helper for fetching combined reports

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -31,6 +31,20 @@ def fetch_fi_reports():
         return None, f"Failed to fetch FI reports: {exc}"
 
 
+def fetch_combined_reports():
+    """Retrieve all combined reports from the database.
+
+    Returns:
+        tuple[list | None, str | None]: (data, error)
+    """
+    supabase = _get_client()
+    try:
+        response = supabase.table("combined_reports").select("*").execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch combined reports: {exc}"
+
+
 def fetch_moat():
     """Retrieve MOAT data from the database."""
     supabase = _get_client()


### PR DESCRIPTION
## Summary
- add `fetch_combined_reports` helper to access `combined_reports` table via Supabase

## Testing
- `python -m py_compile app/db.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b1c8e249e08325a5b4593d00af6fd1