### PR TITLE
Add integrated report export and shared aggregation logic

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ fastapi
 uvicorn
 pytest
 numpy
+weasyprint


### PR DESCRIPTION
## Summary
- factor integrated report aggregation into `build_report_payload`
- reuse shared payload builder for API and new export route
- support PDF export using WeasyPrint and include it in requirements

## Testing
- `pip install -q weasyprint` (fails: No matching distribution found)
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bec25fd2b08325b8c23fdf90df90fa