### PR TITLE
Add yield data table to PDF report

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -150,6 +150,19 @@ document.addEventListener('DOMContentLoaded', () => {
         [0, 123, 255]
       );
 
+      doc.autoTable({
+        startY: rowBottom + 10,
+        head: [['Date', 'Yield %']],
+        body: (reportData.yieldData.dates || []).map((d, i) => [
+          d,
+          (reportData.yieldData.yields[i] ?? 0).toFixed(1),
+        ]),
+        margin: { left: 10, right: 10 },
+      });
+      y = doc.lastAutoTable.finalY + 10;
+      col = 0;
+      rowBottom = y;
+
       const os = reportData.operatorSummary || {};
       addChart(
         'operatorRejectChart',


### PR DESCRIPTION
## Summary
- Render yield percentage table below the yield trend chart in the PDF export
- Update layout tracking after table insertion

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bafa17a3048325bd846e1bb198cfa8