### PR TITLE
Pre-zip report data for template rendering

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -898,22 +898,39 @@ def build_report_payload(start=None, end=None):
         'avgFalseCalls': avg_fc,
         'over20': [m['name'] for m in problem_assemblies],
     }
+    dates_iso = [d.isoformat() for d in dates]
+    yield_pairs = list(zip(dates_iso, yields))
+
+    fc_vs_ng_dates_iso = [d.isoformat() for d in fc_vs_ng_dates]
+    fc_vs_ng_pairs = list(zip(fc_vs_ng_dates_iso, ng_ppm_series, fc_ppm_series))
+
+    fc_ng_ratio_pairs = list(
+        zip(
+            fc_ng_ratio_data['models'],
+            fc_ng_ratio_data['fcParts'],
+            fc_ng_ratio_data['ngParts'],
+            fc_ng_ratio_data['ratios'],
+        )
+    )
 
     return {
         'yieldData': {
-            'dates': [d.isoformat() for d in dates],
+            'dates': dates_iso,
             'yields': yields,
             'assemblyYields': assembly_yields,
         },
+        'yield_pairs': yield_pairs,
         'operators': ops,
         'models': model_rows,
         'fcVsNgRate': {
-            'dates': [d.isoformat() for d in fc_vs_ng_dates],
+            'dates': fc_vs_ng_dates_iso,
             'ngPpm': ng_ppm_series,
             'fcPpm': fc_ppm_series,
         },
+        'fc_vs_ng_pairs': fc_vs_ng_pairs,
         'fcVsNgSummary': fc_vs_ng_summary,
         'fcNgRatio': fc_ng_ratio_data,
+        'fc_ng_ratio_pairs': fc_ng_ratio_pairs,
         'fcNgRatioSummary': fc_ng_ratio_summary,
         'yieldSummary': yield_summary,
         'operatorSummary': operator_summary,

--- a/templates/report.html
+++ b/templates/report.html
@@ -18,7 +18,7 @@
                     <p>Date range: {{ start }} - {{ end }}\nAverage yield: {{ yieldSummary.avg|round(1) }}%\nLowest yield date: {{ yieldSummary.worstDay.date or 'N/A' }} ({{ yieldSummary.worstDay.yield|round(1) }}%)\nWorst assembly: {{ yieldSummary.worstAssembly.assembly or 'N/A' }} ({{ yieldSummary.worstAssembly.yield|round(1) }}%)</p>
                     <table class="data-table">
                         <tbody>
-                        {% for d, y in yieldData.dates|zip(yieldData.yields) %}
+                        {% for d, y in yield_pairs %}
                             <tr><td>{{ d }}</td><td>{{ '%.1f'|format(y) }}</td></tr>
                         {% endfor %}
                         </tbody>
@@ -70,7 +70,7 @@
                     <table id="fcVsNgRateTable" class="data-table">
                         <thead><tr><th>Date</th><th>NG PPM</th><th>FalseCall PPM</th></tr></thead>
                         <tbody>
-                        {% for d, ng, fc in fcVsNgRate.dates|zip(fcVsNgRate.ngPpm, fcVsNgRate.fcPpm) %}
+                        {% for d, ng, fc in fc_vs_ng_pairs %}
                             <tr><td>{{ d }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.1f'|format(fc) }}</td></tr>
                         {% endfor %}
                         </tbody>
@@ -85,7 +85,7 @@
                     <table id="fcNgRatioTable" class="data-table">
                         <thead><tr><th>Model</th><th>FalseCall Parts</th><th>NG Parts</th><th>FC/NG Ratio</th></tr></thead>
                         <tbody>
-                        {% for m, fc, ng, r in fcNgRatio.models|zip(fcNgRatio.fcParts, fcNgRatio.ngParts, fcNgRatio.ratios) %}
+                        {% for m, fc, ng, r in fc_ng_ratio_pairs %}
                             <tr><td>{{ m }}</td><td>{{ '%.1f'|format(fc) }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
                         {% endfor %}
                         </tbody>


### PR DESCRIPTION
## Summary
- Precompute zipped data pairs in `build_report_payload` for yield, FC vs NG rate, and FC/NG ratio sections
- Simplify `report.html` loops to iterate over pre-zipped lists instead of using the Jinja `zip` filter

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68becd7844008325b5688ed7827c0e18