### PR TITLE
Add operator filter to report page

### DIFF
--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -13,6 +13,10 @@
       <label for="end-date">End Date</label>
       <input type="date" id="end-date" />
     </div>
+    <div class="field">
+      <label>Operator</label>
+      <div id="operator-wrapper"></div>
+    </div>
     <button type="button" id="run-report">Run</button>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- add operator dropdown to Operator Report template
- load unique operator names and pass selection when running or exporting report

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c075b1de208325bdb47cc96162118a