### PR TITLE
Include FI reject rate in operator report

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -159,6 +159,10 @@ header img {
     color: #888;
 }
 
+.null-value {
+    color: #bbb;
+}
+
 .data-table {
     width: 100%;
     border-collapse: collapse;

--- a/templates/report/operator.html
+++ b/templates/report/operator.html
@@ -37,11 +37,22 @@
         <h2>Assemblies</h2>
         <table class="data-table">
             <thead>
-                <tr><th>Assembly</th><th>Inspected</th></tr>
+                <tr><th>Assembly</th><th>Inspected</th><th>Rejected</th><th>FI Reject %</th></tr>
             </thead>
             <tbody>
                 {% for asm in assemblies %}
-                <tr><td>{{ asm.assembly }}</td><td>{{ asm.inspected }}</td></tr>
+                <tr>
+                    <td>{{ asm.assembly }}</td>
+                    <td>{{ asm.inspected }}</td>
+                    <td>{{ asm.rejected }}</td>
+                    <td>
+                        {% if asm.fiRejectRate is not none %}
+                            {{ asm.fiRejectRate }}
+                        {% else %}
+                            <span class="null-value">null</span>
+                        {% endif %}
+                    </td>
+                </tr>
                 {% endfor %}
             </tbody>
         </table>

--- a/tests/test_operator_report_api.py
+++ b/tests/test_operator_report_api.py
@@ -52,7 +52,24 @@ def test_operator_report_api(app_instance, monkeypatch):
                 "Quantity Rejected": 4,
             },
         ]
+        combined_rows = [
+            {
+                "aoi_Date": "2024-07-01",
+                "aoi_Operator": "Alice",
+                "aoi_Assembly": "A1",
+                "aoi_Quantity Inspected": 10,
+                "fi_Quantity Rejected": 1,
+            },
+            {
+                "aoi_Date": "2024-07-02",
+                "aoi_Operator": "Alice",
+                "aoi_Assembly": "A1",
+                "aoi_Quantity Inspected": 30,
+                "fi_Quantity Rejected": 2,
+            },
+        ]
         monkeypatch.setattr(routes, "fetch_aoi_reports", lambda: (aoi_rows, None))
+        monkeypatch.setattr(routes, "fetch_combined_reports", lambda: (combined_rows, None))
         with client.session_transaction() as sess:
             sess["username"] = "tester"
         resp = client.get(
@@ -70,6 +87,16 @@ def test_operator_report_api(app_instance, monkeypatch):
             "avgBoards": 60.0,
         }
         assert data["assemblies"] == [
-            {"assembly": "A1", "inspected": 40.0},
-            {"assembly": "A2", "inspected": 20.0},
+            {
+                "assembly": "A1",
+                "inspected": 40.0,
+                "rejected": 4.0,
+                "fiRejectRate": 7.5,
+            },
+            {
+                "assembly": "A2",
+                "inspected": 20.0,
+                "rejected": 2.0,
+                "fiRejectRate": None,
+            },
         ]


### PR DESCRIPTION
## Summary
- Track inspected, rejected, and FI reject rate per assembly in operator report
- Add "Rejected" and "FI Reject %" columns with null styling in operator report template
- Define `.null-value` CSS class for missing FI reject data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0886451108325a47dcae259d8a9dd