### PR TITLE
Add chart summary blocks to integrated report

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -224,6 +224,20 @@ h2 {
   padding: 10px;
 }
 
+.chart-block {
+  border: 2px solid #000;
+  background: #fff;
+  padding: 10px;
+  margin-bottom: 20px;
+}
+
+.chart-summary {
+  border-top: 2px solid #275317;
+  background: #f5f5f5;
+  padding: 8px;
+  margin-top: 8px;
+}
+
 .section-title {
   font-weight: bold;
   margin-bottom: 6px;

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -349,7 +349,7 @@ document.addEventListener('DOMContentLoaded', () => {
       `Average false calls/board: ${ms.avgFalseCalls?.toFixed(2) ?? '0'}\n` +
       `Problem assemblies (>20 false calls/board): ${ms.over20?.join(', ') || 'None'}`;
 
-    const table = document.getElementById('problemAssemblies');
+    const table = document.getElementById('problem-assemblies');
     const tbody = table.querySelector('tbody');
     tbody.innerHTML = '';
     (problemAssemblies || []).forEach((m) => {

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -17,26 +17,27 @@
   </div>
 </div>
 
-<div id="charts" class="section-card">
-  <div class="chart-block">
-    <canvas id="yieldTrendChart"></canvas>
-    <p id="yieldTrendDesc"></p>
+  <div id="charts" class="section-card">
+    <div class="chart-block">
+      <canvas id="yieldTrendChart"></canvas>
+      <div class="chart-summary">
+        <p id="yieldTrendDesc"></p>
+      </div>
+    </div>
+    <div class="chart-block">
+      <canvas id="operatorRejectChart"></canvas>
+      <div class="chart-summary">
+        <p id="operatorRejectDesc"></p>
+      </div>
+    </div>
+    <div class="chart-block">
+      <canvas id="modelFalseCallsChart"></canvas>
+      <div class="chart-summary">
+        <p id="modelFalseCallsDesc"></p>
+        <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
+      </div>
+    </div>
   </div>
-  <div class="chart-block">
-    <canvas id="operatorRejectChart"></canvas>
-    <p id="operatorRejectDesc"></p>
-  </div>
-  <div class="chart-block">
-    <canvas id="modelFalseCallsChart"></canvas>
-    <p id="modelFalseCallsDesc"></p>
-    <table id="problemAssemblies" class="data-table">
-      <thead>
-        <tr><th>Assembly</th><th>False Calls/Board</th></tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
-</div>
 
 <div class="field-row" id="download-controls">
   <div class="field">


### PR DESCRIPTION
## Summary
- add chart summary sections after each integrated report chart
- style chart blocks and summaries with bordered boxes and color accents
- update report script to target new problem-assemblies table placeholder

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bae791eb2c832588dafab65730c895