### PR TITLE
Add cover page toggle to report downloads

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -31,6 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
     const params = new URLSearchParams({ format: fmt });
+    const includeCover = document.getElementById('include-cover')?.checked;
+    params.append('show_cover', includeCover ? 'true' : 'false');
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
     window.location = `/reports/integrated/export?${params.toString()}`;

--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -87,6 +87,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const end = document.getElementById('end-date').value;
     const operator = getDropdownValues('filter-operator').join(',');
     const params = new URLSearchParams({ format: fmt });
+    const includeCover = document.getElementById('include-cover')?.checked;
+    params.append('show_cover', includeCover ? 'true' : 'false');
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
     if (operator) params.append('operator', operator);

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -87,6 +87,10 @@
       <option value="html">html</option>
     </select>
   </div>
+  <div class="field">
+    <label for="include-cover">Cover Page</label>
+    <input type="checkbox" id="include-cover" checked />
+  </div>
   <button id="download-report">Download</button>
   <button id="email-report">Email Report</button>
 </div>

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -56,6 +56,10 @@
       <option value="html">html</option>
     </select>
   </div>
+  <div class="field">
+    <label for="include-cover">Cover Page</label>
+    <input type="checkbox" id="include-cover" checked />
+  </div>
   <button id="download-report">Download</button>
   <button id="email-report">Email Report</button>
 </div>


### PR DESCRIPTION
## Summary
- add Cover Page checkbox to operator and integrated report pages
- append `show_cover` param when exporting reports

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0bf20db488325b95e436e9e1b8c67