### PR TITLE
Use company logo in report

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     <header>
-        <img src="{{ url_for('static', filename='images/logo.svg') }}" alt="Logo">
+        <img src="{{ url_for('static', filename='images/company-logo.png') }}" alt="Company logo">
         <h1>Report</h1>
     </header>
     <main>


### PR DESCRIPTION
## Summary
- Use company-logo.png in report header instead of old SVG.
- Update alt text to describe company logo.

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement weasyprint)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beca76477883258a3cc39a2cdc25df