### PR TITLE
Add section descriptions to report templates

### DIFF
--- a/templates/report/appendix.html
+++ b/templates/report/appendix.html
@@ -1,5 +1,6 @@
 <section class="report-section section-card">
     <h2>Appendix</h2>
+    <p class="section-desc">Contains supporting tables for yield and false-call metrics.</p>
     <h3>Yield</h3>
     <table class="data-table">
         <tbody>

--- a/templates/report/capa_action_register.html
+++ b/templates/report/capa_action_register.html
@@ -1,5 +1,6 @@
 <section class="report-section section-card">
     <h2>CAPA / Action Register</h2>
+    <p class="section-desc">Tracks corrective and preventive actions for assemblies.</p>
     <table class="data-table">
         <thead><tr><th>Assembly</th><th>Value</th></tr></thead>
         <tbody>

--- a/templates/report/defect_intelligence.html
+++ b/templates/report/defect_intelligence.html
@@ -1,5 +1,6 @@
 <section class="report-section section-card">
     <h2>Defect Intelligence</h2>
+    <p class="section-desc">Presents key defect metrics and notable highlights.</p>
     <div class="kpi-grid">
     {% for kpi in kpis %}
         <div>

--- a/templates/report/fc_ng_ratio.html
+++ b/templates/report/fc_ng_ratio.html
@@ -1,4 +1,5 @@
 <section class="report-section">
+    <p class="section-desc">Shows each model's false-call to NG part ratio.</p>
     <div class="chart-block">
         <img src="{{ fcNgRatioImg }}" alt="FC/NG Ratio">
         <div class="chart-summary">

--- a/templates/report/fc_vs_ng_rate.html
+++ b/templates/report/fc_vs_ng_rate.html
@@ -1,4 +1,5 @@
 <section class="report-section">
+    <p class="section-desc">Compares false-call rates with NG rates to reveal correlation trends.</p>
     <div class="chart-block">
         <img src="{{ fcVsNgRateImg }}" alt="FC vs NG Rate">
         <div class="chart-summary">

--- a/templates/report/low_yield_assemblies.html
+++ b/templates/report/low_yield_assemblies.html
@@ -1,6 +1,6 @@
 <section class="report-section section-card">
     <h2>Low Yield Assemblies</h2>
-    <p class="section-desc">Assemblies with yield below target.</p>
+    <p class="section-desc">Highlights assemblies performing below yield targets.</p>
     <table class="data-table">
         <thead><tr><th>Assembly</th><th>Yield %</th><th>Target</th><th>Delta</th></tr></thead>
         <tbody>

--- a/templates/report/model_false_calls.html
+++ b/templates/report/model_false_calls.html
@@ -1,4 +1,5 @@
 <section class="report-section">
+    <p class="section-desc">Analyzes false calls per model and flags assemblies needing review.</p>
     <div class="chart-block">
         <img src="{{ modelFalseCallsImg }}" alt="False Calls by Model">
         <div class="chart-summary">

--- a/templates/report/operator_production.html
+++ b/templates/report/operator_production.html
@@ -1,6 +1,6 @@
 <section class="report-section section-card avoid-break">
     <h2>Operator Production</h2>
-    <p class="section-desc">Inspection volume by operator.</p>
+    <p class="section-desc">Shows inspection volume completed by each operator.</p>
     <table class="data-table">
         <thead><tr><th>Operator</th><th>Inspected Quantity</th></tr></thead>
         <tbody>

--- a/templates/report/operator_reject.html
+++ b/templates/report/operator_reject.html
@@ -1,4 +1,5 @@
 <section class="report-section">
+    <p class="section-desc">Summarizes operator reject rates for the reporting period.</p>
     <div class="chart-block">
         <img src="{{ operatorRejectImg }}" alt="Operator Reject">
         <div class="chart-summary">

--- a/templates/report/operator_reliability.html
+++ b/templates/report/operator_reliability.html
@@ -1,5 +1,6 @@
 <section class="report-section section-card">
     <h2>Operator Reliability</h2>
+    <p class="section-desc">Lists inspection counts and reject rates to gauge operator reliability.</p>
     <table class="data-table">
         <thead>
             <tr><th>Operator</th><th>Inspected</th><th>Rejected</th><th>Reject %</th></tr>

--- a/templates/report/summary.html
+++ b/templates/report/summary.html
@@ -1,5 +1,6 @@
 <div class="summary section-card">
     <h2>Summary</h2>
+    <p class="section-desc">Provides key metrics from the reporting period.</p>
     <p>Date range: {{ start }} - {{ end }}</p>
     <p>Average yield: {{ yieldSummary.avg|round(1) }}%</p>
     <p>Total boards: {{ operatorSummary.totalBoards }}</p>

--- a/templates/report/yield_trend.html
+++ b/templates/report/yield_trend.html
@@ -1,4 +1,5 @@
 <section class="report-section">
+    <p class="section-desc">Shows yield performance over the selected date range.</p>
     <div class="chart-block">
         <img src="{{ yieldTrendImg }}" alt="Yield Trend">
         <div class="chart-summary">


### PR DESCRIPTION
## Summary
- Add concise section descriptions to clarify purpose across report templates
- Improve readability for summaries of yield, operators, defects, ratios and appendix sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bef44881588325a8c3f5ce77584316