### PR TITLE
Wrap operator report charts in expandable section

### DIFF
--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -21,29 +21,31 @@
   </div>
 </div>
 
-<div id="dailySection" class="section-card" style="display:none">
-  <div class="chart-block">
-    <canvas id="dailyChart"></canvas>
-    <div class="chart-summary">
-      <p id="dailyDesc"></p>
-      <table id="dailyTable" class="data-table">
+<details id="charts" class="section-card">
+  <summary>Preview Charts</summary>
+  <div>
+    <div id="dailySection" class="chart-block">
+      <canvas id="dailyChart"></canvas>
+      <div class="chart-summary">
+        <p id="dailyDesc"></p>
+        <table id="dailyTable" class="data-table">
+          <thead>
+            <tr><th>Date</th><th>Reject %</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </div>
+    <div id="assemblySection" class="chart-block">
+      <table id="assemblyTotals" class="data-table">
         <thead>
-          <tr><th>Date</th><th>Reject %</th></tr>
+          <tr><th>Assembly</th><th>Inspected</th></tr>
         </thead>
         <tbody></tbody>
       </table>
     </div>
   </div>
-</div>
-
-<div id="assemblySection" class="section-card" style="display:none">
-  <table id="assemblyTotals" class="data-table">
-    <thead>
-      <tr><th>Assembly</th><th>Inspected</th></tr>
-    </thead>
-    <tbody></tbody>
-  </table>
-</div>
+</details>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- Wrap operator report daily and assembly sections in a `<details>` container with a `Preview Charts` summary
- Keep daily chart and assembly table in dedicated `chart-block` wrappers for consistent layout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c08a44f8948325921b41ad1f8a2782