### PR TITLE
Load jsPDF AutoTable plugin for report templates

### DIFF
--- a/templates/aoi_daily_reports.html
+++ b/templates/aoi_daily_reports.html
@@ -146,5 +146,6 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.min.js"></script>
 <script src="{{ url_for('static', filename='js/aoi.js') }}"></script>
 {% endblock %}

--- a/templates/fi_daily_reports.html
+++ b/templates/fi_daily_reports.html
@@ -146,6 +146,7 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.min.js"></script>
 <script src="{{ url_for('static', filename='js/fi.js') }}"></script>
 {% endblock %}
 

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -231,5 +231,6 @@
 {% block scripts %}
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.min.js"></script>
 <script src="{{ url_for('static', filename='js/ppm.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
## Summary
- load jsPDF AutoTable plugin in FI, AOI, and PPM report templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bb0871cb40832598ba26d2b8ed62d3