### PR TITLE
feat: move summary and toc to cover page

### DIFF
--- a/templates/report/integrated/cover.html
+++ b/templates/report/integrated/cover.html
@@ -15,4 +15,31 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
+    {% if show_summary %}
+    <div class="summary section-card">
+        <h2>Summary</h2>
+        <p class="section-desc">Provides key metrics from the reporting period.</p>
+        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
+        <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%</p>
+        <p><strong>Total boards:</strong> {{ operatorSummary.totalBoards }}</p>
+        <p><strong>Average false calls/board:</strong> {{ modelSummary.avgFalseCalls|round(2) }}</p>
+    </div>
+    <div class="summary-break"></div>
+    <div class="toc section-card">
+        <h2>Table of Contents</h2>
+        <ol>
+            <li><a href="#yield-trend">Yield Trend</a></li>
+            <li><a href="#operator-reject">Operator Reject</a></li>
+            <li><a href="#model-false-calls">Model False Calls</a></li>
+            <li><a href="#fc-vs-ng-rate">FC vs NG Rate</a></li>
+            <li><a href="#fc-ng-ratio">FC/NG Ratio</a></li>
+            <li><a href="#defect-intelligence">Defect Intelligence</a></li>
+            <li><a href="#operator-reliability">Operator Reliability</a></li>
+            <li><a href="#operator-production">Operator Production</a></li>
+            <li><a href="#low-yield-assemblies">Low Yield Assemblies</a></li>
+            <li><a href="#capa-action-register">CAPA / Action Register</a></li>
+            <li><a href="#appendix">Appendix</a></li>
+        </ol>
+    </div>
+    {% endif %}
 </section>

--- a/templates/report/integrated/index.html
+++ b/templates/report/integrated/index.html
@@ -8,8 +8,7 @@
 <body>
     {% if show_cover %}
         {% include 'report/integrated/cover.html' %}
-    {% endif %}
-    {% if show_summary %}
+    {% elif show_summary %}
         {% include 'report/summary_toc.html' %}
     {% endif %}
     {% include 'report/integrated/yield_trend.html' %}

--- a/templates/report/operator/cover.html
+++ b/templates/report/operator/cover.html
@@ -15,4 +15,22 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
+    {% if show_summary %}
+    <div class="summary section-card">
+        <h2>Summary</h2>
+        <p class="section-desc">Overview of operator performance.</p>
+        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
+        <p><strong>Total Boards:</strong> {{ summary.totalBoards }}</p>
+        <p><strong>Average per shift:</strong> {{ summary.avgPerShift|round(2) }}</p>
+        <p><strong>Average reject rate:</strong> {{ summary.avgRejectRate|round(2) }}%</p>
+    </div>
+    <div class="summary-break"></div>
+    <div class="toc section-card">
+        <h2>Table of Contents</h2>
+        <ol>
+            <li><a href="#operator-daily">Daily Reject Rates</a></li>
+            <li><a href="#operator-assemblies">Assemblies</a></li>
+        </ol>
+    </div>
+    {% endif %}
 </section>

--- a/templates/report/operator/index.html
+++ b/templates/report/operator/index.html
@@ -8,8 +8,7 @@
 <body>
     {% if show_cover %}
         {% include 'report/operator/cover.html' %}
-    {% endif %}
-    {% if show_summary %}
+    {% elif show_summary %}
         {% include 'report/operator_summary_toc.html' %}
     {% endif %}
     {% include 'report/operator/operator_daily.html' %}


### PR DESCRIPTION
## Summary
- embed summary metrics and table of contents directly into integrated and operator report cover pages
- collapse index logic so summary pages are rendered separately only when the cover is omitted
- adjust tests for new cover layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0c193415c83259a33e1ac06b30fa1