### PR TITLE
Ensure chart summary paragraphs break into new lines

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -15,7 +15,10 @@
             <div class="chart-block">
                 <img src="{{ yieldTrendImg }}" alt="Yield Trend">
                 <div class="chart-summary">
-                    <p>Date range: {{ start }} - {{ end }}\nAverage yield: {{ yieldSummary.avg|round(1) }}%\nLowest yield date: {{ yieldSummary.worstDay.date or 'N/A' }} ({{ yieldSummary.worstDay.yield|round(1) }}%)\nWorst assembly: {{ yieldSummary.worstAssembly.assembly or 'N/A' }} ({{ yieldSummary.worstAssembly.yield|round(1) }}%)</p>
+                    <p>Date range: {{ start }} - {{ end }}
+Average yield: {{ yieldSummary.avg|round(1) }}%
+Lowest yield date: {{ yieldSummary.worstDay.date or 'N/A' }} ({{ yieldSummary.worstDay.yield|round(1) }}%)
+Worst assembly: {{ yieldSummary.worstAssembly.assembly or 'N/A' }} ({{ yieldSummary.worstAssembly.yield|round(1) }}%)</p>
                     <table class="data-table">
                         <tbody>
                         {% for d, y in yield_pairs %}
@@ -29,7 +32,11 @@
             <div class="chart-block">
                 <img src="{{ operatorRejectImg }}" alt="Operator Reject">
                 <div class="chart-summary">
-                    <p>Date range: {{ start }} - {{ end }}\nTotal boards: {{ operatorSummary.totalBoards }}\nAverage reject rate: {{ operatorSummary.avgRate|round(2) }}%\nMin reject rate: {{ operatorSummary.min.name or 'N/A' }} ({{ operatorSummary.min.rate|round(2) }}%)\nMax reject rate: {{ operatorSummary.max.name or 'N/A' }} ({{ operatorSummary.max.rate|round(2) }}%)</p>
+                    <p>Date range: {{ start }} - {{ end }}
+Total boards: {{ operatorSummary.totalBoards }}
+Average reject rate: {{ operatorSummary.avgRate|round(2) }}%
+Min reject rate: {{ operatorSummary.min.name or 'N/A' }} ({{ operatorSummary.min.rate|round(2) }}%)
+Max reject rate: {{ operatorSummary.max.name or 'N/A' }} ({{ operatorSummary.max.rate|round(2) }}%)</p>
                     <table class="data-table">
                         <thead>
                             <tr><th>Operator</th><th>Inspected</th><th>Rejected</th><th>Reject %</th></tr>
@@ -51,7 +58,10 @@
             <div class="chart-block">
                 <img src="{{ modelFalseCallsImg }}" alt="False Calls by Model">
                 <div class="chart-summary">
-                    <p>Date range: {{ start }} - {{ end }}\nAverage false calls/board: {{ modelSummary.avgFalseCalls|round(2) }}\nLine chart shows mean and ±3σ control limits; models outside may need review.\nProblem assemblies (>20 false calls/board): {{ modelSummary.over20|join(', ') if modelSummary.over20 else 'None' }}</p>
+                    <p>Date range: {{ start }} - {{ end }}
+Average false calls/board: {{ modelSummary.avgFalseCalls|round(2) }}
+Line chart shows mean and ±3σ control limits; models outside may need review.
+Problem assemblies (>20 false calls/board): {{ modelSummary.over20|join(', ') if modelSummary.over20 else 'None' }}</p>
                     <table id="problem-assemblies" class="data-table">
                         <thead><tr><th>Model</th><th>False Calls</th></tr></thead>
                         <tbody>
@@ -66,7 +76,9 @@
             <div class="chart-block">
                 <img src="{{ fcVsNgRateImg }}" alt="FC vs NG Rate">
                 <div class="chart-summary">
-                    <p>Date range: {{ start }} - {{ end }}\nCorrelation (FC vs NG): {{ fcVsNgSummary.correlation|round(2) }}\nFalse call rate has {{ fcVsNgSummary.fcTrend }} over period</p>
+                    <p>Date range: {{ start }} - {{ end }}
+Correlation (FC vs NG): {{ fcVsNgSummary.correlation|round(2) }}
+False call rate has {{ fcVsNgSummary.fcTrend }} over period</p>
                     <table id="fcVsNgRateTable" class="data-table">
                         <thead><tr><th>Date</th><th>NG PPM</th><th>FalseCall PPM</th></tr></thead>
                         <tbody>
@@ -81,7 +93,8 @@
             <div class="chart-block">
                 <img src="{{ fcNgRatioImg }}" alt="FC/NG Ratio">
                 <div class="chart-summary">
-                    <p>Date range: {{ start }} - {{ end }}\nTop ratios: {% if fcNgRatioSummary.top %}{% for t in fcNgRatioSummary.top %}{{ t.name }} ({{ '%.2f'|format(t.ratio) }}){% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}</p>
+                    <p>Date range: {{ start }} - {{ end }}
+Top ratios: {% if fcNgRatioSummary.top %}{% for t in fcNgRatioSummary.top %}{{ t.name }} ({{ '%.2f'|format(t.ratio) }}){% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}</p>
                     <table id="fcNgRatioTable" class="data-table">
                         <thead><tr><th>Model</th><th>FalseCall Parts</th><th>NG Parts</th><th>FC/NG Ratio</th></tr></thead>
                         <tbody>


### PR DESCRIPTION
## Summary
- Render each chart summary paragraph in `report.html` using real newline characters for better readability
- Preserve existing `white-space: pre-line` styling so summaries display with the intended line breaks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bed4a468b08325ba1ce3bb90b1d66a