### PR TITLE
Add operator report page and export

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1150,6 +1150,69 @@ def export_integrated_report():
     return html
 
 
+def build_operator_report_payload(start=None, end=None):
+    """Placeholder payload for the operator report."""
+    return {
+        'start': start.isoformat() if start else '',
+        'end': end.isoformat() if end else '',
+        'yieldTrendImg': '',
+        'yieldSummary': {
+            'avg': 0,
+            'worstDay': {'date': None, 'yield': 0},
+            'worstAssembly': {'assembly': None, 'yield': 0},
+        },
+        'yield_pairs': [],
+        'operatorRejectImg': '',
+        'operatorSummary': {
+            'totalBoards': 0,
+            'avgRate': 0,
+            'min': {'name': '', 'rate': 0},
+            'max': {'name': '', 'rate': 0},
+        },
+        'operators': [],
+        'modelFalseCallsImg': '',
+        'modelSummary': {'avgFalseCalls': 0, 'over20': []},
+        'problemAssemblies': [],
+        'fcVsNgRateImg': '',
+        'fcVsNgSummary': {'correlation': 0, 'fcTrend': ''},
+        'fc_vs_ng_pairs': [],
+        'fcNgRatioImg': '',
+        'fcNgRatioSummary': {'top': []},
+        'fc_ng_ratio_pairs': [],
+        'kpis': [{'label': 'Placeholder KPI', 'value': 0}],
+        'highlights': [],
+        'top_tables': {'operators': []},
+        'jobs': [],
+        'top_risks': [],
+        'summary_actions': [],
+        'appendix': {'yield': [], 'fcVsNg': [], 'fcNgRatio': []},
+    }
+
+
+@main_bp.route('/reports/operator', methods=['GET'])
+def operator_report():
+    """Render the Operator Report page."""
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    return render_template('operator_report.html', username=session.get('username'))
+
+
+@main_bp.route('/reports/operator/export')
+def export_operator_report():
+    """Export the operator report as styled HTML."""
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    start = _parse_date(request.args.get('start_date'))
+    end = _parse_date(request.args.get('end_date'))
+    payload = build_operator_report_payload(start, end)
+    return render_template(
+        'report/index.html',
+        show_cover=False,
+        show_summary=False,
+        **payload,
+    )
+
+
 @main_bp.route('/analysis/aoi/grades', methods=['GET'])
 def aoi_grades():
     """Return AOI grades computed from combined reports.

--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -1,0 +1,467 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const runBtn = document.getElementById('run-report');
+  const downloadControls = document.getElementById('download-controls');
+  const downloadBtn = document.getElementById('download-report');
+  let reportData = null;
+  let yieldChart, operatorChart, modelChart, fcVsNgChart, fcNgRatioChart;
+
+  if (downloadControls) downloadControls.style.display = 'none';
+
+  runBtn?.addEventListener('click', () => {
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    if (!start || !end) {
+      alert('Please select a date range.');
+      return;
+    }
+
+    fetch(`/api/reports/operator?start_date=${start}&end_date=${end}`)
+      .then((res) => res.json())
+      .then((data) => {
+        reportData = { ...data, start, end };
+        computeSummary(reportData);
+        renderCharts(reportData);
+        downloadControls.style.display = 'flex';
+      })
+      .catch(() => alert('Failed to run report.'));
+  });
+
+  downloadBtn?.addEventListener('click', () => {
+    const fmt = document.getElementById('file-format').value;
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    const params = new URLSearchParams({ format: fmt });
+    if (start) params.append('start_date', start);
+    if (end) params.append('end_date', end);
+    window.location = `/reports/operator/export?${params.toString()}`;
+  });
+
+  document.getElementById('email-report')?.addEventListener('click', () => {
+    alert('Email sent (placeholder).');
+  });
+
+  function setDesc(id, lines) {
+    const el = document.getElementById(id);
+    if (!el) return;
+    el.innerHTML = lines.map((line) => `<span>${line}</span>`).join('');
+  }
+
+  function computeSummary(data) {
+    const yields = data.yieldData.yields || [];
+    const dates = data.yieldData.dates || [];
+    const avgYield =
+      yields.reduce((a, b) => a + b, 0) / (yields.length || 1);
+    let worstIdx = 0;
+    yields.forEach((v, i) => {
+      if (v < yields[worstIdx]) worstIdx = i;
+    });
+    const worstDay = {
+      date: dates[worstIdx] || null,
+      yield: yields[worstIdx] || 0,
+    };
+    let worstAsm = { assembly: null, yield: Infinity };
+    Object.entries(data.yieldData.assemblyYields || {}).forEach(([k, v]) => {
+      if (v < worstAsm.yield) worstAsm = { assembly: k, yield: v };
+    });
+    data.yieldSummary = { avg: avgYield, worstDay, worstAssembly: worstAsm };
+
+    const ops = (data.operators || []).map((o) => ({
+      ...o,
+      rate: o.inspected ? (o.rejected / o.inspected) * 100 : 0,
+    }));
+    // Sort operators by inspected count so charts and exports share the order
+    ops.sort((a, b) => b.inspected - a.inspected);
+    data.operators = ops;
+    const totalBoards = ops.reduce((a, o) => a + o.inspected, 0);
+    const avgRate =
+      ops.reduce((a, o) => a + o.rate, 0) / (ops.length || 1);
+    let minOp = ops[0] || { name: '', rate: 0 };
+    let maxOp = ops[0] || { name: '', rate: 0 };
+    ops.forEach((o) => {
+      if (o.rate < minOp.rate) minOp = o;
+      if (o.rate > maxOp.rate) maxOp = o;
+    });
+    data.operatorSummary = { totalBoards, avgRate, min: minOp, max: maxOp };
+
+    const avgFc =
+      (data.models || []).reduce((a, m) => a + m.falseCalls, 0) /
+      ((data.models || []).length || 1);
+    const problemAssemblies = (data.models || []).filter(
+      (m) => m.falseCalls > 20
+    );
+    const over20 = problemAssemblies.map((m) => m.name);
+    data.modelSummary = { avgFalseCalls: avgFc, over20 };
+    data.problemAssemblies = problemAssemblies;
+
+    const fc = data.fcVsNgRate || {};
+    const ngVals = fc.ngPpm || [];
+    const fcVals = fc.fcPpm || [];
+    const n = Math.min(ngVals.length, fcVals.length);
+    let corr = 0;
+    if (n > 1) {
+      const avgNg = ngVals.reduce((a, b) => a + b, 0) / n;
+      const avgFc = fcVals.reduce((a, b) => a + b, 0) / n;
+      let num = 0;
+      let denNg = 0;
+      let denFc = 0;
+      for (let i = 0; i < n; i += 1) {
+        const x = ngVals[i] - avgNg;
+        const y = fcVals[i] - avgFc;
+        num += x * y;
+        denNg += x * x;
+        denFc += y * y;
+      }
+      const den = Math.sqrt(denNg * denFc);
+      corr = den ? num / den : 0;
+    }
+    const fcTrend =
+      fcVals.length > 1
+        ? fcVals[0] < fcVals[fcVals.length - 1]
+          ? 'increased'
+          : 'decreased'
+        : 'stable';
+    data.fcVsNgSummary = { correlation: corr, fcTrend };
+
+    const ratioData = data.fcNgRatio || {};
+    const rModels = ratioData.models || [];
+    const rFcParts = ratioData.fcParts || [];
+    const rNgParts = ratioData.ngParts || [];
+    const rRatios =
+      ratioData.ratios ||
+      rModels.map((_, i) => {
+        const fcPart = rFcParts[i] || 0;
+        const ngPart = rNgParts[i] || 0;
+        return ngPart ? fcPart / ngPart : 0;
+      });
+    const combined = rModels
+      .map((m, i) => ({
+        model: m,
+        fc: rFcParts[i] || 0,
+        ng: rNgParts[i] || 0,
+        ratio: rRatios[i],
+      }))
+      .filter((item) => item.ng > 2);
+    combined.sort((a, b) => b.ratio - a.ratio);
+    const top = combined.slice(0, 10);
+    data.fcNgRatio = {
+      models: top.map((t) => t.model),
+      fcParts: top.map((t) => t.fc),
+      ngParts: top.map((t) => t.ng),
+      ratios: top.map((t) => t.ratio),
+    };
+    data.fcNgRatioSummary = { top: combined.slice(0, 3) };
+  }
+
+  function renderCharts(data) {
+    const {
+      yieldData,
+      operators,
+      models,
+      yieldSummary,
+      operatorSummary,
+      modelSummary,
+      problemAssemblies,
+      fcVsNgRate,
+      fcVsNgSummary,
+      fcNgRatio,
+      fcNgRatioSummary,
+      start,
+      end,
+    } = data;
+
+    yieldChart?.destroy();
+    operatorChart?.destroy();
+    modelChart?.destroy();
+    fcVsNgChart?.destroy();
+    fcNgRatioChart?.destroy();
+
+    const yieldCanvas = document.getElementById('yieldTrendChart');
+    yieldCanvas.width = 800;
+    yieldCanvas.height = 400;
+    const yieldCtx = yieldCanvas.getContext('2d');
+    yieldChart = new Chart(yieldCtx, {
+      type: 'line',
+      data: {
+        labels: yieldData.dates,
+        datasets: [
+          {
+            label: 'Yield %',
+            data: yieldData.yields,
+            borderColor: 'blue',
+            fill: false,
+          },
+        ],
+      },
+    });
+    const yd = yieldSummary || {};
+    setDesc('yieldTrendDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Average yield:</strong> ${yd.avg?.toFixed(2) ?? '0.00'}%`,
+      `<strong>Lowest yield date:</strong> ${
+        yd.worstDay?.date || 'N/A'
+      } (${yd.worstDay?.yield?.toFixed(2) ?? '0.00'}%)`,
+      `<strong>Worst assembly:</strong> ${
+        yd.worstAssembly?.assembly || 'N/A'
+      } (${yd.worstAssembly?.yield?.toFixed(2) ?? '0.00'}%)`,
+    ]);
+
+    const yTable = document.getElementById('yieldTrendTable');
+    const yTbody = yTable.querySelector('tbody');
+    yTbody.innerHTML = '';
+    (yieldData.dates || []).forEach((d, i) => {
+      const tr = document.createElement('tr');
+      const dateTd = document.createElement('td');
+      dateTd.textContent = d;
+      const yieldTd = document.createElement('td');
+      yieldTd.textContent = (yieldData.yields[i] ?? 0).toFixed(2);
+      tr.appendChild(dateTd);
+      tr.appendChild(yieldTd);
+      yTbody.appendChild(tr);
+    });
+    yTable.style.display = (yieldData.dates || []).length ? 'table' : 'none';
+
+    const operatorCanvas = document.getElementById('operatorRejectChart');
+    operatorCanvas.width = 800;
+    operatorCanvas.height = 400;
+    const operatorCtx = operatorCanvas.getContext('2d');
+    const accepted = operators.map((o) => o.inspected - o.rejected);
+    const rejected = operators.map((o) => o.rejected);
+    operatorChart = new Chart(operatorCtx, {
+      type: 'bar',
+      data: {
+        labels: operators.map((o) => o.name),
+        datasets: [
+          { label: 'Accepted', data: accepted, backgroundColor: 'green' },
+          { label: 'Rejected', data: rejected, backgroundColor: 'red' },
+        ],
+      },
+      options: {
+        scales: {
+          x: { stacked: true },
+          y: { stacked: true },
+        },
+      },
+    });
+    const os = operatorSummary || {};
+    setDesc('operatorRejectDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Total boards:</strong> ${os.totalBoards ?? 0}`,
+      `<strong>Average reject rate:</strong> ${
+        os.avgRate?.toFixed(2) ?? '0.00'
+      }%`,
+      `<strong>Min reject rate:</strong> ${
+        os.min?.name || 'N/A'
+      } (${os.min?.rate?.toFixed(2) ?? '0.00'}%)`,
+      `<strong>Max reject rate:</strong> ${
+        os.max?.name || 'N/A'
+      } (${os.max?.rate?.toFixed(2) ?? '0.00'}%)`,
+    ]);
+
+    const oTable = document.getElementById('operatorRejectTable');
+    const oTbody = oTable.querySelector('tbody');
+    oTbody.innerHTML = '';
+    (operators || []).forEach((op) => {
+      const tr = document.createElement('tr');
+      const nameTd = document.createElement('td');
+      nameTd.textContent = op.name;
+      const inspTd = document.createElement('td');
+      inspTd.textContent = op.inspected;
+      const rejTd = document.createElement('td');
+      rejTd.textContent = op.rejected;
+      const rateTd = document.createElement('td');
+      rateTd.textContent = `${op.rate?.toFixed(2) ?? '0.00'}%`;
+      tr.appendChild(nameTd);
+      tr.appendChild(inspTd);
+      tr.appendChild(rejTd);
+      tr.appendChild(rateTd);
+      oTbody.appendChild(tr);
+    });
+    oTable.style.display = (operators || []).length ? 'table' : 'none';
+
+    const modelCanvas = document.getElementById('modelFalseCallsChart');
+    modelCanvas.width = 800;
+    modelCanvas.height = 400;
+    const modelCtx = modelCanvas.getContext('2d');
+
+    // Calculate control limits for false calls by model
+    const falseCalls = models.map((m) => m.falseCalls);
+    const mean =
+      falseCalls.reduce((sum, v) => sum + v, 0) / (falseCalls.length || 1);
+    const stdDev = Math.sqrt(
+      falseCalls.reduce((sum, v) => sum + Math.pow(v - mean, 2), 0) /
+        (falseCalls.length || 1)
+    );
+    const upperCL = mean + 3 * stdDev;
+    const lowerCL = Math.max(mean - 3 * stdDev, 0);
+
+    modelChart = new Chart(modelCtx, {
+      type: 'line',
+      data: {
+        labels: models.map((m) => m.name),
+        datasets: [
+          {
+            label: 'False Calls',
+            data: falseCalls,
+            borderColor: 'orange',
+            backgroundColor: 'orange',
+            tension: 0,
+            fill: false,
+          },
+          {
+            label: 'Mean',
+            data: Array(falseCalls.length).fill(mean),
+            borderColor: 'blue',
+            borderDash: [5, 5],
+            pointRadius: 0,
+            fill: false,
+          },
+          {
+            label: '+3σ',
+            data: Array(falseCalls.length).fill(upperCL),
+            borderColor: 'green',
+            borderDash: [5, 5],
+            pointRadius: 0,
+            fill: false,
+          },
+          {
+            label: '-3σ',
+            data: Array(falseCalls.length).fill(lowerCL),
+            borderColor: 'red',
+            borderDash: [5, 5],
+            pointRadius: 0,
+            fill: false,
+          },
+        ],
+      },
+      options: {
+        scales: {
+          x: {
+            ticks: { display: false },
+            grid: { display: false },
+          },
+        },
+      },
+    });
+    const ms = modelSummary || {};
+    setDesc('modelFalseCallsDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Average false calls/board:</strong> ${
+        ms.avgFalseCalls?.toFixed(2) ?? '0.00'
+      }`,
+      'Line chart shows mean and ±3σ control limits; models outside may need review.',
+      `<strong>Problem assemblies (>20 false calls/board):</strong> ${
+        ms.over20?.join(', ') || 'None'
+      }`,
+    ]);
+
+    const table = document.getElementById('problem-assemblies');
+    const tbody = table.querySelector('tbody');
+    tbody.innerHTML = '';
+    (problemAssemblies || []).forEach((m) => {
+      const tr = document.createElement('tr');
+      const nameTd = document.createElement('td');
+      nameTd.textContent = m.name;
+      const fcTd = document.createElement('td');
+      fcTd.textContent = m.falseCalls;
+      tr.appendChild(nameTd);
+      tr.appendChild(fcTd);
+      tbody.appendChild(tr);
+    });
+    table.style.display = (problemAssemblies || []).length ? 'table' : 'none';
+
+    const fcCanvas = document.getElementById('fcVsNgRateChart');
+    fcCanvas.width = 800;
+    fcCanvas.height = 400;
+    const fcCtx = fcCanvas.getContext('2d');
+    fcVsNgChart = new Chart(fcCtx, {
+      type: 'line',
+      data: {
+        labels: fcVsNgRate?.dates || [],
+        datasets: [
+          {
+            label: 'NG PPM',
+            data: fcVsNgRate?.ngPpm || [],
+            borderColor: 'red',
+            fill: false,
+          },
+          {
+            label: 'FalseCall PPM',
+            data: fcVsNgRate?.fcPpm || [],
+            borderColor: 'blue',
+            fill: false,
+          },
+        ],
+      },
+    });
+    const fr = fcVsNgSummary || {};
+    setDesc('fcVsNgDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Correlation (FC vs NG):</strong> ${
+        fr.correlation?.toFixed(2) ?? '0.00'
+      }`,
+      `<strong>False call rate has</strong> ${fr.fcTrend} over period`,
+    ]);
+
+    const fcTable = document.getElementById('fcVsNgRateTable');
+    const fcTbody = fcTable.querySelector('tbody');
+    fcTbody.innerHTML = '';
+    (fcVsNgRate?.dates || []).forEach((d, i) => {
+      const tr = document.createElement('tr');
+      const dateTd = document.createElement('td');
+      dateTd.textContent = d;
+      const ngTd = document.createElement('td');
+      ngTd.textContent = (fcVsNgRate?.ngPpm[i] ?? 0).toFixed(2);
+      const fcTd = document.createElement('td');
+      fcTd.textContent = (fcVsNgRate?.fcPpm[i] ?? 0).toFixed(2);
+      tr.appendChild(dateTd);
+      tr.appendChild(ngTd);
+      tr.appendChild(fcTd);
+      fcTbody.appendChild(tr);
+    });
+    fcTable.style.display = (fcVsNgRate?.dates || []).length ? 'table' : 'none';
+
+    const ratioCanvas = document.getElementById('fcNgRatioChart');
+    ratioCanvas.width = 800;
+    ratioCanvas.height = 400;
+    const ratioCtx = ratioCanvas.getContext('2d');
+    fcNgRatioChart = new Chart(ratioCtx, {
+      type: 'bar',
+      data: {
+        labels: fcNgRatio?.models || [],
+        datasets: [
+          {
+            label: 'FC/NG Ratio',
+            data: fcNgRatio?.ratios || [],
+            backgroundColor: 'teal',
+          },
+        ],
+      },
+    });
+    const nr = fcNgRatioSummary || {};
+    setDesc('fcNgRatioDesc', [
+      `<strong>Date range:</strong> ${start} - ${end}`,
+      `<strong>Top ratios:</strong> ${(nr.top || [])
+        .map((m) => `${m.name} (${m.ratio.toFixed(2)})`)
+        .join(', ') || 'None'}`,
+    ]);
+
+    const ratioTable = document.getElementById('fcNgRatioTable');
+    const ratioTbody = ratioTable.querySelector('tbody');
+    ratioTbody.innerHTML = '';
+    (fcNgRatio?.models || []).forEach((m, i) => {
+      const tr = document.createElement('tr');
+      const modelTd = document.createElement('td');
+      modelTd.textContent = m;
+      const fcTd = document.createElement('td');
+      fcTd.textContent = (fcNgRatio.fcParts?.[i] ?? 0).toFixed(2);
+      const ngTd = document.createElement('td');
+      ngTd.textContent = (fcNgRatio.ngParts?.[i] ?? 0).toFixed(2);
+      const ratioTd = document.createElement('td');
+      ratioTd.textContent = (fcNgRatio.ratios?.[i] ?? 0).toFixed(2);
+      tr.append(modelTd, fcTd, ngTd, ratioTd);
+      ratioTbody.appendChild(tr);
+    });
+    ratioTable.style.display = (fcNgRatio?.models || []).length ? 'table' : 'none';
+  }
+});
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -38,6 +38,7 @@
           <a href="#">Reports <span class="arrow">&#9662;</span></a>
           <div class="dropdown">
             <a href="{{ url_for('main.integrated_report') }}">AOI Integrated Report</a>
+            <a href="{{ url_for('main.operator_report') }}">Operator Report</a>
           </div>
         </li>
       </ul>

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -1,0 +1,98 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Operator Report</h2>
+
+<div class="section-card">
+  <div class="field-row">
+    <div class="field">
+      <label for="start-date">Start Date</label>
+      <input type="date" id="start-date" />
+    </div>
+    <div class="field">
+      <label for="end-date">End Date</label>
+      <input type="date" id="end-date" />
+    </div>
+    <button type="button" id="run-report">Run</button>
+  </div>
+</div>
+
+  <details id="charts" class="section-card">
+    <summary>Preview Charts</summary>
+    <div>
+      <div class="chart-block">
+        <canvas id="yieldTrendChart"></canvas>
+        <div class="chart-summary">
+          <p id="yieldTrendDesc"></p>
+          <table id="yieldTrendTable" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="operatorRejectChart"></canvas>
+        <div class="chart-summary">
+          <p id="operatorRejectDesc"></p>
+          <table id="operatorRejectTable" class="data-table">
+            <thead>
+              <tr>
+                <th>Operator</th>
+                <th>Inspected</th>
+                <th>Rejected</th>
+                <th>Reject %</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="modelFalseCallsChart"></canvas>
+        <div class="chart-summary">
+          <p id="modelFalseCallsDesc"></p>
+          <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="fcVsNgRateChart"></canvas>
+        <div class="chart-summary">
+          <p id="fcVsNgDesc"></p>
+          <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
+        </div>
+      </div>
+      <div class="chart-block">
+        <canvas id="fcNgRatioChart"></canvas>
+        <div class="chart-summary">
+          <p id="fcNgRatioDesc"></p>
+          <table id="fcNgRatioTable" class="data-table">
+            <thead>
+              <tr>
+                <th>Model</th>
+                <th>FalseCall Parts</th>
+                <th>NG Parts</th>
+                <th>FC/NG Ratio</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </details>
+
+<div class="field-row" id="download-controls">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="xlsx">xlsx</option>
+      <option value="html">html</option>
+    </select>
+  </div>
+  <button id="download-report">Download</button>
+  <button id="email-report">Email Report</button>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="{{ url_for('static', filename='js/operator_report.js') }}"></script>
+{% endblock %}

--- a/tests/test_operator_report_routes.py
+++ b/tests/test_operator_report_routes.py
@@ -1,0 +1,38 @@
+import os
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def test_operator_report_page(app_instance):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/reports/operator")
+        assert resp.status_code == 200
+        assert b"Operator Report" in resp.data
+
+
+def test_export_operator_report_placeholder(app_instance):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/reports/operator/export?format=html")
+        assert resp.status_code == 200
+        assert b"Placeholder KPI" in resp.data


### PR DESCRIPTION
## Summary
- Create an Operator Report template and client script based on the integrated report
- Introduce placeholder operator report routes and payload builder
- Expose Operator Report in navbar and test its basic responses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c04db8162c8325832265d1af8539ff