### PR TITLE
Allow AOI-prefixed operator and job filters

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -557,9 +557,11 @@ def aoi_grades():
             continue
         if end_dt and (not dt or dt > end_dt):
             continue
-        if operator_set and (row.get('Operator') not in operator_set):
+        operator = row.get('aoi_Operator') or row.get('Operator')
+        if operator_set and (operator not in operator_set):
             continue
-        if job_set and (row.get('Job Number') not in job_set):
+        job_number = row.get('aoi_Job Number') or row.get('Job Number')
+        if job_set and (job_number not in job_set):
             continue
         filtered.append(row)
 


### PR DESCRIPTION
## Summary
- Handle `aoi_Operator` and `aoi_Job Number` fields when filtering AOI grades
- Preserve existing date handling and grading workflow

## Testing
- `python -m py_compile app/main/routes.py`
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_68b1cf849c488325afd5cea8c1a5e8e0