### PR TITLE
Add integrated report section templates with job drilldown styling

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -57,6 +57,11 @@ header img {
     height: auto;
 }
 
+.avoid-break {
+    page-break-inside: avoid;
+    break-inside: avoid;
+}
+
 .chart-summary {
     border-top: 2px solid var(--accent);
     background: var(--muted-light);

--- a/templates/report/appendix.html
+++ b/templates/report/appendix.html
@@ -1,0 +1,29 @@
+<section class="report-section section-card">
+    <h2>Appendix</h2>
+    <h3>Yield</h3>
+    <table class="data-table">
+        <tbody>
+        {% for d, y in appendix.yield %}
+            <tr><td>{{ d }}</td><td>{{ '%.1f'|format(y) }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <h3>FC vs NG</h3>
+    <table class="data-table">
+        <thead><tr><th>Date</th><th>NG PPM</th><th>FC PPM</th></tr></thead>
+        <tbody>
+        {% for d, ng, fc in appendix.fcVsNg %}
+            <tr><td>{{ d }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.1f'|format(fc) }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <h3>FC/NG Ratio</h3>
+    <table class="data-table">
+        <thead><tr><th>Model</th><th>FC Parts</th><th>NG Parts</th><th>Ratio</th></tr></thead>
+        <tbody>
+        {% for m, fc, ng, r in appendix.fcNgRatio %}
+            <tr><td>{{ m }}</td><td>{{ '%.1f'|format(fc) }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>

--- a/templates/report/capa_action_register.html
+++ b/templates/report/capa_action_register.html
@@ -1,0 +1,11 @@
+<section class="report-section section-card">
+    <h2>CAPA / Action Register</h2>
+    <table class="data-table">
+        <thead><tr><th>Assembly</th><th>Value</th></tr></thead>
+        <tbody>
+        {% for action in summary_actions %}
+            <tr><td>{{ action.label }}</td><td>{{ action.value }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>

--- a/templates/report/defect_intelligence.html
+++ b/templates/report/defect_intelligence.html
@@ -1,0 +1,16 @@
+<section class="report-section section-card">
+    <h2>Defect Intelligence</h2>
+    <div class="kpi-grid">
+    {% for kpi in kpis %}
+        <div>
+            <strong>{{ kpi.label }}</strong><br>
+            {{ '%.2f'|format(kpi.value) }}{% if kpi.target is defined %} (target {{ kpi.target }}){% endif %}
+        </div>
+    {% endfor %}
+    </div>
+    <ul>
+    {% for item in highlights %}
+        <li>{{ item.label }}: {{ item.value }}</li>
+    {% endfor %}
+    </ul>
+</section>

--- a/templates/report/index.html
+++ b/templates/report/index.html
@@ -17,5 +17,12 @@
     {% include 'report/model_false_calls.html' %}
     {% include 'report/fc_vs_ng_rate.html' %}
     {% include 'report/fc_ng_ratio.html' %}
+    {% include 'report/defect_intelligence.html' %}
+    {% include 'report/operator_reliability.html' %}
+    {% include 'report/program_review_queue.html' %}
+    {% include 'report/jobs_drilldown.html' %}
+    {% include 'report/throughput_downtime.html' %}
+    {% include 'report/capa_action_register.html' %}
+    {% include 'report/appendix.html' %}
 </body>
 </html>

--- a/templates/report/jobs_drilldown.html
+++ b/templates/report/jobs_drilldown.html
@@ -1,0 +1,11 @@
+<section class="report-section section-card avoid-break">
+    <h2>Jobs Drill-Down</h2>
+    <table class="data-table">
+        <thead><tr><th>Job</th><th>Boards</th></tr></thead>
+        <tbody>
+        {% for job in jobs %}
+            <tr><td>{{ job.label }}</td><td>{{ job.value }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>

--- a/templates/report/operator_reliability.html
+++ b/templates/report/operator_reliability.html
@@ -1,0 +1,19 @@
+<section class="report-section section-card">
+    <h2>Operator Reliability</h2>
+    <table class="data-table">
+        <thead>
+            <tr><th>Operator</th><th>Inspected</th><th>Rejected</th><th>Reject %</th></tr>
+        </thead>
+        <tbody>
+        {% for op in top_tables.operators %}
+            <tr>
+                <td>{{ op.name }}</td>
+                <td>{{ op.inspected }}</td>
+                <td>{{ op.rejected }}</td>
+                <td>{{ '%.2f'|format(op.rate) }}%</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+    <p>Total boards: {{ operatorSummary.totalBoards }} | Average reject rate: {{ operatorSummary.avgRate|round(2) }}%</p>
+</section>

--- a/templates/report/program_review_queue.html
+++ b/templates/report/program_review_queue.html
@@ -1,0 +1,11 @@
+<section class="report-section section-card">
+    <h2>Program Review Queue</h2>
+    <table class="data-table">
+        <thead><tr><th>Model</th><th>False Calls</th></tr></thead>
+        <tbody>
+        {% for item in program_queue %}
+            <tr><td>{{ item.label }}</td><td>{{ item.value }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>

--- a/templates/report/throughput_downtime.html
+++ b/templates/report/throughput_downtime.html
@@ -1,0 +1,16 @@
+<section class="report-section section-card">
+    <h2>Throughput & Downtime / Cost & Risk</h2>
+    <table class="data-table">
+        <thead><tr><th>Assembly</th><th>Yield %</th><th>Target</th><th>Delta</th></tr></thead>
+        <tbody>
+        {% for item in top_risks %}
+            <tr>
+                <td>{{ item.label }}</td>
+                <td>{{ '%.1f'|format(item.value) }}</td>
+                <td>{{ item.target }}</td>
+                <td>{{ '%.1f'|format(item.delta) }}</td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>


### PR DESCRIPTION
## Summary
- Add CSS utility class to prevent page breaks within report sections
- Expand integrated report index to include new partial sections
- Introduce partial templates for defect intelligence, operator reliability, program queue, job drill-down, cost/risk, CAPA actions, and appendix

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bee1f0f1948325993f8b06e7fde537