### PR TITLE
Add summary structures to integrated report payload

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -936,6 +936,79 @@ def build_report_payload(start=None, end=None):
         )
     )
 
+    # Centralized targets for key metrics so deltas can be computed uniformly
+    targets = {
+        'avg_yield': 98.0,
+        'operator_rate': 5.0,
+        'false_calls': 10.0,
+    }
+
+    def _kpi(label, value, target_key):
+        item = {'label': label, 'value': value}
+        target = targets.get(target_key)
+        if target is not None:
+            item['target'] = target
+            item['delta'] = value - target
+        return item
+
+    summary_kpis = [
+        _kpi('Average Yield', yield_summary['avg'], 'avg_yield'),
+        _kpi('Operator Defect Rate', operator_summary['avgRate'], 'operator_rate'),
+        _kpi('False Calls per Board', model_summary['avgFalseCalls'], 'false_calls'),
+    ]
+
+    summary_actions = [
+        {'label': m['name'], 'value': m['falseCalls']}
+        for m in problem_assemblies
+    ]
+
+    program_queue = [
+        {'label': m['name'], 'value': m['falseCalls']}
+        for m in problem_assemblies
+    ]
+
+    top_risks = [
+        _kpi(asm, assembly_yields[asm], 'avg_yield')
+        for asm, _ in sorted(assembly_yields.items(), key=lambda x: x[1])[:3]
+    ]
+
+    summary_charts = [
+        {'label': 'Yield Trend', 'data': yield_pairs},
+        {'label': 'FC vs NG', 'data': fc_vs_ng_pairs},
+    ]
+
+    executive_summary = {
+        'kpis': summary_kpis,
+        'actions': summary_actions,
+        'programQueue': program_queue,
+        'topRisks': top_risks,
+        'charts': summary_charts,
+    }
+
+    highlights = summary_actions
+    kpis = summary_kpis
+
+    charts = {
+        'yield': yield_pairs,
+        'fcVsNg': fc_vs_ng_pairs,
+        'fcNgRatio': fc_ng_ratio_pairs,
+    }
+
+    top_tables = {
+        'operators': ops,
+        'models': model_rows,
+    }
+
+    jobs = [
+        {'label': op['name'], 'value': op['inspected']} for op in ops
+    ]
+
+    appendix = {
+        'yield': yield_pairs,
+        'fcVsNg': fc_vs_ng_pairs,
+        'fcNgRatio': fc_ng_ratio_pairs,
+    }
+
     return {
         'yieldData': {
             'dates': dates_iso,
@@ -959,6 +1032,18 @@ def build_report_payload(start=None, end=None):
         'operatorSummary': operator_summary,
         'modelSummary': model_summary,
         'problemAssemblies': problem_assemblies,
+        'summary_kpis': summary_kpis,
+        'summary_actions': summary_actions,
+        'program_queue': program_queue,
+        'top_risks': top_risks,
+        'summary_charts': summary_charts,
+        'executive_summary': executive_summary,
+        'highlights': highlights,
+        'kpis': kpis,
+        'charts': charts,
+        'top_tables': top_tables,
+        'jobs': jobs,
+        'appendix': appendix,
     }
 
 

--- a/tests/test_report_payload_summary_sections.py
+++ b/tests/test_report_payload_summary_sections.py
@@ -1,0 +1,72 @@
+import os
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def test_summary_sections(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        combined = []
+        aoi_rows = [
+            {
+                "Date": "2024-01-01",
+                "Operator": "Op1",
+                "Assembly": "ASM1",
+                "Job Number": "J1",
+                "Quantity Inspected": 100,
+                "Quantity Rejected": 10,
+            },
+            {
+                "Date": "2024-01-02",
+                "Operator": "Op2",
+                "Assembly": "ASM2",
+                "Job Number": "J2",
+                "Quantity Inspected": 100,
+                "Quantity Rejected": 0,
+            },
+        ]
+        moat_rows = [
+            {
+                "Report Date": "2024-01-01",
+                "Model": "ASM1",
+                "FalseCall Parts": 5,
+                "Total Boards": 1,
+                "Total Parts": 10,
+                "NG Parts": 1,
+            }
+        ]
+        monkeypatch.setattr(routes, "fetch_combined_reports", lambda: (combined, None))
+        monkeypatch.setattr(routes, "fetch_aoi_reports", lambda: (aoi_rows, None))
+        monkeypatch.setattr(routes, "fetch_moat", lambda: (moat_rows, None))
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/api/reports/integrated")
+        assert resp.status_code == 200
+        data = resp.get_json()
+
+        kpis = data["summary_kpis"]
+        assert isinstance(kpis, list)
+        first = kpis[0]
+        assert {"label", "value", "target", "delta"}.issubset(first.keys())
+        assert first["delta"] == pytest.approx(first["value"] - first["target"])
+
+        assert "executive_summary" in data
+        assert data["executive_summary"]["kpis"] == kpis
+        assert "charts" in data
+        assert "top_tables" in data


### PR DESCRIPTION
## Summary
- centralize KPI targets in `build_report_payload`
- generate summary sections (KPIs, actions, program queue, risks, charts)
- expose high-level report structures and accompanying tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedf3df86c83259db5cb50530fe4bb