### PR TITLE
Preview Integrated Report PDF and reuse for download

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,6 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
+  let pdfDoc;
   const runBtn = document.getElementById('run-report');
   const preview = document.getElementById('report-preview');
+  const pdfFrame = document.getElementById('pdf-preview');
+
   runBtn?.addEventListener('click', () => {
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
@@ -79,13 +82,24 @@ document.addEventListener('DOMContentLoaded', () => {
       tbody.appendChild(tr);
     });
     table.style.display = problem.length ? 'table' : 'none';
+
+    const { jsPDF } = window.jspdf;
+    pdfDoc = new jsPDF();
+    pdfDoc.text('Integrated Report', 10, 10);
+    const blob = pdfDoc.output('blob');
+    const url = URL.createObjectURL(blob);
+    if (pdfFrame) {
+      pdfFrame.src = url;
+      pdfFrame.style.display = 'block';
+    }
   });
 
   document.getElementById('download-pdf')?.addEventListener('click', () => {
-    const { jsPDF } = window.jspdf;
-    const pdf = new jsPDF();
-    pdf.text('Integrated Report', 10, 10);
-    pdf.save('integrated-report.pdf');
+    if (pdfDoc) {
+      pdfDoc.save('integrated-report.pdf');
+    } else {
+      alert('Run the report first.');
+    }
   });
 
   document.getElementById('download-xls')?.addEventListener('click', () => {

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -18,6 +18,7 @@
 </div>
 
 <div id="report-preview" style="display:none; margin-top:20px;">
+  <iframe id="pdf-preview" style="display:none; width:100%; height:600px; border:none;"></iframe>
   <div class="section-card">
     <div class="section-title">True Yield</div>
     <canvas id="yieldChart"></canvas>


### PR DESCRIPTION
## Summary
- add hidden iframe container to display generated PDF preview
- generate Integrated Report PDF with jsPDF and show via blob URL
- reuse same jsPDF instance for downloading the displayed report

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68badc3bc7788325b7e58300eafc7cde