### PR TITLE
Format CAPA values to two decimals

### DIFF
--- a/templates/report/capa_action_register.html
+++ b/templates/report/capa_action_register.html
@@ -5,7 +5,7 @@
         <thead><tr><th>Assembly</th><th>Value</th></tr></thead>
         <tbody>
         {% for action in summary_actions %}
-            <tr><td>{{ action.label }}</td><td>{{ action.value }}</td></tr>
+            <tr><td>{{ action.label }}</td><td>{{ '%.2f'|format(action.value) }}</td></tr>
         {% endfor %}
         </tbody>
     </table>


### PR DESCRIPTION
## Summary
- Ensure CAPA register values render with two decimal precision

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c048fa43bc8325bb71f8d1cf938f16