### PR TITLE
Order FC/NG ratios and limit table to top 10

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -435,16 +435,30 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const ratioData = data.fcNgRatio || {};
     const rModels = ratioData.models || [];
+    const rFcParts = ratioData.fcParts || [];
+    const rNgParts = ratioData.ngParts || [];
     const rRatios =
       ratioData.ratios ||
       rModels.map((_, i) => {
-        const fcPart = ratioData.fcParts?.[i] || 0;
-        const ngPart = ratioData.ngParts?.[i] || 0;
+        const fcPart = rFcParts[i] || 0;
+        const ngPart = rNgParts[i] || 0;
         return ngPart ? fcPart / ngPart : 0;
       });
-    const pairs = rModels.map((m, i) => ({ name: m, ratio: rRatios[i] }));
-    pairs.sort((a, b) => b.ratio - a.ratio);
-    data.fcNgRatioSummary = { top: pairs.slice(0, 3) };
+    const combined = rModels.map((m, i) => ({
+      model: m,
+      fc: rFcParts[i] || 0,
+      ng: rNgParts[i] || 0,
+      ratio: rRatios[i],
+    }));
+    combined.sort((a, b) => b.ratio - a.ratio);
+    const top = combined.slice(0, 10);
+    data.fcNgRatio = {
+      models: top.map((t) => t.model),
+      fcParts: top.map((t) => t.fc),
+      ngParts: top.map((t) => t.ng),
+      ratios: top.map((t) => t.ratio),
+    };
+    data.fcNgRatioSummary = { top: combined.slice(0, 3) };
   }
 
   function renderCharts(data) {


### PR DESCRIPTION
## Summary
- sort False Call/NG ratio data descending and expose only the top 10 entries
- ensure chart and table display highest ratios on the left and limit the list to the top ten

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0464733c8325836504da280a22c4