### PR TITLE
Add integrated report charts with PDF and XLSX export

### DIFF
--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -17,6 +17,21 @@
   </div>
 </div>
 
+<div id="charts" class="section-card">
+  <div class="chart-block">
+    <canvas id="yieldTrendChart"></canvas>
+    <p id="yieldTrendDesc"></p>
+  </div>
+  <div class="chart-block">
+    <canvas id="operatorRejectChart"></canvas>
+    <p id="operatorRejectDesc"></p>
+  </div>
+  <div class="chart-block">
+    <canvas id="modelFalseCallsChart"></canvas>
+    <p id="modelFalseCallsDesc"></p>
+  </div>
+</div>
+
 <div class="field-row" id="download-controls">
   <div class="field">
     <label for="file-format">Format</label>
@@ -31,6 +46,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 <script src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>


### PR DESCRIPTION
## Summary
- Add chart canvases and Chart.js dependency to integrated report template
- Render yield, operator reject rate, and false call charts with descriptions
- Include charts and data tables in PDF and XLSX downloads

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68badf4228448325b178d65fc224155b