### PR TITLE
Add reject rate column to integrated report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -717,7 +717,7 @@ def api_integrated_report():
                 'yields': yields,
                 'assemblyYields': assembly_yields,
             },
-            'operators': operator_rows,
+            'operators': ops,
             'models': model_rows,
             'yieldSummary': yield_summary,
             'operatorSummary': operator_summary,

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -191,11 +191,12 @@ document.addEventListener('DOMContentLoaded', () => {
         ],
         [0, 200, 0],
         {
-          head: [['Operator', 'Inspected', 'Rejected']],
+          head: [['Operator', 'Inspected', 'Rejected', 'Reject %']],
           body: (reportData.operators || []).map((o) => [
             o.name,
             o.inspected,
             o.rejected,
+            o.rate?.toFixed(2),
           ]),
         },
         true
@@ -266,12 +267,17 @@ document.addEventListener('DOMContentLoaded', () => {
       );
       XLSX.utils.sheet_add_aoa(
         ws,
-        [['Operator', 'Inspected', 'Rejected']],
+        [['Operator', 'Inspected', 'Rejected', 'Reject %']],
         { origin: `A${row + 2}` }
       );
       XLSX.utils.sheet_add_aoa(
         ws,
-        reportData.operators.map((o) => [o.name, o.inspected, o.rejected]),
+        reportData.operators.map((o) => [
+          o.name,
+          o.inspected,
+          o.rejected,
+          o.rate?.toFixed(2),
+        ]),
         { origin: `A${row + 3}` }
       );
       row += reportData.operators.length + 6;
@@ -457,9 +463,12 @@ document.addEventListener('DOMContentLoaded', () => {
       inspTd.textContent = op.inspected;
       const rejTd = document.createElement('td');
       rejTd.textContent = op.rejected;
+      const rateTd = document.createElement('td');
+      rateTd.textContent = `${op.rate?.toFixed(2) ?? '0.00'}%`;
       tr.appendChild(nameTd);
       tr.appendChild(inspTd);
       tr.appendChild(rejTd);
+      tr.appendChild(rateTd);
       oTbody.appendChild(tr);
     });
     oTable.style.display = (operators || []).length ? 'table' : 'none';

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -29,7 +29,17 @@
       <canvas id="operatorRejectChart"></canvas>
       <div class="chart-summary">
         <p id="operatorRejectDesc"></p>
-        <table id="operatorRejectTable" class="data-table"><tbody></tbody></table>
+        <table id="operatorRejectTable" class="data-table">
+          <thead>
+            <tr>
+              <th>Operator</th>
+              <th>Inspected</th>
+              <th>Rejected</th>
+              <th>Reject %</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
       </div>
     </div>
     <div class="chart-block">


### PR DESCRIPTION
## Summary
- Include calculated reject rate in operators API response
- Show "Reject %" column on integrated report page and exports
- Update PDF and spreadsheet generation to include reject rate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68baff4bde588325a92d5eb42f6c076a