### PR TITLE
Collapse integrated report charts and improve summaries

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1104,7 +1104,7 @@ def export_integrated_report():
     report_id = _get('report_id')
     contact = _get('contact', 'tschwartz@4spectra.com')
     confidentiality = _get('confidentiality', 'Spectra-Tech • Confidential')
-    generated_at = datetime.now(ZoneInfo('America/New_York')).strftime('%Y-%m-%d %H:%M:%S %Z')
+    generated_at = datetime.now(ZoneInfo('EST')).strftime('%Y-%m-%d %H:%M:%S %Z')
 
     html = render_template(
         'report/index.html',

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -261,7 +261,19 @@ h2 {
 
 .chart-summary p {
   display: flex;
-  align-items: center;
+  flex-direction: column;
+  align-items: flex-start;
+  margin: 0;
+}
+
+.chart-summary p span {
+  display: block;
+  line-height: 1.2;
+  padding: 2px 4px;
+}
+
+.chart-summary p span:nth-child(even) {
+  background: var(--muted);
 }
 
 .section-title {

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -40,6 +40,12 @@ document.addEventListener('DOMContentLoaded', () => {
     alert('Email sent (placeholder).');
   });
 
+  function setDesc(id, lines) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.innerHTML = lines.map((line) => `<span>${line}</span>`).join('');
+  }
+
   function computeSummary(data) {
     const yields = data.yieldData.yields || [];
     const dates = data.yieldData.dates || [];
@@ -188,16 +194,16 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     const yd = yieldSummary || {};
-    const yDesc = document.getElementById('yieldTrendDesc');
-    yDesc.innerHTML =
-      `<strong>Date range:</strong> ${start} - ${end}<br>` +
-      `<strong>Average yield:</strong> ${yd.avg?.toFixed(2) ?? '0.00'}%<br>` +
+    setDesc('yieldTrendDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Average yield:</strong> ${yd.avg?.toFixed(2) ?? '0.00'}%`,
       `<strong>Lowest yield date:</strong> ${
         yd.worstDay?.date || 'N/A'
-      } (${yd.worstDay?.yield?.toFixed(2) ?? '0.00'}%)<br>` +
+      } (${yd.worstDay?.yield?.toFixed(2) ?? '0.00'}%)`,
       `<strong>Worst assembly:</strong> ${
         yd.worstAssembly?.assembly || 'N/A'
-      } (${yd.worstAssembly?.yield?.toFixed(2) ?? '0.00'}%)`;
+      } (${yd.worstAssembly?.yield?.toFixed(2) ?? '0.00'}%)`,
+    ]);
 
     const yTable = document.getElementById('yieldTrendTable');
     const yTbody = yTable.querySelector('tbody');
@@ -237,19 +243,19 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     const os = operatorSummary || {};
-    const oDesc = document.getElementById('operatorRejectDesc');
-    oDesc.innerHTML =
-      `<strong>Date range:</strong> ${start} - ${end}<br>` +
-      `<strong>Total boards:</strong> ${os.totalBoards ?? 0}<br>` +
+    setDesc('operatorRejectDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Total boards:</strong> ${os.totalBoards ?? 0}`,
       `<strong>Average reject rate:</strong> ${
         os.avgRate?.toFixed(2) ?? '0.00'
-      }%<br>` +
+      }%`,
       `<strong>Min reject rate:</strong> ${
         os.min?.name || 'N/A'
-        } (${os.min?.rate?.toFixed(2) ?? '0.00'}%)<br>` +
+      } (${os.min?.rate?.toFixed(2) ?? '0.00'}%)`,
       `<strong>Max reject rate:</strong> ${
         os.max?.name || 'N/A'
-        } (${os.max?.rate?.toFixed(2) ?? '0.00'}%)`;
+      } (${os.max?.rate?.toFixed(2) ?? '0.00'}%)`,
+    ]);
 
     const oTable = document.getElementById('operatorRejectTable');
     const oTbody = oTable.querySelector('tbody');
@@ -337,16 +343,16 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     const ms = modelSummary || {};
-    const mDesc = document.getElementById('modelFalseCallsDesc');
-    mDesc.innerHTML =
-      `<strong>Date range:</strong> ${start} - ${end}<br>` +
+    setDesc('modelFalseCallsDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
       `<strong>Average false calls/board:</strong> ${
         ms.avgFalseCalls?.toFixed(2) ?? '0.00'
-      }<br>` +
-      'Line chart shows mean and ±3σ control limits; models outside may need review.<br>' +
+      }`,
+      'Line chart shows mean and ±3σ control limits; models outside may need review.',
       `<strong>Problem assemblies (>20 false calls/board):</strong> ${
         ms.over20?.join(', ') || 'None'
-      }`;
+      }`,
+    ]);
 
     const table = document.getElementById('problem-assemblies');
     const tbody = table.querySelector('tbody');
@@ -388,13 +394,13 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     const fr = fcVsNgSummary || {};
-    const fcDesc = document.getElementById('fcVsNgDesc');
-    fcDesc.innerHTML =
-      `<strong>Date range:</strong> ${start} - ${end}<br>` +
+    setDesc('fcVsNgDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
       `<strong>Correlation (FC vs NG):</strong> ${
         fr.correlation?.toFixed(2) ?? '0.00'
-      }<br>` +
-      `<strong>False call rate has</strong> ${fr.fcTrend} over period`;
+      }`,
+      `<strong>False call rate has</strong> ${fr.fcTrend} over period`,
+    ]);
 
     const fcTable = document.getElementById('fcVsNgRateTable');
     const fcTbody = fcTable.querySelector('tbody');
