### PR TITLE
Overlay operator report daily chart

### DIFF
--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -119,11 +119,43 @@ document.addEventListener('DOMContentLoaded', () => {
           labels: daily.dates,
           datasets: [
             {
+              type: 'bar',
               label: 'Boards Inspected',
               data: daily.inspected,
               backgroundColor: 'steelblue',
+              yAxisID: 'y',
+            },
+            {
+              type: 'line',
+              label: 'Reject %',
+              data: daily.rejectRates,
+              yAxisID: 'y1',
+              borderColor: 'crimson',
+              backgroundColor: 'crimson',
+              tension: 0.1,
+              pointRadius: 3,
             },
           ],
+        },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          interaction: { mode: 'index', intersect: false },
+          scales: {
+            y: {
+              beginAtZero: true,
+              title: { display: true, text: 'Boards Inspected' },
+            },
+            y1: {
+              beginAtZero: true,
+              max: 100,
+              position: 'right',
+              grid: { drawOnChartArea: false },
+              ticks: { callback: (v) => `${v}%` },
+              title: { display: true, text: 'Reject %' },
+            },
+          },
+          plugins: { legend: { display: true } },
         },
       });
       setDesc('dailyDesc', [

--- a/templates/report/operator_daily.html
+++ b/templates/report/operator_daily.html
@@ -1,11 +1,8 @@
 <section id="operator-daily" class="report-section">
-    <p class="section-desc">Daily reject rates and boards inspected for the selected operator.</p>
+    <p class="section-desc">Daily reject rates overlaid with boards inspected for the selected operator.</p>
     <div class="chart-block">
         {% if dailyImg %}
-        <img src="{{ dailyImg }}" alt="Daily Reject Rate">
-        {% endif %}
-        {% if boardsInspectedImg %}
-        <img src="{{ boardsInspectedImg }}" alt="Boards Inspected">
+        <img src="{{ dailyImg }}" alt="Daily Reject Rate and Boards Inspected">
         {% endif %}
         <div class="chart-summary">
             <table class="data-table">


### PR DESCRIPTION
## Summary
- Replace dual daily charts with a single matplotlib figure combining inspected counts and reject rates on twin axes.
- Update operator daily template and browser JS to overlay boards inspected and reject rates.
- Merge new `dailyImg` chart in export flow.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c091d7cd9c8325980e959cb03066d9