### PR TITLE
Allow integrated report customization

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1078,12 +1078,42 @@ def export_integrated_report():
     payload['start'] = start.isoformat() if start else ''
     payload['end'] = end.isoformat() if end else ''
     charts = _generate_report_charts(payload)
-    show_cover = request.args.get('show_cover', '1') != '0'
-    show_summary = request.args.get('show_summary', '1') != '0'
+    body = request.get_json(silent=True) or {}
+
+    def _get(name, default=''):
+        return request.args.get(name, body.get(name, default))
+
+    def _get_bool(name, default=True):
+        value = request.args.get(name)
+        if value is None:
+            value = body.get(name)
+        if value is None:
+            return default
+        if isinstance(value, bool):
+            return value
+        return str(value).lower() not in {'0', 'false', 'no'}
+
+    show_cover = _get_bool('show_cover')
+    show_summary = _get_bool('show_summary')
+    title = _get('title')
+    subtitle = _get('subtitle')
+    report_date = _get('report_date')
+    period = _get('period')
+    author = _get('author')
+    logo_url = _get('logo_url')
+    footer_left = _get('footer_left')
+
     html = render_template(
         'report/index.html',
         show_cover=show_cover,
         show_summary=show_summary,
+        title=title,
+        subtitle=subtitle,
+        report_date=report_date,
+        period=period,
+        author=author,
+        logo_url=logo_url,
+        footer_left=footer_left,
         **payload,
         **charts,
     )

--- a/tests/test_export_integrated_report_params.py
+++ b/tests/test_export_integrated_report_params.py
@@ -1,0 +1,56 @@
+import os
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def test_export_integrated_report_accepts_custom_fields(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        monkeypatch.setattr(routes, "build_report_payload", lambda start, end: {})
+        monkeypatch.setattr(routes, "_generate_report_charts", lambda payload: {})
+        captured = {}
+
+        def fake_render(template, **context):
+            captured.update(context)
+            return "ok"
+
+        monkeypatch.setattr(routes, "render_template", fake_render)
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        payload = {
+            "show_cover": False,
+            "title": "My Title",
+            "subtitle": "Sub",
+            "report_date": "2024-09-01",
+            "period": "Q3",
+            "author": "Alice",
+            "logo_url": "http://logo",
+            "footer_left": "left foot",
+        }
+        resp = client.get("/reports/integrated/export?show_summary=0", json=payload)
+        assert resp.status_code == 200
+        assert captured["show_cover"] is False
+        assert captured["show_summary"] is False
+        assert captured["title"] == "My Title"
+        assert captured["subtitle"] == "Sub"
+        assert captured["report_date"] == "2024-09-01"
+        assert captured["period"] == "Q3"
+        assert captured["author"] == "Alice"
+        assert captured["logo_url"] == "http://logo"
+        assert captured["footer_left"] == "left foot"


### PR DESCRIPTION
## Summary
- Parse cover/summary flags and report metadata from query parameters or JSON body in `export_integrated_report`
- Forward customization options to report template and add regression test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bee014c84883258e78e101102bfd20