### PR TITLE
Add report metrics and problem assembly table

### DIFF
--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -29,6 +29,12 @@
   <div class="chart-block">
     <canvas id="modelFalseCallsChart"></canvas>
     <p id="modelFalseCallsDesc"></p>
+    <table id="problemAssemblies" class="data-table">
+      <thead>
+        <tr><th>Assembly</th><th>False Calls/Board</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- compute yield and operator metrics after fetching report data
- display multi-line descriptions with key stats for each chart
- show problem assemblies with >20 false calls per board in a summary table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bae6d4cb7c8325827244c2663bdcd6