### PR TITLE
Add export controls to operator report

### DIFF
--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -48,7 +48,11 @@ function getDropdownValues(className) {
 
 document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-report');
+  const downloadControls = document.getElementById('download-controls');
+  const downloadBtn = document.getElementById('download-report');
   let dailyChart = null;
+
+  if (downloadControls) downloadControls.style.display = 'none';
 
   fetch('/aoi_reports')
     .then((r) => r.json())
@@ -72,8 +76,25 @@ document.addEventListener('DOMContentLoaded', () => {
       .then((res) => res.json())
       .then((data) => {
         renderReport(data);
+        if (downloadControls) downloadControls.style.display = 'flex';
       })
       .catch(() => alert('Failed to run report.'));
+  });
+
+  downloadBtn?.addEventListener('click', () => {
+    const fmt = document.getElementById('file-format').value;
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    const operator = getDropdownValues('filter-operator').join(',');
+    const params = new URLSearchParams({ format: fmt });
+    if (start) params.append('start_date', start);
+    if (end) params.append('end_date', end);
+    if (operator) params.append('operator', operator);
+    window.location = `/reports/operator/export?${params.toString()}`;
+  });
+
+  document.getElementById('email-report')?.addEventListener('click', () => {
+    alert('Email sent (placeholder).');
   });
 
   function setDesc(id, lines) {

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -46,6 +46,19 @@
     </div>
   </div>
 </details>
+
+<div id="download-controls" class="field-row" style="display:none">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="xlsx">xlsx</option>
+      <option value="html">html</option>
+    </select>
+  </div>
+  <button id="download-report">Download</button>
+  <button id="email-report">Email Report</button>
+</div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
## Summary
- Add hidden download controls to operator report template with format selection and email placeholder
- Wire up operator report JS to toggle controls, export report, and show placeholder email alert

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c08b3253308325b0022cd14ce97691