### PR TITLE
Center chart descriptions vertically with flexbox

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -238,6 +238,11 @@ h2 {
   margin-top: 8px;
 }
 
+.chart-summary p {
+  display: flex;
+  align-items: center;
+}
+
 .section-title {
   font-weight: bold;
   margin-bottom: 6px;


### PR DESCRIPTION
## Summary
- Vertically center description text within chart summary blocks by using flexbox on `.chart-summary p`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bb034746a48325821950ea80f04129