### PR TITLE
Add FC vs NG rate chart and backend data

### DIFF
--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -49,6 +49,13 @@
         <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
       </div>
     </div>
+    <div class="chart-block">
+      <canvas id="fcVsNgRateChart"></canvas>
+      <div class="chart-summary">
+        <p id="fcVsNgDesc"></p>
+        <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
+      </div>
+    </div>
   </div>
 
 <div class="field-row" id="download-controls">


### PR DESCRIPTION
## Summary
- Extend integrated report API to compute and return per-date NG and false call PPM
- Add FC vs NG rate chart section to integrated report template and JS
- Render dual-line chart with correlation summary and PDF export

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb002210b08325add342c696514918