### PR TITLE
Format highlight values to two decimals

### DIFF
--- a/templates/report/defect_intelligence.html
+++ b/templates/report/defect_intelligence.html
@@ -11,7 +11,7 @@
     </div>
     <ul>
     {% for item in highlights %}
-        <li>{{ item.label }}: {{ item.value }}</li>
+        <li>{{ item.label }}: {{ '%.2f'|format(item.value) }}</li>
     {% endfor %}
     </ul>
 </section>


### PR DESCRIPTION
## Summary
- format highlight metric values to two decimal places in defect intelligence report template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c048840ec88325b46d7553527eccde