### PR TITLE
Use lowest/highest labels for operator reject rates

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -101,8 +101,8 @@ document.addEventListener('DOMContentLoaded', () => {
           `Date range: ${reportData.start} - ${reportData.end}`,
           `Total boards: ${os.totalBoards ?? 0}`,
           `Avg reject rate: ${os.avgRate?.toFixed(2) ?? '0'}%`,
-          `Best: ${os.min?.name || 'N/A'} (${os.min?.rate?.toFixed(2) ?? '0'}%)`,
-          `Worst: ${os.max?.name || 'N/A'} (${os.max?.rate?.toFixed(2) ?? '0'}%)`,
+          `Lowest: ${os.min?.name || 'N/A'} (${os.min?.rate?.toFixed(2) ?? '0'}%)`,
+          `Highest: ${os.max?.name || 'N/A'} (${os.max?.rate?.toFixed(2) ?? '0'}%)`,
         ];
         const operatorTable = {
           head: [['Operator', 'Inspected', 'Rejected', 'Reject %']],


### PR DESCRIPTION
## Summary
- Update operator summary to label best/worst reject rates as lowest/highest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bebfe4645083258a7474a83527de6e