### PR TITLE
Add false call to NG ratio chart

### DIFF
--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -56,6 +56,23 @@
         <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
       </div>
     </div>
+    <div class="chart-block">
+      <canvas id="fcNgRatioChart"></canvas>
+      <div class="chart-summary">
+        <p id="fcNgRatioDesc"></p>
+        <table id="fcNgRatioTable" class="data-table">
+          <thead>
+            <tr>
+              <th>Model</th>
+              <th>FalseCall Parts</th>
+              <th>NG Parts</th>
+              <th>FC/NG Ratio</th>
+            </tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
   </div>
 
 <div class="field-row" id="download-controls">


### PR DESCRIPTION
## Summary
- compute false call to NG part ratios per model and expose via `fcNgRatio`
- visualize FC/NG ratios with descriptive insights on the integrated report
- extend PDF export to include the new ratio chart and table

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb01254f888325819ee1559bef20c7