### PR TITLE
Filter FI rejects for non-AOI reasons

### DIFF
--- a/aoi_grading.py
+++ b/aoi_grading.py
@@ -130,10 +130,8 @@ def compute_aoi_grades(
     if col_op not in df.columns:
         df[col_op] = None
 
-    # Job-level aggregates.
+    # Job-level aggregates for FI totals.
     job_group = df.groupby(col_job, dropna=False)
-
-    # Job-level rejects (R_j) and FI inspected (for reference).
     df["fi_rejects_job"] = job_group[col_fi_rejected].transform("max").fillna(0.0)
     df["fi_inspected_job"] = job_group[col_fi_inspected].transform("max").fillna(0.0)
 
@@ -165,6 +163,9 @@ def compute_aoi_grades(
 
     # Scope-adjusted passed.
     df["scope_passed"] = df["aoi_passed"] * df["scope_beta"]
+
+    # Recompute job grouping to include new columns.
+    job_group = df.groupby(col_job, dropna=False)
 
     # Per-job total scope; compute share within job.
     total_scope = job_group["scope_passed"].transform("sum")

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -39,10 +39,10 @@ from app.db import (
 )
 
 from app.grades import calculate_aoi_grades
+from fi_utils import parse_fi_rejections, NON_AOI_REASONS
 
 # Helpers for AOI Grades analytics
 from collections import defaultdict, Counter
-
 
 def _parse_date(val):
     if not val:
@@ -74,6 +74,7 @@ def _gap_days(row):
     if a and f:
         return (f - a).days
     return None
+
 
 main_bp = Blueprint('main', __name__)
 
@@ -588,6 +589,8 @@ def aoi_grades():
         job_number = row.get('aoi_Job Number') or row.get('Job Number')
         if job_set and (job_number not in job_set):
             continue
+        info = row.get('fi_Additional Information') or ""
+        row['fi_Quantity Rejected'] = parse_fi_rejections(info, NON_AOI_REASONS)
         filtered.append(row)
 
     grades = calculate_aoi_grades(filtered)

--- a/fi_utils.py
+++ b/fi_utils.py
@@ -1,0 +1,22 @@
+import re
+
+# Reasons in FI Additional Information that should be excluded from AOI analysis
+NON_AOI_REASONS = ["Missing Coating"]
+
+
+def parse_fi_rejections(info: str, ignore_phrases: list[str]) -> int:
+    """Parse FI Additional Information and sum counts not in ignore list."""
+    if not info:
+        return 0
+    total = 0
+    entries = [e.strip() for e in info.split(",") if e.strip()]
+    pattern = re.compile(r"\((\d+)\)")
+    ignore = [p.lower() for p in ignore_phrases]
+    for entry in entries:
+        entry_lower = entry.lower()
+        if any(phrase in entry_lower for phrase in ignore):
+            continue
+        match = pattern.search(entry)
+        if match:
+            total += int(match.group(1))
+    return total

--- a/tests/test_aoi_grades_excludes_non_aoi_defects.py
+++ b/tests/test_aoi_grades_excludes_non_aoi_defects.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+from aoi_grading import compute_aoi_grades
+from fi_utils import parse_fi_rejections, NON_AOI_REASONS
+
+
+def test_aoi_grades_excludes_non_aoi_defects():
+    row = {
+        'aoi_Job Number': 'J1',
+        'aoi_Operator': 'Op',
+        'aoi_Date': '2024-01-01',
+        'aoi_Quantity Inspected': 10,
+        'aoi_Quantity Rejected': 0,
+        'fi_Date': '2024-01-02',
+        'fi_Quantity Inspected': 10,
+        'fi_Quantity Rejected': 60,
+        'fi_Additional Information': 'U3 Solder Holes (1), U1 Missing Coating (59)',
+    }
+    row['fi_Quantity Rejected'] = parse_fi_rejections(row['fi_Additional Information'], NON_AOI_REASONS)
+    df = pd.DataFrame([row])
+    grades, breakdown = compute_aoi_grades(df)
+    assert breakdown['fi_rejects_job'].iloc[0] == 1


### PR DESCRIPTION
## Summary
- add FI rejection parser and exclusion list for non-AOI reasons
- adjust AOI grades route to replace FI reject counts with filtered values
- regression test ensuring non-AOI defects don't affect grade calculations

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b87e03b68083259c9ef068ef62fa82