### PR TITLE
Add model false call table to integrated report PDFs

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -36,6 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const format = formatSelect.value;
     if (format === 'pdf') {
       const { jsPDF } = window.jspdf;
+      if (window.jspdfAutoTable) {
+        window.jspdfAutoTable(jsPDF);
+      }
       const doc = new jsPDF();
       const pageWidth = doc.internal.pageSize.getWidth();
       const pageHeight = doc.internal.pageSize.getHeight();
@@ -174,6 +177,12 @@ document.addEventListener('DOMContentLoaded', () => {
         [255, 165, 0],
         true
       );
+      doc.autoTable({
+        startY: y,
+        head: [['Model Name', 'Avg False Calls']],
+        body: (reportData.problemAssemblies || []).map((m) => [m.name, m.falseCalls]),
+      });
+      y = doc.lastAutoTable.finalY + 10;
 
       doc.save('integrated-report.pdf');
     } else if (format === 'xlsx') {

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -57,6 +57,7 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/xlsx@0.18.5/dist/xlsx.full.min.js"></script>
 <script src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Load jspdf-autotable plugin and integrate with jsPDF
- Include problem assemblies table with model false call data in PDF export

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baf9393be48325ae282ce1ae79b459