### PR TITLE
Format false call values with two decimals

### DIFF
--- a/templates/report/model_false_calls.html
+++ b/templates/report/model_false_calls.html
@@ -11,7 +11,7 @@ Line chart shows mean and ±3σ control limits; models outside may need review.<
                 <thead><tr><th>Model</th><th>False Calls</th></tr></thead>
                 <tbody>
                 {% for m in problemAssemblies %}
-                    <tr><td>{{ m.name }}</td><td>{{ m.falseCalls }}</td></tr>
+                    <tr><td>{{ m.name }}</td><td>{{ '%.2f'|format(m.falseCalls) }}</td></tr>
                 {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
## Summary
- Format false call counts to display two decimal places in model false call report table

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c049f460f88325ae870a89e417b6a2