### PR TITLE
Add operator filtering and HTML export for operator report

### DIFF
--- a/templates/report/operator.html
+++ b/templates/report/operator.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Operator Report</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+</head>
+<body>
+    <h1>Operator Report</h1>
+
+    <section>
+        <h2>Summary</h2>
+        <p>Total Boards: {{ summary.totalBoards }}</p>
+        <p>Average per Shift: {{ summary.avgPerShift }}</p>
+        <p>Average Reject Rate: {{ summary.avgRejectRate }}%</p>
+    </section>
+
+    <section>
+        <h2>Daily</h2>
+        <table class="data-table">
+            <thead>
+                <tr><th>Date</th><th>Inspected</th><th>Reject %</th></tr>
+            </thead>
+            <tbody>
+                {% for i in range(daily.dates|length) %}
+                <tr>
+                    <td>{{ daily.dates[i] }}</td>
+                    <td>{{ daily.inspected[i] }}</td>
+                    <td>{{ daily.rejectRates[i] }}</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+
+    <section>
+        <h2>Assemblies</h2>
+        <table class="data-table">
+            <thead>
+                <tr><th>Assembly</th><th>Inspected</th></tr>
+            </thead>
+            <tbody>
+                {% for asm in assemblies %}
+                <tr><td>{{ asm.assembly }}</td><td>{{ asm.inspected }}</td></tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </section>
+</body>
+</html>

--- a/tests/test_operator_report_routes.py
+++ b/tests/test_operator_report_routes.py
@@ -28,11 +28,36 @@ def test_operator_report_page(app_instance):
         assert b"Operator Report" in resp.data
 
 
-def test_export_operator_report_placeholder(app_instance):
+def test_export_operator_report(app_instance, monkeypatch):
     client = app_instance.test_client()
     with app_instance.app_context():
+        # Sample AOI rows to drive the aggregation
+        aoi_rows = [
+            {
+                "Date": "2024-07-01",
+                "Operator": "Alice",
+                "Assembly": "A1",
+                "Quantity Inspected": 10,
+                "Quantity Rejected": 1,
+            },
+            {
+                "Date": "2024-07-02",
+                "Operator": "Alice",
+                "Assembly": "A2",
+                "Quantity Inspected": 20,
+                "Quantity Rejected": 2,
+            },
+        ]
+        from app.main import routes
+
+        monkeypatch.setattr(routes, "fetch_aoi_reports", lambda: (aoi_rows, None))
         with client.session_transaction() as sess:
             sess["username"] = "tester"
-        resp = client.get("/reports/operator/export?format=html")
+        resp = client.get(
+            "/reports/operator/export?format=html&start_date=2024-07-01&end_date=2024-07-02&operator=Alice"
+        )
         assert resp.status_code == 200
-        assert b"Placeholder KPI" in resp.data
+        html = resp.data.decode()
+        assert "Total Boards" in html
+        assert "A1" in html
+        assert "2024-07-01" in html


### PR DESCRIPTION
## Summary
- Share aggregation logic for operator reports and allow filtering by operator
- Include daily, summary, and assembly stats in exportable operator report
- Render new operator report HTML template and update export route

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c07895a9c08325a9ba9d2df276a697