### PR TITLE
Add operator report export templates and PDF support

### DIFF
--- a/templates/report/operator_assemblies.html
+++ b/templates/report/operator_assemblies.html
@@ -1,0 +1,11 @@
+<section id="operator-assemblies" class="report-section">
+    <p class="section-desc">Assemblies inspected by the operator.</p>
+    <table class="data-table">
+        <thead><tr><th>Assembly</th><th>Inspected</th></tr></thead>
+        <tbody>
+        {% for asm in assemblies %}
+            <tr><td>{{ asm.assembly }}</td><td>{{ '%.2f'|format(asm.inspected) }}</td></tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>

--- a/templates/report/operator_daily.html
+++ b/templates/report/operator_daily.html
@@ -1,0 +1,24 @@
+<section id="operator-daily" class="report-section">
+    <p class="section-desc">Daily reject rates for the selected operator.</p>
+    <div class="chart-block">
+        {% if dailyImg %}
+        <img src="{{ dailyImg }}" alt="Daily Reject Rate">
+        {% endif %}
+        <div class="chart-summary">
+            <table class="data-table">
+                <thead>
+                    <tr><th>Date</th><th>Inspected</th><th>Reject %</th></tr>
+                </thead>
+                <tbody>
+                {% for i in range(daily.dates|length) %}
+                    <tr>
+                        <td>{{ daily.dates[i] }}</td>
+                        <td>{{ '%.2f'|format(daily.inspected[i]) }}</td>
+                        <td>{{ '%.2f'|format(daily.rejectRates[i]) }}</td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </div>
+</section>

--- a/templates/report/operator_index.html
+++ b/templates/report/operator_index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Operator Report</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+</head>
+<body>
+    {% if show_cover %}
+        {% include 'report/cover.html' %}
+    {% elif show_summary %}
+        {% include 'report/operator_summary.html' %}
+    {% endif %}
+    {% include 'report/operator_toc.html' %}
+    {% include 'report/operator_daily.html' %}
+    {% include 'report/operator_assemblies.html' %}
+</body>
+</html>

--- a/templates/report/operator_summary.html
+++ b/templates/report/operator_summary.html
@@ -1,0 +1,8 @@
+<div class="summary section-card">
+    <h2>Summary</h2>
+    <p class="section-desc">Overview of operator performance.</p>
+    <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
+    <p><strong>Total Boards:</strong> {{ summary.totalBoards }}</p>
+    <p><strong>Average per shift:</strong> {{ summary.avgPerShift|round(2) }}</p>
+    <p><strong>Average reject rate:</strong> {{ summary.avgRejectRate|round(2) }}%</p>
+</div>

--- a/templates/report/operator_toc.html
+++ b/templates/report/operator_toc.html
@@ -1,0 +1,7 @@
+<div class="toc section-card">
+    <h2>Table of Contents</h2>
+    <ol>
+        <li><a href="#operator-daily">Daily Reject Rates</a></li>
+        <li><a href="#operator-assemblies">Assemblies</a></li>
+    </ol>
+</div>


### PR DESCRIPTION
## Summary
- Add dedicated operator report templates with summary, TOC, daily chart, and assembly table
- Generate operator daily chart images and export operator report in HTML or PDF
- Fetch live data from AOI and combined reports for operator exports

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c083d45de483259d28041633f83b1c