### PR TITLE
Split report cover templates by type

### DIFF
--- a/templates/report/integrated/cover.html
+++ b/templates/report/integrated/cover.html
@@ -1,0 +1,18 @@
+<section id="cover" class="report-section cover-page">
+    <br>
+    <header>
+        <h1>
+            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {{ title or 'AOI Integrated Report' }}
+        </h1>
+    </header>
+    <br />
+    <div class="report-details">
+        <p><b>report_range:</b> {{ start }} - {{ end }}</p>
+        <p><b>generated_at:</b> {{ generated_at }}</p>
+        <p>{{ report_id }}</p>
+        <p><b>report author:</b> Thomas Schwartz</p>
+        <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
+        <p>{{ confidentiality }}</p>
+    </div>
+</section>

--- a/templates/report/integrated/index.html
+++ b/templates/report/integrated/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     {% if show_cover %}
-        {% include 'report/cover.html' %}
+        {% include 'report/integrated/cover.html' %}
     {% endif %}
     {% if show_summary %}
         {% include 'report/summary_toc.html' %}

--- a/templates/report/operator/cover.html
+++ b/templates/report/operator/cover.html
@@ -1,0 +1,18 @@
+<section id="cover" class="report-section cover-page">
+    <br>
+    <header>
+        <h1>
+            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {{ title or 'Operator Report' }}
+        </h1>
+    </header>
+    <br />
+    <div class="report-details">
+        <p><b>report_range:</b> {{ start }} - {{ end }}</p>
+        <p><b>generated_at:</b> {{ generated_at }}</p>
+        <p>{{ report_id }}</p>
+        <p><b>report author:</b> Thomas Schwartz</p>
+        <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
+        <p>{{ confidentiality }}</p>
+    </div>
+</section>

--- a/templates/report/operator/index.html
+++ b/templates/report/operator/index.html
@@ -7,7 +7,7 @@
 </head>
 <body>
     {% if show_cover %}
-        {% include 'report/cover.html' %}
+        {% include 'report/operator/cover.html' %}
     {% endif %}
     {% if show_summary %}
         {% include 'report/operator_summary_toc.html' %}


### PR DESCRIPTION
## Summary
- duplicate global report cover for integrated and operator reports
- include new cover pages in the respective report index templates

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0bc7795ec8325a1f7659dd2f65268