### PR TITLE
Format numeric data in report tables

### DIFF
--- a/templates/report/operator_production.html
+++ b/templates/report/operator_production.html
@@ -5,7 +5,7 @@
         <thead><tr><th>Operator</th><th>Inspected Quantity</th></tr></thead>
         <tbody>
         {% for job in jobs %}
-            <tr><td>{{ job.label }}</td><td>{{ job.value }}</td></tr>
+            <tr><td>{{ job.label }}</td><td>{{ '%.2f'|format(job.value) }}</td></tr>
         {% endfor %}
         </tbody>
     </table>

--- a/templates/report/operator_reject.html
+++ b/templates/report/operator_reject.html
@@ -16,8 +16,8 @@
                 {% for op in operators %}
                     <tr>
                         <td>{{ op.name }}</td>
-                        <td>{{ op.inspected }}</td>
-                        <td>{{ op.rejected }}</td>
+                        <td>{{ '%.2f'|format(op.inspected) }}</td>
+                        <td>{{ '%.2f'|format(op.rejected) }}</td>
                         <td>{{ '%.2f'|format(op.rate) }}%</td>
                     </tr>
                 {% endfor %}

--- a/templates/report/operator_reliability.html
+++ b/templates/report/operator_reliability.html
@@ -9,8 +9,8 @@
         {% for op in top_tables.operators %}
             <tr>
                 <td>{{ op.name }}</td>
-                <td>{{ op.inspected }}</td>
-                <td>{{ op.rejected }}</td>
+                <td>{{ '%.2f'|format(op.inspected) }}</td>
+                <td>{{ '%.2f'|format(op.rejected) }}</td>
                 <td>{{ '%.2f'|format(op.rate) }}%</td>
             </tr>
         {% endfor %}


### PR DESCRIPTION
## Summary
- Ensure operator production table displays inspected quantities with two decimal precision
- Standardize operator reject and reliability tables to show inspected and rejected counts with two decimal formatting

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c04a69da9c8325a514c709e555f845