### PR TITLE
Add operator reject data table to PDF report

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -178,6 +178,20 @@ document.addEventListener('DOMContentLoaded', () => {
         true
       );
 
+      doc.autoTable({
+        startY: y,
+        head: [['Operator', 'Inspected', 'Rejected']],
+        body: (reportData.operators || []).map((o) => [
+          o.name,
+          o.inspected,
+          o.rejected,
+        ]),
+        margin: { left: 10, right: 10 },
+      });
+      y = doc.lastAutoTable.finalY + 10;
+      rowBottom = y;
+      col = 0;
+
       const ms = reportData.modelSummary || {};
       addChart(
         'modelFalseCallsChart',


### PR DESCRIPTION
## Summary
- Render operator reject metrics as a table below the operator chart in the PDF export
- Maintain layout positioning and margins for the new operator table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bafaaac7c083258b128914b470e675