### PR TITLE
Refactor report summary and TOC placement

### DIFF
--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -15,9 +15,4 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
-    {% if show_summary %}
-        {% include 'report/summary.html' %}
-        <div class="summary-break"></div>
-        {% include 'report/toc.html' %}
-    {% endif %}
 </section>

--- a/templates/report/index.html
+++ b/templates/report/index.html
@@ -8,8 +8,10 @@
 <body>
     {% if show_cover %}
         {% include 'report/cover.html' %}
-    {% elif show_summary %}
+    {% endif %}
+    {% if show_summary %}
         {% include 'report/summary.html' %}
+        {% include 'report/toc.html' %}
     {% endif %}
     {% include 'report/yield_trend.html' %}
     {% include 'report/operator_reject.html' %}

--- a/templates/report/operator_index.html
+++ b/templates/report/operator_index.html
@@ -8,10 +8,11 @@
 <body>
     {% if show_cover %}
         {% include 'report/cover.html' %}
-    {% elif show_summary %}
-        {% include 'report/operator_summary.html' %}
     {% endif %}
-    {% include 'report/operator_toc.html' %}
+    {% if show_summary %}
+        {% include 'report/operator_summary.html' %}
+        {% include 'report/operator_toc.html' %}
+    {% endif %}
     {% include 'report/operator_daily.html' %}
     {% include 'report/operator_assemblies.html' %}
 </body>

--- a/templates/report/operator_summary.html
+++ b/templates/report/operator_summary.html
@@ -1,8 +1,10 @@
-<div class="summary section-card">
-    <h2>Summary</h2>
-    <p class="section-desc">Overview of operator performance.</p>
-    <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
-    <p><strong>Total Boards:</strong> {{ summary.totalBoards }}</p>
-    <p><strong>Average per shift:</strong> {{ summary.avgPerShift|round(2) }}</p>
-    <p><strong>Average reject rate:</strong> {{ summary.avgRejectRate|round(2) }}%</p>
-</div>
+<section class="report-section">
+    <div class="summary section-card">
+        <h2>Summary</h2>
+        <p class="section-desc">Overview of operator performance.</p>
+        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
+        <p><strong>Total Boards:</strong> {{ summary.totalBoards }}</p>
+        <p><strong>Average per shift:</strong> {{ summary.avgPerShift|round(2) }}</p>
+        <p><strong>Average reject rate:</strong> {{ summary.avgRejectRate|round(2) }}%</p>
+    </div>
+</section>

--- a/templates/report/operator_toc.html
+++ b/templates/report/operator_toc.html
@@ -1,7 +1,9 @@
-<div class="toc section-card">
-    <h2>Table of Contents</h2>
-    <ol>
-        <li><a href="#operator-daily">Daily Reject Rates</a></li>
-        <li><a href="#operator-assemblies">Assemblies</a></li>
-    </ol>
-</div>
+<section class="report-section">
+    <div class="toc section-card">
+        <h2>Table of Contents</h2>
+        <ol>
+            <li><a href="#operator-daily">Daily Reject Rates</a></li>
+            <li><a href="#operator-assemblies">Assemblies</a></li>
+        </ol>
+    </div>
+</section>

--- a/templates/report/summary.html
+++ b/templates/report/summary.html
@@ -1,8 +1,10 @@
-<div class="summary section-card">
-    <h2>Summary</h2>
-    <p class="section-desc">Provides key metrics from the reporting period.</p>
-    <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
-    <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%</p>
-    <p><strong>Total boards:</strong> {{ operatorSummary.totalBoards }}</p>
-    <p><strong>Average false calls/board:</strong> {{ modelSummary.avgFalseCalls|round(2) }}</p>
-</div>
+<section class="report-section">
+    <div class="summary section-card">
+        <h2>Summary</h2>
+        <p class="section-desc">Provides key metrics from the reporting period.</p>
+        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
+        <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%</p>
+        <p><strong>Total boards:</strong> {{ operatorSummary.totalBoards }}</p>
+        <p><strong>Average false calls/board:</strong> {{ modelSummary.avgFalseCalls|round(2) }}</p>
+    </div>
+</section>

--- a/templates/report/toc.html
+++ b/templates/report/toc.html
@@ -1,17 +1,19 @@
-<div class="toc section-card">
-    <h2>Table of Contents</h2>
-    <ol>
-        <li><a href="#yield-trend">Yield Trend</a></li>
-        <li><a href="#operator-reject">Operator Reject</a></li>
-        <li><a href="#model-false-calls">Model False Calls</a></li>
-        <li><a href="#fc-vs-ng-rate">FC vs NG Rate</a></li>
-        <li><a href="#fc-ng-ratio">FC/NG Ratio</a></li>
-        <li><a href="#defect-intelligence">Defect Intelligence</a></li>
-        <li><a href="#operator-reliability">Operator Reliability</a></li>
-        <li><a href="#operator-production">Operator Production</a></li>
-        <li><a href="#low-yield-assemblies">Low Yield Assemblies</a></li>
-        <li><a href="#capa-action-register">CAPA / Action Register</a></li>
-        <li><a href="#appendix">Appendix</a></li>
-    </ol>
-</div>
+<section class="report-section">
+    <div class="toc section-card">
+        <h2>Table of Contents</h2>
+        <ol>
+            <li><a href="#yield-trend">Yield Trend</a></li>
+            <li><a href="#operator-reject">Operator Reject</a></li>
+            <li><a href="#model-false-calls">Model False Calls</a></li>
+            <li><a href="#fc-vs-ng-rate">FC vs NG Rate</a></li>
+            <li><a href="#fc-ng-ratio">FC/NG Ratio</a></li>
+            <li><a href="#defect-intelligence">Defect Intelligence</a></li>
+            <li><a href="#operator-reliability">Operator Reliability</a></li>
+            <li><a href="#operator-production">Operator Production</a></li>
+            <li><a href="#low-yield-assemblies">Low Yield Assemblies</a></li>
+            <li><a href="#capa-action-register">CAPA / Action Register</a></li>
+            <li><a href="#appendix">Appendix</a></li>
+        </ol>
+    </div>
+</section>
 


### PR DESCRIPTION
## Summary
- Remove summary and table of contents from the cover template
- Include summary and TOC after the cover in integrated and operator reports
- Wrap summary and TOC templates in `report-section` elements to enforce page breaks

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'openpyxl')*
- `pip install openpyxl` *(fails: Could not find a version that satisfies the requirement openpyxl)*

------
https://chatgpt.com/codex/tasks/task_e_68c08edc05988325966d8b2ed6d6ec04