### PR TITLE
Remove default page margin for reports

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -1,3 +1,7 @@
+@page {
+    margin: 0;
+}
+
 /* Color system */
 :root {
     --ink: #000;


### PR DESCRIPTION
## Summary
- Ensure reports print edge-to-edge by resetting page margin in report stylesheet

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bed120b1d08325b95a3547ccf6dba4