### PR TITLE
Add Table of Contents for report sections

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -83,6 +83,26 @@ header img {
     margin-top: 20px;
 }
 
+.summary-break {
+    height: 20px;
+}
+
+.toc ol {
+    list-style: none;
+    padding-left: 0;
+    margin: 0;
+}
+
+.toc a {
+    text-decoration: none;
+    color: inherit;
+}
+
+.toc a::after {
+    content: leader('.') target-counter(attr(href), page);
+    float: right;
+}
+
 .chart-block {
     border-style: solid;
     border-color: var(--border);

--- a/templates/report/appendix.html
+++ b/templates/report/appendix.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card">
+<section id="appendix" class="report-section section-card">
     <h2>Appendix</h2>
     <p class="section-desc">Contains supporting tables for yield and false-call metrics.</p>
     <h3>Yield</h3>

--- a/templates/report/capa_action_register.html
+++ b/templates/report/capa_action_register.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card">
+<section id="capa-action-register" class="report-section section-card">
     <h2>CAPA / Action Register</h2>
     <p class="section-desc">Tracks corrective and preventive actions for assemblies.</p>
     <table class="data-table">

--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -1,4 +1,4 @@
-<section class="report-section cover-page">
+<section id="cover" class="report-section cover-page">
     <br>
         <h1>
             <img src="{{ url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
@@ -16,5 +16,7 @@
     </header>
     {% if show_summary %}
         {% include 'report/summary.html' %}
+        <div class="summary-break"></div>
+        {% include 'report/toc.html' %}
     {% endif %}
 </section>

--- a/templates/report/defect_intelligence.html
+++ b/templates/report/defect_intelligence.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card">
+<section id="defect-intelligence" class="report-section section-card">
     <h2>Defect Intelligence</h2>
     <p class="section-desc">Presents key defect metrics and notable highlights.</p>
     <div class="kpi-grid">

--- a/templates/report/fc_ng_ratio.html
+++ b/templates/report/fc_ng_ratio.html
@@ -1,4 +1,4 @@
-<section class="report-section">
+<section id="fc-ng-ratio" class="report-section">
     <p class="section-desc">Shows each model's false-call to NG part ratio.</p>
     <div class="chart-block">
         <img src="{{ fcNgRatioImg }}" alt="FC/NG Ratio">

--- a/templates/report/fc_vs_ng_rate.html
+++ b/templates/report/fc_vs_ng_rate.html
@@ -1,4 +1,4 @@
-<section class="report-section">
+<section id="fc-vs-ng-rate" class="report-section">
     <p class="section-desc">Compares false-call rates with NG rates to reveal correlation trends.</p>
     <div class="chart-block">
         <img src="{{ fcVsNgRateImg }}" alt="FC vs NG Rate">

--- a/templates/report/low_yield_assemblies.html
+++ b/templates/report/low_yield_assemblies.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card combined-section last">
+<section id="low-yield-assemblies" class="report-section section-card combined-section last">
     <h2>Low Yield Assemblies</h2>
     <p class="section-desc">Highlights assemblies performing below yield targets.</p>
     <table class="data-table">

--- a/templates/report/model_false_calls.html
+++ b/templates/report/model_false_calls.html
@@ -1,4 +1,4 @@
-<section class="report-section">
+<section id="model-false-calls" class="report-section">
     <p class="section-desc">Analyzes false calls per model and flags assemblies needing review.</p>
     <div class="chart-block">
         <img src="{{ modelFalseCallsImg }}" alt="False Calls by Model">

--- a/templates/report/operator_production.html
+++ b/templates/report/operator_production.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card avoid-break combined-section">
+<section id="operator-production" class="report-section section-card avoid-break combined-section">
     <h2>Operator Production</h2>
     <p class="section-desc">Shows inspection volume completed by each operator.</p>
     <table class="data-table">

--- a/templates/report/operator_reject.html
+++ b/templates/report/operator_reject.html
@@ -1,4 +1,4 @@
-<section class="report-section">
+<section id="operator-reject" class="report-section">
     <p class="section-desc">Summarizes operator reject rates for the reporting period.</p>
     <div class="chart-block">
         <img src="{{ operatorRejectImg }}" alt="Operator Reject">

--- a/templates/report/operator_reliability.html
+++ b/templates/report/operator_reliability.html
@@ -1,4 +1,4 @@
-<section class="report-section section-card combined-section">
+<section id="operator-reliability" class="report-section section-card combined-section">
     <h2>Operator Reliability</h2>
     <p class="section-desc">Lists inspection counts and reject rates to gauge operator reliability.</p>
     <table class="data-table">

--- a/templates/report/toc.html
+++ b/templates/report/toc.html
@@ -1,0 +1,17 @@
+<div class="toc section-card">
+    <h2>Table of Contents</h2>
+    <ol>
+        <li><a href="#yield-trend">Yield Trend</a></li>
+        <li><a href="#operator-reject">Operator Reject</a></li>
+        <li><a href="#model-false-calls">Model False Calls</a></li>
+        <li><a href="#fc-vs-ng-rate">FC vs NG Rate</a></li>
+        <li><a href="#fc-ng-ratio">FC/NG Ratio</a></li>
+        <li><a href="#defect-intelligence">Defect Intelligence</a></li>
+        <li><a href="#operator-reliability">Operator Reliability</a></li>
+        <li><a href="#operator-production">Operator Production</a></li>
+        <li><a href="#low-yield-assemblies">Low Yield Assemblies</a></li>
+        <li><a href="#capa-action-register">CAPA / Action Register</a></li>
+        <li><a href="#appendix">Appendix</a></li>
+    </ol>
+</div>
+

--- a/templates/report/yield_trend.html
+++ b/templates/report/yield_trend.html
@@ -1,4 +1,4 @@
-<section class="report-section">
+<section id="yield-trend" class="report-section">
     <p class="section-desc">Shows yield performance over the selected date range.</p>
     <div class="chart-block">
         <img src="{{ yieldTrendImg }}" alt="Yield Trend">

--- a/tests/test_export_report_rendering.py
+++ b/tests/test_export_report_rendering.py
@@ -35,8 +35,9 @@ def _mock_report(monkeypatch):
         tpl = (
             "{% if show_cover %}<div class='cover-page'>cover"
             "{% if show_summary %}<section class='summary'>"
-            "{% for k in summary_kpis %}<div class='kpi'>{{ k.label }}</div>{% endfor %}"
-            "</section>{% endif %}</div>{% elif show_summary %}"
+            "{% for k in summary_kpis %}<div class='kpi'>{{ k.label }}</div>{% endfor %}</section>"
+            "<div class='summary-break'></div><div class='toc'>Table of Contents</div>"
+            "{% endif %}</div>{% elif show_summary %}"
             "<section class='summary'>"
             "{% for k in summary_kpis %}<div class='kpi'>{{ k.label }}</div>{% endfor %}"
             "</section>{% endif %}"
@@ -85,6 +86,21 @@ def test_cover_contains_summary_when_enabled(app_instance, monkeypatch):
         assert "KPI1" in html
         assert "JobA" in html
         assert "Program Review Queue" not in html
+
+
+def test_cover_contains_toc_when_summary_enabled(app_instance, monkeypatch):
+    _mock_report(monkeypatch)
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get(
+            "/reports/integrated/export?format=html",
+            json={"show_cover": True, "show_summary": True},
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "Table of Contents" in html
 
 
 def test_data_keys_present_in_pdf(app_instance, monkeypatch):


### PR DESCRIPTION
## Summary
- add unique IDs to all report section templates
- include a reusable Table of Contents card and show it on the cover when summaries are enabled
- style TOC links and spacer in report stylesheet
- test that the cover renders the Table of Contents when summaries are displayed

## Testing
- `pytest tests/test_export_report_rendering.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c04bbf45408325ae683156d39d0c49