### PR TITLE
Rename throughput report and add low yield assemblies section

### DIFF
--- a/templates/report/index.html
+++ b/templates/report/index.html
@@ -19,7 +19,7 @@
     {% include 'report/defect_intelligence.html' %}
     {% include 'report/operator_reliability.html' %}
     {% include 'report/jobs_drilldown.html' %}
-    {% include 'report/throughput_downtime.html' %}
+    {% include 'report/low_yield_assemblies.html' %}
     {% include 'report/capa_action_register.html' %}
     {% include 'report/appendix.html' %}
 </body>

--- a/templates/report/low_yield_assemblies.html
+++ b/templates/report/low_yield_assemblies.html
@@ -1,5 +1,6 @@
 <section class="report-section section-card">
-    <h2>Throughput & Downtime / Cost & Risk</h2>
+    <h2>Low Yield Assemblies</h2>
+    <p class="section-desc">Assemblies with yield below target.</p>
     <table class="data-table">
         <thead><tr><th>Assembly</th><th>Yield %</th><th>Target</th><th>Delta</th></tr></thead>
         <tbody>


### PR DESCRIPTION
## Summary
- rename `throughput_downtime.html` to `low_yield_assemblies.html`
- retitle the section and add a brief description for low yield assemblies
- update report index to include the renamed template

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68beed2e5fa88325908527c94f555ba7