### PR TITLE
Add AOI operator grades page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -567,6 +567,13 @@ def aoi_grades():
     return jsonify(grades)
 
 
+@main_bp.route('/analysis/aoi/grades/view', methods=['GET'])
+def aoi_grades_page():
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    return render_template('aoi_grades.html', username=session.get('username'))
+
+
 @main_bp.route('/analysis/aoi', methods=['GET'])
 def aoi_daily_reports():
     if 'username' not in session:

--- a/static/js/aoi_grades.js
+++ b/static/js/aoi_grades.js
@@ -1,0 +1,34 @@
+document.addEventListener('DOMContentLoaded', () => {
+  fetch('/analysis/aoi/grades')
+    .then((r) => r.json())
+    .then((data) => {
+      const labels = Object.keys(data);
+      const grades = labels.map((op) => (data[op].grade * 100).toFixed(1));
+      const inspected = labels.map((op) => data[op].inspected);
+      const missed = labels.map((op) => data[op].weighted_missed);
+
+      const ctx = document.getElementById('gradesChart').getContext('2d');
+      // eslint-disable-next-line no-undef
+      new Chart(ctx, {
+        type: 'bar',
+        data: {
+          labels,
+          datasets: [{ label: 'Grade %', data: grades, backgroundColor: 'rgba(54,162,235,0.6)' }],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          scales: { y: { beginAtZero: true, max: 100, ticks: { callback: (v) => v + '%' } } },
+        },
+      });
+
+      const tbody = document.querySelector('#gradesTable tbody');
+      labels.forEach((op, i) => {
+        const tr = document.createElement('tr');
+        const inspectedVal = inspected[i];
+        const missedVal = missed[i];
+        tr.innerHTML = `<td>${op}</td><td>${inspectedVal}</td><td>${missedVal.toFixed ? missedVal.toFixed(1) : missedVal}</td><td>${grades[i]}%</td>`;
+        tbody.appendChild(tr);
+      });
+    });
+});

--- a/templates/aoi_grades.html
+++ b/templates/aoi_grades.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>AOI Operator Grades</h2>
+<div class="section-card">
+  <div style="height:300px">
+    <canvas id="gradesChart"></canvas>
+  </div>
+  <table id="gradesTable" class="data-table" style="margin-top:16px;">
+    <thead>
+      <tr><th>Operator</th><th>Inspected</th><th>Weighted Missed</th><th>Grade %</th></tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/aoi_grades.js') }}"></script>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -15,7 +15,7 @@
           <a href="#">Analysis <span class="arrow">&#9662;</span></a>
           <div class="dropdown">
             <a href="{{ url_for('main.ppm_analysis') }}">PPM analysis</a>
-            <a href="#">AOI Grades</a>
+            <a href="{{ url_for('main.aoi_grades_page') }}">AOI Grades</a>
             <a href="{{ url_for('main.aoi_daily_reports') }}">AOI Daily Reports</a>
             <a href="{{ url_for('main.fi_daily_reports') }}">FI Daily Reports</a>
           </div>


### PR DESCRIPTION
## Summary
- Add `/analysis/aoi/grades/view` route to render operator grade page and updated navigation link
- Create `aoi_grades.html` template with chart and table placeholders
- Implement `aoi_grades.js` to fetch grade data and render chart/table

## Testing
- `python -m py_compile app/main/routes.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1cb0128608325b54a934776140522