### PR TITLE
Use shared report title in cover

### DIFF
--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -1,19 +1,20 @@
 <section id="cover" class="report-section cover-page">
     <br>
+    <header>
         <h1>
             <img src="{{ url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
-            AOI Integrated Report
+            {{ title }}
         </h1>
-        <br />
-        <div class="report-details">
-            <p><b>report_range:</b> {{ start }} - {{ end }}</p>
-            <p><b>generated_at:</b> {{ generated_at }}</p>
-            <p>{{ report_id }}</p>
-            <p><b>report author:</b> Thomas Schwartz</p>
-            <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
-            <p>{{ confidentiality }}</p>
-        </div>
     </header>
+    <br />
+    <div class="report-details">
+        <p><b>report_range:</b> {{ start }} - {{ end }}</p>
+        <p><b>generated_at:</b> {{ generated_at }}</p>
+        <p>{{ report_id }}</p>
+        <p><b>report author:</b> Thomas Schwartz</p>
+        <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
+        <p>{{ confidentiality }}</p>
+    </div>
     {% if show_summary %}
         {% include 'report/summary.html' %}
         <div class="summary-break"></div>


### PR DESCRIPTION
## Summary
- wrap cover page logo and heading in a semantic header element
- allow report title to be supplied with a Jinja variable so the cover can be reused

## Testing
- `pytest`
- `python - <<'PY' ... (generate pdf with cover)`
- `python - <<'PY' ... (fetch logo)`

------
https://chatgpt.com/codex/tasks/task_e_68c08df674d88325805c3d0ab3db9526