### PR TITLE
Add integrated report stub and navigation

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -546,6 +546,14 @@ def ppm_saved_queries():
     return jsonify(data), status
 
 
+@main_bp.route('/reports/integrated', methods=['GET'])
+def integrated_report():
+    """Render the Integrated Report page."""
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    return render_template('integrated_report.html', username=session.get('username'))
+
+
 @main_bp.route('/analysis/aoi/grades', methods=['GET'])
 def aoi_grades():
     """Return AOI grades computed from combined reports.

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,0 +1,101 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const runBtn = document.getElementById('run-report');
+  const preview = document.getElementById('report-preview');
+  runBtn?.addEventListener('click', () => {
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    if (!start || !end) {
+      alert('Please select a date range.');
+      return;
+    }
+    preview.style.display = 'block';
+
+    // --- Sample Yield Data ---
+    const yieldData = {
+      dates: ['2024-01-01', '2024-01-02', '2024-01-03'],
+      yields: [95, 90, 97],
+      assemblyYields: { ASM1: 95, ASM2: 88, ASM3: 92 },
+    };
+    const yieldCtx = document.getElementById('yieldChart').getContext('2d');
+    // eslint-disable-next-line no-undef
+    new Chart(yieldCtx, {
+      type: 'line',
+      data: { labels: yieldData.dates, datasets: [{ data: yieldData.yields, borderColor: '#000', backgroundColor: '#000', pointRadius: 3, fill: false, tension: 0 }] },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+    const avg = yieldData.yields.reduce((a, b) => a + b, 0) / yieldData.yields.length;
+    const minIdx = yieldData.yields.indexOf(Math.min(...yieldData.yields));
+    const worstDay = yieldData.dates[minIdx];
+    const worstAssembly = Object.entries(yieldData.assemblyYields).reduce((a, b) => (a[1] < b[1] ? a : b))[0];
+    document.getElementById('yield-info').textContent = `For ${start} to ${end}:\nAverage Daily Yield: ${avg.toFixed(1)}%\nWorst day: ${worstDay}\nWorst Assembly: ${worstAssembly}`;
+
+    // --- Operator Reject Rate ---
+    const operators = [
+      { name: 'Alice', inspected: 100, rejected: 5 },
+      { name: 'Bob', inspected: 120, rejected: 2 },
+      { name: 'Cara', inspected: 110, rejected: 10 },
+    ];
+    const labels = operators.map((o) => o.name);
+    const rejectRates = operators.map((o) => ((o.rejected / o.inspected) * 100).toFixed(1));
+    const opCtx = document.getElementById('operatorChart').getContext('2d');
+    // eslint-disable-next-line no-undef
+    new Chart(opCtx, {
+      type: 'bar',
+      data: { labels, datasets: [{ data: rejectRates, backgroundColor: '#000' }] },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+    const totalBoards = operators.reduce((sum, o) => sum + o.inspected, 0);
+    const avgReject =
+      (operators.reduce((sum, o) => sum + o.rejected / o.inspected, 0) / operators.length) * 100;
+    const minOp = operators.reduce((a, b) => (a.rejected / a.inspected < b.rejected / b.inspected ? a : b));
+    const maxOp = operators.reduce((a, b) => (a.rejected / a.inspected > b.rejected / b.inspected ? a : b));
+    document.getElementById('operator-info').textContent = `Total boards ran through AOI for ${start} to ${end}: ${totalBoards}\nAverage Rejection Rate: ${avgReject.toFixed(1)}%\nMin Reject Rate: ${minOp.name} (${((minOp.rejected / minOp.inspected) * 100).toFixed(1)}%)\nMax Reject Rate: ${maxOp.name} (${((maxOp.rejected / maxOp.inspected) * 100).toFixed(1)}%)`;
+
+    // --- False Calls by Model ---
+    const models = [
+      { name: 'ModelA', falseCalls: 15 },
+      { name: 'ModelB', falseCalls: 25 },
+      { name: 'ModelC', falseCalls: 5 },
+      { name: 'ModelD', falseCalls: 30 },
+    ];
+    const modelLabels = models.map((m) => m.name);
+    const falseVals = models.map((m) => m.falseCalls);
+    const falseCtx = document.getElementById('falseChart').getContext('2d');
+    // eslint-disable-next-line no-undef
+    new Chart(falseCtx, {
+      type: 'bar',
+      data: { labels: modelLabels, datasets: [{ data: falseVals, backgroundColor: '#000' }] },
+      options: { responsive: true, maintainAspectRatio: false },
+    });
+    const avgFalse = falseVals.reduce((a, b) => a + b, 0) / falseVals.length;
+    document.getElementById('false-info').textContent = `Average False Call/Panel: ${avgFalse.toFixed(1)}`;
+    const problem = models.filter((m) => m.falseCalls > 20);
+    const table = document.getElementById('problem-table');
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    problem.forEach((p) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `<td>${p.name}</td><td>${p.falseCalls}</td>`;
+      tbody.appendChild(tr);
+    });
+    table.style.display = problem.length ? 'table' : 'none';
+  });
+
+  document.getElementById('download-pdf')?.addEventListener('click', () => {
+    const { jsPDF } = window.jspdf;
+    const pdf = new jsPDF();
+    pdf.text('Integrated Report', 10, 10);
+    pdf.save('integrated-report.pdf');
+  });
+
+  document.getElementById('download-xls')?.addEventListener('click', () => {
+    const wb = XLSX.utils.book_new();
+    const ws = XLSX.utils.aoa_to_sheet([["Integrated Report"]]);
+    XLSX.utils.book_append_sheet(wb, ws, 'Report');
+    XLSX.writeFile(wb, 'integrated-report.xlsx');
+  });
+
+  document.getElementById('email-report')?.addEventListener('click', () => {
+    alert('Email sent (placeholder).');
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -34,6 +34,12 @@
             <a href="#"><em>SPC Dashboard</em></a>
           </div>
         </li>
+        <li class="nav-item">
+          <a href="#">Reports <span class="arrow">&#9662;</span></a>
+          <div class="dropdown">
+            <a href="{{ url_for('main.integrated_report') }}">Integrated Report</a>
+          </div>
+        </li>
       </ul>
     </div>
     <div class="nav-right">

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -1,0 +1,56 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Integrated Report</h2>
+
+<div class="section-card">
+  <div class="field-row">
+    <div class="field">
+      <label for="start-date">Start Date</label>
+      <input type="date" id="start-date" />
+    </div>
+    <div class="field">
+      <label for="end-date">End Date</label>
+      <input type="date" id="end-date" />
+    </div>
+    <button type="button" id="run-report">Run</button>
+  </div>
+</div>
+
+<div id="report-preview" style="display:none; margin-top:20px;">
+  <div class="section-card">
+    <div class="section-title">True Yield</div>
+    <canvas id="yieldChart"></canvas>
+    <div id="yield-info" class="preview-info" style="white-space:pre-line;"></div>
+  </div>
+
+  <div class="section-card" style="margin-top:10px;">
+    <div class="section-title">Operator Reject Rate</div>
+    <canvas id="operatorChart"></canvas>
+    <div id="operator-info" class="preview-info" style="white-space:pre-line;"></div>
+  </div>
+
+  <div class="section-card" style="margin-top:10px;">
+    <div class="section-title">Avg False Calls per Board (by Model)</div>
+    <canvas id="falseChart"></canvas>
+    <div id="false-info" class="preview-info"></div>
+    <table id="problem-table" class="data-table" style="display:none;">
+      <thead><tr><th>Model</th><th>False Calls</th></tr></thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <div class="field-row" style="margin-top:10px;">
+    <button id="download-pdf">Download PDF</button>
+    <button id="download-xls">Download XLS</button>
+    <button id="email-report">Email Report</button>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
+<script src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add Reports tab with Integrated Report link in navbar
- New route and template for Integrated Report with date range picker and chart placeholders
- Client-side script renders sample charts and includes export placeholders

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bad8244a80832585515e57b2a8f85c