### PR TITLE
Add AOI daily report export and charting

### DIFF
--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>AOI Daily Report</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+</head>
+<body>
+    <h1>AOI Daily Report - {{ day }}</h1>
+    {% if shiftImg %}
+    <img src="{{ shiftImg }}" alt="Boards inspected by shift" />
+    {% endif %}
+
+    <h2>1st Shift</h2>
+    <table>
+        <tr><th>Operator</th><th>Assembly</th><th>Job</th><th>Inspected</th><th>Rejected</th></tr>
+        {% for row in shift1 %}
+        <tr>
+            <td>{{ row.operator }}</td>
+            <td>{{ row.assembly }}</td>
+            <td>{{ row.job }}</td>
+            <td>{{ row.inspected }}</td>
+            <td>{{ row.rejected }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <h2>2nd Shift</h2>
+    <table>
+        <tr><th>Operator</th><th>Assembly</th><th>Job</th><th>Inspected</th><th>Rejected</th></tr>
+        {% for row in shift2 %}
+        <tr>
+            <td>{{ row.operator }}</td>
+            <td>{{ row.assembly }}</td>
+            <td>{{ row.job }}</td>
+            <td>{{ row.inspected }}</td>
+            <td>{{ row.rejected }}</td>
+        </tr>
+        {% endfor %}
+    </table>
+
+    <h2>Assemblies</h2>
+    <table>
+        <tr><th>Assembly</th><th>Yield</th><th>Past 3 Job Avg</th></tr>
+        {% for asm in assemblies %}
+        <tr>
+            <td>{{ asm.assembly }}</td>
+            <td>{{ '%.2f'|format(asm.yield) if asm.yield is not string else asm.yield }}</td>
+            <td>
+                {% if asm.past3Avg is string %}
+                    {{ asm.past3Avg }}
+                {% else %}
+                    {{ '%.2f'|format(asm.past3Avg) }}
+                {% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Build AOI daily report payload with shift breakdowns, totals, and historical yield comparisons
- Render a simple bar chart of boards inspected per shift
- Add `/reports/aoi_daily/export` endpoint and template supporting HTML/PDF output

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0cc3fa1b48325bfa27094517e1890