### PR TITLE
Streamline integrated report downloads

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -234,6 +234,11 @@ h2 {
 .field label { font-size: 12px; }
 .field input, .field select { padding: 6px; }
 
+#download-controls {
+  display: none;
+  margin-top: 10px;
+}
+
 /* Tab styling for Chart Builder / Upload */
 .tab-bar {
   display: flex;

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,8 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-  let pdfDoc;
   const runBtn = document.getElementById('run-report');
-  const preview = document.getElementById('report-preview');
-  const pdfFrame = document.getElementById('pdf-preview');
+  const downloadControls = document.getElementById('download-controls');
+  const downloadBtn = document.getElementById('download-report');
+  const formatSelect = document.getElementById('file-format');
+  let reportData = null;
 
   runBtn?.addEventListener('click', () => {
     const start = document.getElementById('start-date').value;
@@ -11,7 +12,6 @@ document.addEventListener('DOMContentLoaded', () => {
       alert('Please select a date range.');
       return;
     }
-    preview.style.display = 'block';
 
     // --- Sample Yield Data ---
     const yieldData = {
@@ -19,18 +19,6 @@ document.addEventListener('DOMContentLoaded', () => {
       yields: [95, 90, 97],
       assemblyYields: { ASM1: 95, ASM2: 88, ASM3: 92 },
     };
-    const yieldCtx = document.getElementById('yieldChart').getContext('2d');
-    // eslint-disable-next-line no-undef
-    new Chart(yieldCtx, {
-      type: 'line',
-      data: { labels: yieldData.dates, datasets: [{ data: yieldData.yields, borderColor: '#000', backgroundColor: '#000', pointRadius: 3, fill: false, tension: 0 }] },
-      options: { responsive: true, maintainAspectRatio: false },
-    });
-    const avg = yieldData.yields.reduce((a, b) => a + b, 0) / yieldData.yields.length;
-    const minIdx = yieldData.yields.indexOf(Math.min(...yieldData.yields));
-    const worstDay = yieldData.dates[minIdx];
-    const worstAssembly = Object.entries(yieldData.assemblyYields).reduce((a, b) => (a[1] < b[1] ? a : b))[0];
-    document.getElementById('yield-info').textContent = `For ${start} to ${end}:\nAverage Daily Yield: ${avg.toFixed(1)}%\nWorst day: ${worstDay}\nWorst Assembly: ${worstAssembly}`;
 
     // --- Operator Reject Rate ---
     const operators = [
@@ -38,21 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
       { name: 'Bob', inspected: 120, rejected: 2 },
       { name: 'Cara', inspected: 110, rejected: 10 },
     ];
-    const labels = operators.map((o) => o.name);
-    const rejectRates = operators.map((o) => ((o.rejected / o.inspected) * 100).toFixed(1));
-    const opCtx = document.getElementById('operatorChart').getContext('2d');
-    // eslint-disable-next-line no-undef
-    new Chart(opCtx, {
-      type: 'bar',
-      data: { labels, datasets: [{ data: rejectRates, backgroundColor: '#000' }] },
-      options: { responsive: true, maintainAspectRatio: false },
-    });
-    const totalBoards = operators.reduce((sum, o) => sum + o.inspected, 0);
-    const avgReject =
-      (operators.reduce((sum, o) => sum + o.rejected / o.inspected, 0) / operators.length) * 100;
-    const minOp = operators.reduce((a, b) => (a.rejected / a.inspected < b.rejected / b.inspected ? a : b));
-    const maxOp = operators.reduce((a, b) => (a.rejected / a.inspected > b.rejected / b.inspected ? a : b));
-    document.getElementById('operator-info').textContent = `Total boards ran through AOI for ${start} to ${end}: ${totalBoards}\nAverage Rejection Rate: ${avgReject.toFixed(1)}%\nMin Reject Rate: ${minOp.name} (${((minOp.rejected / minOp.inspected) * 100).toFixed(1)}%)\nMax Reject Rate: ${maxOp.name} (${((maxOp.rejected / maxOp.inspected) * 100).toFixed(1)}%)`;
 
     // --- False Calls by Model ---
     const models = [
@@ -61,55 +34,33 @@ document.addEventListener('DOMContentLoaded', () => {
       { name: 'ModelC', falseCalls: 5 },
       { name: 'ModelD', falseCalls: 30 },
     ];
-    const modelLabels = models.map((m) => m.name);
-    const falseVals = models.map((m) => m.falseCalls);
-    const falseCtx = document.getElementById('falseChart').getContext('2d');
-    // eslint-disable-next-line no-undef
-    new Chart(falseCtx, {
-      type: 'bar',
-      data: { labels: modelLabels, datasets: [{ data: falseVals, backgroundColor: '#000' }] },
-      options: { responsive: true, maintainAspectRatio: false },
-    });
-    const avgFalse = falseVals.reduce((a, b) => a + b, 0) / falseVals.length;
-    document.getElementById('false-info').textContent = `Average False Call/Panel: ${avgFalse.toFixed(1)}`;
-    const problem = models.filter((m) => m.falseCalls > 20);
-    const table = document.getElementById('problem-table');
-    const tbody = table.querySelector('tbody');
-    tbody.innerHTML = '';
-    problem.forEach((p) => {
-      const tr = document.createElement('tr');
-      tr.innerHTML = `<td>${p.name}</td><td>${p.falseCalls}</td>`;
-      tbody.appendChild(tr);
-    });
-    table.style.display = problem.length ? 'table' : 'none';
 
-    const { jsPDF } = window.jspdf;
-    pdfDoc = new jsPDF();
-    pdfDoc.text('Integrated Report', 10, 10);
-    const blob = pdfDoc.output('blob');
-    const url = URL.createObjectURL(blob);
-    if (pdfFrame) {
-      pdfFrame.src = url;
-      pdfFrame.style.display = 'block';
-    }
+    reportData = { start, end, yieldData, operators, models };
+    downloadControls.style.display = 'flex';
   });
 
-  document.getElementById('download-pdf')?.addEventListener('click', () => {
-    if (pdfDoc) {
-      pdfDoc.save('integrated-report.pdf');
-    } else {
+  downloadBtn?.addEventListener('click', () => {
+    if (!reportData) {
       alert('Run the report first.');
+      return;
     }
-  });
 
-  document.getElementById('download-xls')?.addEventListener('click', () => {
-    const wb = XLSX.utils.book_new();
-    const ws = XLSX.utils.aoa_to_sheet([["Integrated Report"]]);
-    XLSX.utils.book_append_sheet(wb, ws, 'Report');
-    XLSX.writeFile(wb, 'integrated-report.xlsx');
+    const format = formatSelect.value;
+    if (format === 'pdf') {
+      const { jsPDF } = window.jspdf;
+      const doc = new jsPDF();
+      doc.text('Integrated Report', 10, 10);
+      doc.save('integrated-report.pdf');
+    } else if (format === 'xlsx') {
+      const wb = XLSX.utils.book_new();
+      const ws = XLSX.utils.aoa_to_sheet([['Integrated Report']]);
+      XLSX.utils.book_append_sheet(wb, ws, 'Report');
+      XLSX.writeFile(wb, 'integrated-report.xlsx');
+    }
   });
 
   document.getElementById('email-report')?.addEventListener('click', () => {
     alert('Email sent (placeholder).');
   });
 });
+

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -17,40 +17,20 @@
   </div>
 </div>
 
-<div id="report-preview" style="display:none; margin-top:20px;">
-  <iframe id="pdf-preview" style="display:none; width:100%; height:600px; border:none;"></iframe>
-  <div class="section-card">
-    <div class="section-title">True Yield</div>
-    <canvas id="yieldChart"></canvas>
-    <div id="yield-info" class="preview-info" style="white-space:pre-line;"></div>
+<div class="field-row" id="download-controls">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="xlsx">xlsx</option>
+    </select>
   </div>
-
-  <div class="section-card" style="margin-top:10px;">
-    <div class="section-title">Operator Reject Rate</div>
-    <canvas id="operatorChart"></canvas>
-    <div id="operator-info" class="preview-info" style="white-space:pre-line;"></div>
-  </div>
-
-  <div class="section-card" style="margin-top:10px;">
-    <div class="section-title">Avg False Calls per Board (by Model)</div>
-    <canvas id="falseChart"></canvas>
-    <div id="false-info" class="preview-info"></div>
-    <table id="problem-table" class="data-table" style="display:none;">
-      <thead><tr><th>Model</th><th>False Calls</th></tr></thead>
-      <tbody></tbody>
-    </table>
-  </div>
-
-  <div class="field-row" style="margin-top:10px;">
-    <button id="download-pdf">Download PDF</button>
-    <button id="download-xls">Download XLS</button>
-    <button id="email-report">Email Report</button>
-  </div>
+  <button id="download-report">Download</button>
+  <button id="email-report">Email Report</button>
 </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 <script src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>


### PR DESCRIPTION
## Summary
- Remove chart preview from integrated report template and add unified download controls
- Simplify integrated report script to generate data and export as PDF or XLSX
- Add stylesheet rule for download control layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68badd99a2c88325a012cc461fec5b4b