### PR TITLE
Add configurable non-AOI phrase list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # MOATAppSpectra
+
+## Configuring Non-AOI Phrases
+
+The application excludes certain FI rejection phrases from AOI grade
+calculations. These phrases are loaded from a JSON file during application
+startup.
+
+1. Edit `config/non_aoi_phrases.json` and update the list of phrases to
+   ignore.
+2. Restart the application process. A full redeploy is not required because
+   the list is read from disk on each startup.
+3. (Optional) Set the `NON_AOI_PHRASES_FILE` environment variable to point to
+   a different JSON file if you want to maintain the list outside the
+   repository.
+
+The file contains a simple JSON array of strings, e.g.:
+
+```json
+[
+  "Missing Coating"
+]
+```
+
+Administrators can modify this file at any time to adjust the ignore list
+without rebuilding the application.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,6 @@
 import os
+import json
+from pathlib import Path
 
 from flask import Flask, current_app
 from supabase import create_client
@@ -20,6 +22,16 @@ def create_app():
         os.environ["SUPABASE_SERVICE_KEY"],
     )
     app.config["SUPABASE"] = supabase
+
+    phrases_path = (
+        os.environ.get("NON_AOI_PHRASES_FILE")
+        or Path(__file__).resolve().parent.parent / "config" / "non_aoi_phrases.json"
+    )
+    try:
+        with open(phrases_path, "r", encoding="utf-8") as fh:
+            app.config["NON_AOI_PHRASES"] = json.load(fh)
+    except Exception:
+        app.config["NON_AOI_PHRASES"] = []
 
     app.register_blueprint(auth_bp)
     app.register_blueprint(main_bp)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -7,6 +7,7 @@ from flask import (
     abort,
     request,
     jsonify,
+    current_app,
 )
 from functools import wraps
 import csv
@@ -39,7 +40,7 @@ from app.db import (
 )
 
 from app.grades import calculate_aoi_grades
-from fi_utils import parse_fi_rejections, NON_AOI_REASONS
+from fi_utils import parse_fi_rejections
 
 # Helpers for AOI Grades analytics
 from collections import defaultdict, Counter
@@ -590,7 +591,8 @@ def aoi_grades():
         if job_set and (job_number not in job_set):
             continue
         info = row.get('fi_Additional Information') or ""
-        row['fi_Quantity Rejected'] = parse_fi_rejections(info, NON_AOI_REASONS)
+        phrases = current_app.config.get("NON_AOI_PHRASES", [])
+        row['fi_Quantity Rejected'] = parse_fi_rejections(info, phrases)
         filtered.append(row)
 
     grades = calculate_aoi_grades(filtered)

--- a/config/non_aoi_phrases.json
+++ b/config/non_aoi_phrases.json
@@ -1,0 +1,3 @@
+[
+  "Missing Coating"
+]

--- a/fi_utils.py
+++ b/fi_utils.py
@@ -1,8 +1,5 @@
 import re
 
-# Reasons in FI Additional Information that should be excluded from AOI analysis
-NON_AOI_REASONS = ["Missing Coating"]
-
 
 def parse_fi_rejections(info: str, ignore_phrases: list[str]) -> int:
     """Parse FI Additional Information and sum counts not in ignore list."""

--- a/tests/test_aoi_grades_excludes_non_aoi_defects.py
+++ b/tests/test_aoi_grades_excludes_non_aoi_defects.py
@@ -1,7 +1,13 @@
+import sys
+import json
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import pandas as pd
 
 from aoi_grading import compute_aoi_grades
-from fi_utils import parse_fi_rejections, NON_AOI_REASONS
+from fi_utils import parse_fi_rejections
 
 
 def test_aoi_grades_excludes_non_aoi_defects():
@@ -16,7 +22,11 @@ def test_aoi_grades_excludes_non_aoi_defects():
         'fi_Quantity Rejected': 60,
         'fi_Additional Information': 'U3 Solder Holes (1), U1 Missing Coating (59)',
     }
-    row['fi_Quantity Rejected'] = parse_fi_rejections(row['fi_Additional Information'], NON_AOI_REASONS)
+    phrases_path = Path('config/non_aoi_phrases.json')
+    ignore_phrases = json.loads(phrases_path.read_text())
+    row['fi_Quantity Rejected'] = parse_fi_rejections(
+        row['fi_Additional Information'], ignore_phrases
+    )
     df = pd.DataFrame([row])
     grades, breakdown = compute_aoi_grades(df)
     assert breakdown['fi_rejects_job'].iloc[0] == 1

--- a/tests/test_aoi_grading.py
+++ b/tests/test_aoi_grading.py
@@ -1,4 +1,9 @@
 import math
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
 import pandas as pd
 
 from aoi_grading import compute_aoi_grades, default_alpha_from_gap


### PR DESCRIPTION
## Summary
- Load non-AOI rejection phrases from `config/non_aoi_phrases.json` on app startup
- Use configured phrases when parsing FI rejections
- Document how to adjust the phrase list without redeploying

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b87f90b6e4832582fe84dead5424cf