### PR TITLE
Add report template and styles

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -1,0 +1,17 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+}
+
+header {
+    display: flex;
+    align-items: center;
+    background-color: #f2f2f2;
+    padding: 10px;
+}
+
+header img {
+    height: 40px;
+    margin-right: 10px;
+}

--- a/static/images/logo.svg
+++ b/static/images/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="40" fill="#2E86AB" />
+  <text x="50" y="55" font-size="30" text-anchor="middle" fill="#FFFFFF">R</text>
+</svg>

--- a/templates/report.html
+++ b/templates/report.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Report</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+</head>
+<body>
+    <header>
+        <img src="{{ url_for('static', filename='images/logo.svg') }}" alt="Logo">
+        <h1>Report</h1>
+    </header>
+    <main>
+        <p>This is the report template.</p>
+    </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `report.html` template linking to `report.css`
- include logo SVG asset under `static/images`
- add stylesheet for report page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bec1b9806883258dee5d9e8bb95ebb