### PR TITLE
style: enhance report cover summary

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -39,10 +39,26 @@ header img {
     height: 40px;
     margin-right: 10px;
 }
+
+.report-details {
+    margin-top: 10px;
+    font-size: 14px;
+    line-height: 1.4;
+}
+
+.report-details p {
+    margin: 0;
+}
 .section-card {
     border: 2px solid var(--border);
     background: var(--surface);
     padding: 10px;
+}
+
+.cover-page .summary {
+    border-color: var(--accent);
+    background: var(--muted-light);
+    margin-top: 20px;
 }
 
 .chart-block {
@@ -72,6 +88,12 @@ header img {
 .chart-summary p {
     white-space: pre-line;
     margin: 0 0 8px 0;
+}
+
+.section-desc {
+    font-style: italic;
+    color: #555;
+    margin-bottom: 8px;
 }
 
 .data-table {


### PR DESCRIPTION
## Summary
- style report cover details for better spacing and readability
- emphasize summary block on cover page with accent styling
- add section description styling for muted, italic descriptions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68befeb0f1508325888c3da2aa0ab708