### PR TITLE
Expand yield trend chart to full width

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -147,7 +147,8 @@ document.addEventListener('DOMContentLoaded', () => {
             yd.worstAssembly?.assembly || 'N/A'
           } (${yd.worstAssembly?.yield?.toFixed(1) ?? '0'}%)`,
         ],
-        [0, 123, 255]
+        [0, 123, 255],
+        true
       );
 
       doc.autoTable({


### PR DESCRIPTION
## Summary
- ensure yield trend chart spans full page width in integrated report

## Testing
- `pytest`
- `npm install jspdf jspdf-autotable jsdom` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bafd5d1b2c8325ad855a73c79fd546