@@ -432,12 +438,12 @@ document.addEventListener('DOMContentLoaded', () => {
       },
     });
     const nr = fcNgRatioSummary || {};
-    const ratioDesc = document.getElementById('fcNgRatioDesc');
-    ratioDesc.innerHTML =
-      `<strong>Date range:</strong> ${start} - ${end}<br>` +
+    setDesc('fcNgRatioDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
       `<strong>Top ratios:</strong> ${(nr.top || [])
         .map((m) => `${m.name} (${m.ratio.toFixed(2)})`)
-        .join(', ') || 'None'}`;
+        .join(', ') || 'None'}`,
+    ]);
 
     const ratioTable = document.getElementById('fcNgRatioTable');
     const ratioTbody = ratioTable.querySelector('tbody');

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -17,63 +17,66 @@
   </div>
 </div>
 
-  <div id="charts" class="section-card">
-    <div class="chart-block">
-      <canvas id="yieldTrendChart"></canvas>
-      <div class="chart-summary">
-        <p id="yieldTrendDesc"></p>
-        <table id="yieldTrendTable" class="data-table"><tbody></tbody></table>
+  <details id="charts" class="section-card">
+    <summary>Preview Charts</summary>
+    <div>
+      <div class="chart-block">
+        <canvas id="yieldTrendChart"></canvas>
+        <div class="chart-summary">
+          <p id="yieldTrendDesc"></p>
+          <table id="yieldTrendTable" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="operatorRejectChart"></canvas>
+        <div class="chart-summary">
+          <p id="operatorRejectDesc"></p>
+          <table id="operatorRejectTable" class="data-table">
+            <thead>
+              <tr>
+                <th>Operator</th>
+                <th>Inspected</th>
+                <th>Rejected</th>
+                <th>Reject %</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="modelFalseCallsChart"></canvas>
+        <div class="chart-summary">
+          <p id="modelFalseCallsDesc"></p>
+          <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="fcVsNgRateChart"></canvas>
+        <div class="chart-summary">
+          <p id="fcVsNgDesc"></p>
+          <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="fcNgRatioChart"></canvas>
+        <div class="chart-summary">
+          <p id="fcNgRatioDesc"></p>
+          <table id="fcNgRatioTable" class="data-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>FalseCall Parts</th>
+                <th>NG Parts</th>
+                <th>FC/NG Ratio</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
       </div>
     </div>
-    <div class="chart-block">
-      <canvas id="operatorRejectChart"></canvas>
-      <div class="chart-summary">
-        <p id="operatorRejectDesc"></p>
-        <table id="operatorRejectTable" class="data-table">
-          <thead>
-            <tr>
-              <th>Operator</th>
-              <th>Inspected</th>
-              <th>Rejected</th>
-              <th>Reject %</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-    <div class="chart-block">
-      <canvas id="modelFalseCallsChart"></canvas>
-      <div class="chart-summary">
-        <p id="modelFalseCallsDesc"></p>
-        <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
-      </div>
-    </div>
-    <div class="chart-block">
-      <canvas id="fcVsNgRateChart"></canvas>
-      <div class="chart-summary">
-        <p id="fcVsNgDesc"></p>
-        <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
-      </div>
-    </div>
-    <div class="chart-block">
-      <canvas id="fcNgRatioChart"></canvas>
-      <div class="chart-summary">
-        <p id="fcNgRatioDesc"></p>
-        <table id="fcNgRatioTable" class="data-table">
-          <thead>
-            <tr>
-              <th>Model</th>
-              <th>FalseCall Parts</th>
-              <th>NG Parts</th>
-              <th>FC/NG Ratio</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
-      </div>
-    </div>
-  </div>
+  </details>
 
 <div class="field-row" id="download-controls">
   <div class="field">


### PR DESCRIPTION
## Summary
- Wrap AOI integrated report charts in a collapsible section for easier navigation
- Tighten chart summary line spacing with alternating backgrounds
- Generate report timestamps in EST instead of EDT

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bf16ed38e483259b5067211e66c211