### PR TITLE
Use custom fonts for reports

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1127,7 +1127,10 @@ def export_integrated_report():
     fmt = request.args.get('format')
     if fmt == 'pdf':
         from weasyprint import HTML
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf()
+        from weasyprint.text.fonts import FontConfiguration
+
+        font_config = FontConfiguration()
+        pdf = HTML(string=html, base_url=request.url_root).write_pdf(font_config=font_config)
         return send_file(
             io.BytesIO(pdf),
             mimetype='application/pdf',

--- a/static/css/report.css
+++ b/static/css/report.css
@@ -1,3 +1,5 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Source+Code+Pro:wght@400;700&family=Source+Serif+4:wght@400;700&display=swap');
+
 @page {
     margin: 10px;
     background: var(--surface-alt);
@@ -24,9 +26,18 @@
 }
 
 body {
-    font-family: Arial, sans-serif;
+    font-family: "Source Serif 4", serif;
     margin: 0;
     padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+    font-family: "Inter", sans-serif;
 }
 
 header {
@@ -114,6 +125,14 @@ header img {
     border: 1px solid var(--border);
     padding: 4px;
     font-size: 12px;
+}
+
+.data-table td,
+.data-table th,
+code,
+pre,
+.mono {
+    font-family: "Source Code Pro", monospace;
 }
 
 .data-table th {


### PR DESCRIPTION
## Summary
- Import Google Fonts and update report styling to use Source Serif 4, Inter, and Source Code Pro
- Configure PDF export to load fonts via WeasyPrint's `FontConfiguration`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf109adff88325ae5b2110d55df129