### PR TITLE
Handle PPM report filenames case-insensitively

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -248,6 +248,7 @@ def upload_ppm_reports():
     m = re.match(
         r"^PPMReportControl\s+(\d{4}-\d{2}-\d{2})(?:\s+to\s+(\d{4}-\d{2}-\d{2}))?\s+(L\w+)$",
         base,
+        re.IGNORECASE,
     )
     if not m:
         abort(

--- a/tests/test_upload_ppm_reports.py
+++ b/tests/test_upload_ppm_reports.py
@@ -79,3 +79,32 @@ def test_upload_ppm_date_range(app_instance, monkeypatch):
     assert resp.get_json()["inserted"] == 1
     assert captured["rows"][0]["Line"] == "L2"
     assert captured["rows"][0]["Report Date"] == "2024-07-02"
+
+
+def test_upload_ppm_mixed_case_filename(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = {}
+
+    def fake_insert(rows):
+        captured["rows"] = rows
+        return None, None
+
+    monkeypatch.setattr(routes, "insert_moat_bulk", fake_insert)
+    with app_instance.app_context():
+        data = {
+            "file": (
+                make_workbook(),
+                "pPmRePorTCoNtRoL 2024-07-01 To 2024-07-02 l3.XLSX",
+            )
+        }
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post(
+            "/ppm_reports/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured["rows"][0]["Line"] == "l3"
+    assert captured["rows"][0]["Report Date"] == "2024-07-02"


### PR DESCRIPTION
## Summary
- Accept `upload_ppm_reports` filenames regardless of case by passing `re.IGNORECASE`
- Test `upload_ppm_reports` with mixed-case filename to ensure case-insensitive parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bececb135c832591a9b704af538407