### PR TITLE
Improve table of contents styling for reports

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -83,6 +83,12 @@ header img {
     margin-top: 20px;
 }
 
+.cover-page .toc {
+    border-color: var(--accent);
+    background: var(--muted-light);
+    margin-top: 20px;
+}
+
 .summary-break {
     height: 20px;
 }
@@ -93,9 +99,18 @@ header img {
     margin: 0;
 }
 
+.toc li {
+    padding: 4px 8px;
+}
+
+.toc li:nth-child(even) {
+    background: var(--muted-dark);
+}
+
 .toc a {
-    text-decoration: none;
-    color: inherit;
+    color: #003366;
+    text-decoration: underline;
+    display: block;
 }
 
 .toc a::after {


### PR DESCRIPTION
## Summary
- Style cover page table of contents with accent border and muted background.
- Add padding and zebra striping to TOC items.
- Make TOC links appear clickable with blue color and underline.

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c04fb38b5c832589cd38e2e19f97a4