### PR TITLE
Add operator production report template

### DIFF
--- a/templates/report/index.html
+++ b/templates/report/index.html
@@ -18,7 +18,7 @@
     {% include 'report/fc_ng_ratio.html' %}
     {% include 'report/defect_intelligence.html' %}
     {% include 'report/operator_reliability.html' %}
-    {% include 'report/jobs_drilldown.html' %}
+    {% include 'report/operator_production.html' %}
     {% include 'report/low_yield_assemblies.html' %}
     {% include 'report/capa_action_register.html' %}
     {% include 'report/appendix.html' %}

--- a/templates/report/operator_production.html
+++ b/templates/report/operator_production.html
@@ -1,7 +1,8 @@
 <section class="report-section section-card avoid-break">
-    <h2>Jobs Drill-Down</h2>
+    <h2>Operator Production</h2>
+    <p class="section-desc">Inspection volume by operator.</p>
     <table class="data-table">
-        <thead><tr><th>Job</th><th>Boards</th></tr></thead>
+        <thead><tr><th>Operator</th><th>Inspected Quantity</th></tr></thead>
         <tbody>
         {% for job in jobs %}
             <tr><td>{{ job.label }}</td><td>{{ job.value }}</td></tr>


### PR DESCRIPTION
## Summary
- Rename jobs drill-down report to operator production
- Add section description and operator-focused table headers
- Update report index to include new operator production template

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68beeea0dc7c83258af54a6b615bcef5