### PR TITLE
Add HTML export option to integrated report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -971,13 +971,21 @@ def export_integrated_report():
     payload['end'] = end.isoformat() if end else ''
     charts = _generate_report_charts(payload)
     html = render_template('report.html', **payload, **charts)
-    if request.args.get('format') == 'pdf':
+    fmt = request.args.get('format')
+    if fmt == 'pdf':
         from weasyprint import HTML
         pdf = HTML(string=html, base_url=request.url_root).write_pdf()
         return send_file(
             io.BytesIO(pdf),
             mimetype='application/pdf',
             download_name='report.pdf',
+            as_attachment=True,
+        )
+    if fmt == 'html':
+        return send_file(
+            io.BytesIO(html.encode('utf-8')),
+            mimetype='text/html',
+            download_name='report.html',
             as_attachment=True,
         )
     return html

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -28,7 +28,12 @@ document.addEventListener('DOMContentLoaded', () => {
 
   downloadBtn?.addEventListener('click', () => {
     const fmt = document.getElementById('file-format').value;
-    window.location = `/reports/integrated/export?format=${fmt}`;
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    const params = new URLSearchParams({ format: fmt });
+    if (start) params.append('start_date', start);
+    if (end) params.append('end_date', end);
+    window.location = `/reports/integrated/export?${params.toString()}`;
   });
 
   document.getElementById('email-report')?.addEventListener('click', () => {

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -81,6 +81,7 @@
     <select id="file-format">
       <option value="pdf">pdf</option>
       <option value="xlsx">xlsx</option>
+      <option value="html">html</option>
     </select>
   </div>
   <button id="download-report">Download</button>


### PR DESCRIPTION
## Summary
- add html format option to integrated report export
- handle html export in backend and include date parameters in JS

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bece03b8e083259307fbf89f91e12c