### PR TITLE
Add report metadata and conditional summary embedding

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1102,6 +1102,10 @@ def export_integrated_report():
     author = _get('author')
     logo_url = _get('logo_url')
     footer_left = _get('footer_left')
+    report_id = _get('report_id')
+    contact = _get('contact', 'tschwartz@4spectra.com')
+    confidentiality = _get('confidentiality', 'Spectra-Tech • Confidential')
+    generated_at = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S UTC')
 
     html = render_template(
         'report/index.html',
@@ -1114,6 +1118,10 @@ def export_integrated_report():
         author=author,
         logo_url=logo_url,
         footer_left=footer_left,
+        report_id=report_id,
+        contact=contact,
+        confidentiality=confidentiality,
+        generated_at=generated_at,
         **payload,
         **charts,
     )

--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -2,5 +2,16 @@
     <header>
         <img src="{{ url_for('static', filename='images/company-logo.png') }}" alt="Company logo">
         <h1>Integrated Report</h1>
+        <div class="report-details">
+            <p>{{ start }} - {{ end }}</p>
+            <p>{{ generated_at }}</p>
+            <p>{{ report_id }}</p>
+            <p>Thomas Schwartz</p>
+            <p>{{ confidentiality }}</p>
+            <p>&lt;{{ contact }}&gt;</p>
+        </div>
     </header>
+    {% if show_summary %}
+        {% include 'report/summary.html' %}
+    {% endif %}
 </section>

--- a/templates/report/index.html
+++ b/templates/report/index.html
@@ -8,8 +8,7 @@
 <body>
     {% if show_cover %}
         {% include 'report/cover.html' %}
-    {% endif %}
-    {% if show_summary %}
+    {% elif show_summary %}
         {% include 'report/summary.html' %}
     {% endif %}
     {% include 'report/yield_trend.html' %}

--- a/templates/report/summary.html
+++ b/templates/report/summary.html
@@ -1,7 +1,7 @@
-<section class="report-section section-card">
+<div class="summary section-card">
     <h2>Summary</h2>
     <p>Date range: {{ start }} - {{ end }}</p>
     <p>Average yield: {{ yieldSummary.avg|round(1) }}%</p>
     <p>Total boards: {{ operatorSummary.totalBoards }}</p>
     <p>Average false calls/board: {{ modelSummary.avgFalseCalls|round(2) }}</p>
-</section>
+</div>

--- a/tests/test_export_integrated_report_params.py
+++ b/tests/test_export_integrated_report_params.py
@@ -42,6 +42,9 @@ def test_export_integrated_report_accepts_custom_fields(app_instance, monkeypatc
             "author": "Alice",
             "logo_url": "http://logo",
             "footer_left": "left foot",
+            "report_id": "ID123",
+            "contact": "joe@example.com",
+            "confidentiality": "Top Secret",
         }
         resp = client.get("/reports/integrated/export?show_summary=0", json=payload)
         assert resp.status_code == 200
@@ -54,3 +57,7 @@ def test_export_integrated_report_accepts_custom_fields(app_instance, monkeypatc
         assert captured["author"] == "Alice"
         assert captured["logo_url"] == "http://logo"
         assert captured["footer_left"] == "left foot"
+        assert captured["report_id"] == "ID123"
+        assert captured["contact"] == "joe@example.com"
+        assert captured["confidentiality"] == "Top Secret"
+        assert captured["generated_at"]


### PR DESCRIPTION
## Summary
- Add detailed metadata to report cover, including date range, generation timestamp, report ID, author and contact information
- Allow summary to be embedded in the cover and show summary directly when cover is omitted
- Support additional report context parameters: report ID, contact info, confidentiality label, and generated timestamp

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beea4144708325863ddcf1299acf07