### PR TITLE
Adjust combined-section page breaks and spacing

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -175,6 +175,15 @@ pre,
     width: 480px;
 }
 
+.combined-section {
+    page-break-after: auto;
+    margin-bottom: 20px;
+}
+
+.combined-section.last {
+    page-break-after: always;
+}
+
 @media print {
     .report-section {
         page-break-after: always;
@@ -192,6 +201,14 @@ pre,
     }
 
     .summary-page {
+        page-break-after: always;
+    }
+
+    .combined-section {
+        page-break-after: auto;
+    }
+
+    .combined-section.last {
         page-break-after: always;
     }
 }

--- a/templates/report/low_yield_assemblies.html
+++ b/templates/report/low_yield_assemblies.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card">
+<section class="report-section section-card combined-section last">
     <h2>Low Yield Assemblies</h2>
     <p class="section-desc">Highlights assemblies performing below yield targets.</p>
     <table class="data-table">

--- a/templates/report/operator_production.html
+++ b/templates/report/operator_production.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card avoid-break">
+<section class="report-section section-card avoid-break combined-section">
     <h2>Operator Production</h2>
     <p class="section-desc">Shows inspection volume completed by each operator.</p>
     <table class="data-table">

--- a/templates/report/operator_reliability.html
+++ b/templates/report/operator_reliability.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card">
+<section class="report-section section-card combined-section">
     <h2>Operator Reliability</h2>
     <p class="section-desc">Lists inspection counts and reject rates to gauge operator reliability.</p>
     <table class="data-table">


### PR DESCRIPTION
## Summary
- Add `.combined-section` style with spacing and print-friendly page-break rules
- Extend report templates to use `combined-section` and optional `last` class for force page breaks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf19687c5883259e0d71b96417861a