### PR TITLE
Use two-decimal formatting across integrated reports

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -191,13 +191,13 @@ document.addEventListener('DOMContentLoaded', () => {
     const yDesc = document.getElementById('yieldTrendDesc');
     yDesc.innerHTML =
       `<strong>Date range:</strong> ${start} - ${end}<br>` +
-      `<strong>Average yield:</strong> ${yd.avg?.toFixed(1) ?? '0'}%<br>` +
+      `<strong>Average yield:</strong> ${yd.avg?.toFixed(2) ?? '0.00'}%<br>` +
       `<strong>Lowest yield date:</strong> ${
         yd.worstDay?.date || 'N/A'
-      } (${yd.worstDay?.yield?.toFixed(1) ?? '0'}%)<br>` +
+      } (${yd.worstDay?.yield?.toFixed(2) ?? '0.00'}%)<br>` +
       `<strong>Worst assembly:</strong> ${
         yd.worstAssembly?.assembly || 'N/A'
-      } (${yd.worstAssembly?.yield?.toFixed(1) ?? '0'}%)`;
+      } (${yd.worstAssembly?.yield?.toFixed(2) ?? '0.00'}%)`;
 
     const yTable = document.getElementById('yieldTrendTable');
     const yTbody = yTable.querySelector('tbody');
@@ -207,7 +207,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const dateTd = document.createElement('td');
       dateTd.textContent = d;
       const yieldTd = document.createElement('td');
-      yieldTd.textContent = (yieldData.yields[i] ?? 0).toFixed(1);
+      yieldTd.textContent = (yieldData.yields[i] ?? 0).toFixed(2);
       tr.appendChild(dateTd);
       tr.appendChild(yieldTd);
       yTbody.appendChild(tr);
@@ -242,14 +242,14 @@ document.addEventListener('DOMContentLoaded', () => {
       `<strong>Date range:</strong> ${start} - ${end}<br>` +
       `<strong>Total boards:</strong> ${os.totalBoards ?? 0}<br>` +
       `<strong>Average reject rate:</strong> ${
-        os.avgRate?.toFixed(2) ?? '0'
+        os.avgRate?.toFixed(2) ?? '0.00'
       }%<br>` +
       `<strong>Min reject rate:</strong> ${
         os.min?.name || 'N/A'
-      } (${os.min?.rate?.toFixed(2) ?? '0'}%)<br>` +
+        } (${os.min?.rate?.toFixed(2) ?? '0.00'}%)<br>` +
       `<strong>Max reject rate:</strong> ${
         os.max?.name || 'N/A'
-      } (${os.max?.rate?.toFixed(2) ?? '0'}%)`;
+        } (${os.max?.rate?.toFixed(2) ?? '0.00'}%)`;
 
     const oTable = document.getElementById('operatorRejectTable');
     const oTbody = oTable.querySelector('tbody');
@@ -341,7 +341,7 @@ document.addEventListener('DOMContentLoaded', () => {
     mDesc.innerHTML =
       `<strong>Date range:</strong> ${start} - ${end}<br>` +
       `<strong>Average false calls/board:</strong> ${
-        ms.avgFalseCalls?.toFixed(2) ?? '0'
+        ms.avgFalseCalls?.toFixed(2) ?? '0.00'
       }<br>` +
       'Line chart shows mean and ±3σ control limits; models outside may need review.<br>' +
       `<strong>Problem assemblies (>20 false calls/board):</strong> ${
@@ -392,7 +392,7 @@ document.addEventListener('DOMContentLoaded', () => {
     fcDesc.innerHTML =
       `<strong>Date range:</strong> ${start} - ${end}<br>` +
       `<strong>Correlation (FC vs NG):</strong> ${
-        fr.correlation?.toFixed(2) ?? '0'
+        fr.correlation?.toFixed(2) ?? '0.00'
       }<br>` +
       `<strong>False call rate has</strong> ${fr.fcTrend} over period`;
 
@@ -404,9 +404,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const dateTd = document.createElement('td');
       dateTd.textContent = d;
       const ngTd = document.createElement('td');
-      ngTd.textContent = (fcVsNgRate?.ngPpm[i] ?? 0).toFixed(1);
+      ngTd.textContent = (fcVsNgRate?.ngPpm[i] ?? 0).toFixed(2);
       const fcTd = document.createElement('td');
-      fcTd.textContent = (fcVsNgRate?.fcPpm[i] ?? 0).toFixed(1);
+      fcTd.textContent = (fcVsNgRate?.fcPpm[i] ?? 0).toFixed(2);
       tr.appendChild(dateTd);
       tr.appendChild(ngTd);
       tr.appendChild(fcTd);
@@ -447,9 +447,9 @@ document.addEventListener('DOMContentLoaded', () => {
       const modelTd = document.createElement('td');
       modelTd.textContent = m;
       const fcTd = document.createElement('td');
-      fcTd.textContent = (fcNgRatio.fcParts?.[i] ?? 0).toFixed(1);
+      fcTd.textContent = (fcNgRatio.fcParts?.[i] ?? 0).toFixed(2);
       const ngTd = document.createElement('td');
-      ngTd.textContent = (fcNgRatio.ngParts?.[i] ?? 0).toFixed(1);
+      ngTd.textContent = (fcNgRatio.ngParts?.[i] ?? 0).toFixed(2);
       const ratioTd = document.createElement('td');
       ratioTd.textContent = (fcNgRatio.ratios?.[i] ?? 0).toFixed(2);
       tr.append(modelTd, fcTd, ngTd, ratioTd);

--- a/templates/report/appendix.html
+++ b/templates/report/appendix.html
@@ -5,7 +5,7 @@
     <table class="data-table">
         <tbody>
         {% for d, y in appendix.yield %}
-            <tr><td>{{ d }}</td><td>{{ '%.1f'|format(y) }}</td></tr>
+            <tr><td>{{ d }}</td><td>{{ '%.2f'|format(y) }}</td></tr>
         {% endfor %}
         </tbody>
     </table>
@@ -14,7 +14,7 @@
         <thead><tr><th>Date</th><th>NG PPM</th><th>FC PPM</th></tr></thead>
         <tbody>
         {% for d, ng, fc in appendix.fcVsNg %}
-            <tr><td>{{ d }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.1f'|format(fc) }}</td></tr>
+            <tr><td>{{ d }}</td><td>{{ '%.2f'|format(ng) }}</td><td>{{ '%.2f'|format(fc) }}</td></tr>
         {% endfor %}
         </tbody>
     </table>
@@ -23,7 +23,7 @@
         <thead><tr><th>Model</th><th>FC Parts</th><th>NG Parts</th><th>Ratio</th></tr></thead>
         <tbody>
         {% for m, fc, ng, r in appendix.fcNgRatio %}
-            <tr><td>{{ m }}</td><td>{{ '%.1f'|format(fc) }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
+            <tr><td>{{ m }}</td><td>{{ '%.2f'|format(fc) }}</td><td>{{ '%.2f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/templates/report/fc_ng_ratio.html
+++ b/templates/report/fc_ng_ratio.html
@@ -9,7 +9,7 @@
                 <thead><tr><th>Model</th><th>FalseCall Parts</th><th>NG Parts</th><th>FC/NG Ratio</th></tr></thead>
                 <tbody>
                 {% for m, fc, ng, r in fc_ng_ratio_pairs %}
-                    <tr><td>{{ m }}</td><td>{{ '%.1f'|format(fc) }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
+                    <tr><td>{{ m }}</td><td>{{ '%.2f'|format(fc) }}</td><td>{{ '%.2f'|format(ng) }}</td><td>{{ '%.2f'|format(r) }}</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/report/fc_vs_ng_rate.html
+++ b/templates/report/fc_vs_ng_rate.html
@@ -10,7 +10,7 @@
                 <thead><tr><th>Date</th><th>NG PPM</th><th>FalseCall PPM</th></tr></thead>
                 <tbody>
                 {% for d, ng, fc in fc_vs_ng_pairs %}
-                    <tr><td>{{ d }}</td><td>{{ '%.1f'|format(ng) }}</td><td>{{ '%.1f'|format(fc) }}</td></tr>
+                    <tr><td>{{ d }}</td><td>{{ '%.2f'|format(ng) }}</td><td>{{ '%.2f'|format(fc) }}</td></tr>
                 {% endfor %}
                 </tbody>
             </table>

--- a/templates/report/low_yield_assemblies.html
+++ b/templates/report/low_yield_assemblies.html
@@ -7,9 +7,9 @@
         {% for item in top_risks %}
             <tr>
                 <td>{{ item.label }}</td>
-                <td>{{ '%.1f'|format(item.value) }}</td>
-                <td>{{ item.target }}</td>
-                <td>{{ '%.1f'|format(item.delta) }}</td>
+                <td>{{ '%.2f'|format(item.value) }}</td>
+                <td>{{ '%.2f'|format(item.target) }}</td>
+                <td>{{ '%.2f'|format(item.delta) }}</td>
             </tr>
         {% endfor %}
         </tbody>

--- a/templates/report/summary.html
+++ b/templates/report/summary.html
@@ -2,7 +2,7 @@
     <h2>Summary</h2>
     <p class="section-desc">Provides key metrics from the reporting period.</p>
     <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
-    <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(1) }}%</p>
+    <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%</p>
     <p><strong>Total boards:</strong> {{ operatorSummary.totalBoards }}</p>
     <p><strong>Average false calls/board:</strong> {{ modelSummary.avgFalseCalls|round(2) }}</p>
 </div>

--- a/templates/report/yield_trend.html
+++ b/templates/report/yield_trend.html
@@ -4,13 +4,13 @@
         <img src="{{ yieldTrendImg }}" alt="Yield Trend">
         <div class="chart-summary">
             <p><strong>Date range:</strong> {{ start }} - {{ end }}<br>
-<strong>Average yield:</strong> {{ yieldSummary.avg|round(1) }}%<br>
-<strong>Lowest yield date:</strong> {{ yieldSummary.worstDay.date or 'N/A' }} ({{ yieldSummary.worstDay.yield|round(1) }}%)<br>
-<strong>Worst assembly:</strong> {{ yieldSummary.worstAssembly.assembly or 'N/A' }} ({{ yieldSummary.worstAssembly.yield|round(1) }}%)</p>
+<strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%<br>
+<strong>Lowest yield date:</strong> {{ yieldSummary.worstDay.date or 'N/A' }} ({{ yieldSummary.worstDay.yield|round(2) }}%)<br>
+<strong>Worst assembly:</strong> {{ yieldSummary.worstAssembly.assembly or 'N/A' }} ({{ yieldSummary.worstAssembly.yield|round(2) }}%)</p>
             <table class="data-table">
                 <tbody>
                 {% for d, y in yield_pairs %}
-                    <tr><td>{{ d }}</td><td>{{ '%.1f'|format(y) }}</td></tr>
+                    <tr><td>{{ d }}</td><td>{{ '%.2f'|format(y) }}</td></tr>
                 {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Format integrated report metrics and tables with two-decimal precision
- Update report templates to use two-decimal rounding for displayed values

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf151d89ac8325b80395cb6d78f405