### PR TITLE
Add modular AOI daily report templates

### DIFF
--- a/templates/report/aoi_daily/assembly_history.html
+++ b/templates/report/aoi_daily/assembly_history.html
@@ -1,0 +1,25 @@
+<section id="assembly-history" class="report-section section-card last">
+    <h2>Assembly Historical Yield</h2>
+    <p class="section-desc">Yield performance and three-job average for recent runs.</p>
+    <table class="data-table">
+        <thead>
+            <tr><th>Assembly</th><th>Yield %</th><th>Historical Yield (Past 3 Job Avg)</th></tr>
+        </thead>
+        <tbody>
+        {% for asm in assemblies %}
+            <tr>
+                <td>{{ asm.assembly }}</td>
+                <td>{{ asm.yield if asm.yield is string else '%.2f'|format(asm.yield) }}</td>
+                <td>
+                    {% if asm.past3Avg is string %}
+                        {{ asm.past3Avg }}
+                    {% else %}
+                        {{ '%.2f'|format(asm.past3Avg) }}
+                    {% endif %}
+                </td>
+            </tr>
+        {% endfor %}
+        </tbody>
+    </table>
+</section>
+

--- a/templates/report/aoi_daily/cover.html
+++ b/templates/report/aoi_daily/cover.html
@@ -1,0 +1,57 @@
+<section id="cover" class="report-section cover-page">
+    <br>
+    <header>
+        <h1>
+            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {{ title or 'AOI Daily Report' }}
+        </h1>
+    </header>
+    <br />
+    <div class="report-details">
+        <p><b>report_range:</b> {{ start }} - {{ end }}</p>
+        <p><b>generated_at:</b> {{ generated_at }}</p>
+        <p>{{ report_id }}</p>
+        <p><b>report author:</b> Thomas Schwartz</p>
+        <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
+        <p>{{ confidentiality }}</p>
+    </div>
+
+    <div class="summary section-card">
+        <h2>1st Shift Summary</h2>
+        <table class="data-table">
+            <thead>
+                <tr><th>Operator</th><th>Assembly</th><th>Job Number</th><th>Quantity Inspected</th><th>Quantity Rejected</th></tr>
+            </thead>
+            <tbody>
+            {% for row in shift1 %}
+                <tr>
+                    <td>{{ row.operator }}</td>
+                    <td>{{ row.assembly }}</td>
+                    <td>{{ row.job }}</td>
+                    <td>{{ row.inspected }}</td>
+                    <td>{{ row.rejected }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+
+        <h2>2nd Shift Summary</h2>
+        <table class="data-table">
+            <thead>
+                <tr><th>Operator</th><th>Assembly</th><th>Job Number</th><th>Quantity Inspected</th><th>Quantity Rejected</th></tr>
+            </thead>
+            <tbody>
+            {% for row in shift2 %}
+                <tr>
+                    <td>{{ row.operator }}</td>
+                    <td>{{ row.assembly }}</td>
+                    <td>{{ row.job }}</td>
+                    <td>{{ row.inspected }}</td>
+                    <td>{{ row.rejected }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</section>
+

--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -6,55 +6,14 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
 </head>
 <body>
-    <h1>AOI Daily Report - {{ day }}</h1>
-    {% if shiftImg %}
-    <img src="{{ shiftImg }}" alt="Boards inspected by shift" />
+    {% if show_cover %}
+        {% include 'report/aoi_daily/cover.html' %}
+    {% elif show_summary %}
+        {% include 'report/summary_toc.html' %}
     {% endif %}
 
-    <h2>1st Shift</h2>
-    <table>
-        <tr><th>Operator</th><th>Assembly</th><th>Job</th><th>Inspected</th><th>Rejected</th></tr>
-        {% for row in shift1 %}
-        <tr>
-            <td>{{ row.operator }}</td>
-            <td>{{ row.assembly }}</td>
-            <td>{{ row.job }}</td>
-            <td>{{ row.inspected }}</td>
-            <td>{{ row.rejected }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-
-    <h2>2nd Shift</h2>
-    <table>
-        <tr><th>Operator</th><th>Assembly</th><th>Job</th><th>Inspected</th><th>Rejected</th></tr>
-        {% for row in shift2 %}
-        <tr>
-            <td>{{ row.operator }}</td>
-            <td>{{ row.assembly }}</td>
-            <td>{{ row.job }}</td>
-            <td>{{ row.inspected }}</td>
-            <td>{{ row.rejected }}</td>
-        </tr>
-        {% endfor %}
-    </table>
-
-    <h2>Assemblies</h2>
-    <table>
-        <tr><th>Assembly</th><th>Yield</th><th>Past 3 Job Avg</th></tr>
-        {% for asm in assemblies %}
-        <tr>
-            <td>{{ asm.assembly }}</td>
-            <td>{{ '%.2f'|format(asm.yield) if asm.yield is not string else asm.yield }}</td>
-            <td>
-                {% if asm.past3Avg is string %}
-                    {{ asm.past3Avg }}
-                {% else %}
-                    {{ '%.2f'|format(asm.past3Avg) }}
-                {% endif %}
-            </td>
-        </tr>
-        {% endfor %}
-    </table>
+    {% include 'report/aoi_daily/shift_summary.html' %}
+    {% include 'report/aoi_daily/assembly_history.html' %}
 </body>
 </html>
+

--- a/templates/report/aoi_daily/shift_summary.html
+++ b/templates/report/aoi_daily/shift_summary.html
@@ -1,0 +1,18 @@
+<section id="shift-summary" class="report-section section-card">
+    <h2>Shift Comparison</h2>
+    <p class="section-desc">Comparison of inspection totals and reject rates by shift.</p>
+    <div class="chart-block">
+        <img src="{{ shiftImg }}" alt="Boards inspected by shift">
+        <div class="chart-summary">
+            <p>
+                <strong>1st Shift Total:</strong> {{ shift1_total }}<br>
+                <strong>1st Shift Reject %:</strong> {{ shift1_reject_pct }}%<br>
+                <strong>2nd Shift Total:</strong> {{ shift2_total }}<br>
+                <strong>2nd Shift Reject %:</strong> {{ shift2_reject_pct }}%<br>
+                <strong>Total Difference:</strong> {{ shift_total_diff }}<br>
+                <strong>Reject % Difference:</strong> {{ shift_reject_pct_diff }}%
+            </p>
+        </div>
+    </div>
+</section>
+


### PR DESCRIPTION
## Summary
- Create modular AOI daily report index with optional cover and summary sections
- Implement custom AOI daily report cover with first and second shift tables
- Add shift comparison chart summary and assembly historical yield sections

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c0cdae1a6c83258575ae57e4bf54eb