### PR TITLE
Render model false calls chart full width in PDF report

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -171,7 +171,8 @@ document.addEventListener('DOMContentLoaded', () => {
           `Avg false calls/board: ${ms.avgFalseCalls?.toFixed(2) ?? '0'}`,
           `Models >20 false calls: ${ms.over20?.join(', ') || 'None'}`,
         ],
-        [255, 165, 0]
+        [255, 165, 0],
+        true
       );
 
       doc.save('integrated-report.pdf');


### PR DESCRIPTION
## Summary
- Ensure Model False Calls chart renders at full width in PDF export

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baf863130483258f7e462423e42b64