### PR TITLE
Add AOI daily report page

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1231,6 +1231,14 @@ def export_integrated_report():
     return html
 
 
+@main_bp.route('/reports/aoi_daily', methods=['GET'])
+def aoi_daily_report_page():
+    """Render the AOI Daily Report page."""
+    if 'username' not in session:
+        return redirect(url_for('auth.login'))
+    return render_template('aoi_daily_report.html', username=session.get('username'))
+
+
 @main_bp.route('/reports/aoi_daily/export')
 def export_aoi_daily_report():
     if 'username' not in session:

--- a/static/js/aoi_daily_report.js
+++ b/static/js/aoi_daily_report.js
@@ -1,0 +1,103 @@
+let operatorOptions = [];
+let assemblyOptions = [];
+
+function uniqueSorted(arr) {
+  const map = new Map();
+  arr.forEach((v) => {
+    if (v != null && v !== '') {
+      const key = String(v).toLowerCase();
+      if (!map.has(key)) map.set(key, v);
+    }
+  });
+  return Array.from(map.values()).sort((a, b) => a.localeCompare(b));
+}
+
+function populateDynamicSelect(wrapperId, className, options, values = []) {
+  const wrapper = document.getElementById(wrapperId);
+  if (!wrapper) return;
+  wrapper.innerHTML = '';
+  function addSelect(value = '') {
+    const sel = document.createElement('select');
+    sel.className = className;
+    const blank = document.createElement('option');
+    blank.value = '';
+    blank.textContent = '';
+    sel.appendChild(blank);
+    options.forEach((v) => {
+      const opt = document.createElement('option');
+      opt.value = v;
+      opt.textContent = v;
+      sel.appendChild(opt);
+    });
+    sel.value = value;
+    sel.addEventListener('change', () => {
+      const sels = wrapper.querySelectorAll('select.' + className);
+      const last = sels[sels.length - 1];
+      if (sel === last && sel.value !== '') addSelect('');
+    });
+    wrapper.appendChild(sel);
+  }
+  values.forEach((v) => addSelect(v));
+  addSelect('');
+}
+
+function getDropdownValues(className) {
+  return Array.from(document.querySelectorAll('select.' + className))
+    .map((sel) => sel.value)
+    .filter((v) => v);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const runBtn = document.getElementById('run-report');
+  const downloadBtn = document.getElementById('download-report');
+  const downloadControls = document.getElementById('download-controls');
+  const previewBox = document.getElementById('preview-data');
+
+  if (downloadControls) downloadControls.style.display = 'none';
+
+  fetch('/aoi_reports')
+    .then((r) => r.json())
+    .then((rows) => {
+      operatorOptions = uniqueSorted(rows.map((r) => r['Operator']));
+      populateDynamicSelect('operator-wrapper', 'filter-operator', operatorOptions);
+      assemblyOptions = uniqueSorted(rows.map((r) => r['Assembly']));
+      populateDynamicSelect('assembly-wrapper', 'filter-assembly', assemblyOptions);
+    });
+
+  runBtn?.addEventListener('click', () => {
+    const date = document.getElementById('report-date').value;
+    const operator = getDropdownValues('filter-operator').join(',');
+    const assembly = getDropdownValues('filter-assembly').join(',');
+    if (!date) {
+      alert('Please select a date.');
+      return;
+    }
+    const params = new URLSearchParams({ date });
+    if (operator) params.append('operator', operator);
+    if (assembly) params.append('assembly', assembly);
+    fetch(`/api/reports/aoi_daily?${params.toString()}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (previewBox) previewBox.textContent = JSON.stringify(data, null, 2);
+        if (downloadControls) downloadControls.style.display = 'flex';
+      })
+      .catch(() => alert('Failed to run report.'));
+  });
+
+  downloadBtn?.addEventListener('click', () => {
+    const fmt = document.getElementById('file-format').value;
+    const date = document.getElementById('report-date').value;
+    const operator = getDropdownValues('filter-operator').join(',');
+    const assembly = getDropdownValues('filter-assembly').join(',');
+    const includeCover = document.getElementById('include-cover')?.checked;
+    if (!date) {
+      alert('Please select a date.');
+      return;
+    }
+    const params = new URLSearchParams({ format: fmt, date });
+    params.append('show_cover', includeCover ? 'true' : 'false');
+    if (operator) params.append('operator', operator);
+    if (assembly) params.append('assembly', assembly);
+    window.location = `/reports/aoi_daily/export?${params.toString()}`;
+  });
+});

--- a/templates/aoi_daily_report.html
+++ b/templates/aoi_daily_report.html
@@ -1,0 +1,47 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>AOI Daily Report</h2>
+
+<div class="section-card">
+  <div class="field-row">
+    <div class="field">
+      <label for="report-date">Date</label>
+      <input type="date" id="report-date" />
+    </div>
+    <div class="field">
+      <label>Operator</label>
+      <div id="operator-wrapper"></div>
+    </div>
+    <div class="field">
+      <label>Assembly</label>
+      <div id="assembly-wrapper"></div>
+    </div>
+    <button type="button" id="run-report">Run</button>
+  </div>
+</div>
+
+<details id="preview" class="section-card">
+  <summary>Preview</summary>
+  <pre id="preview-data"></pre>
+</details>
+
+<div id="download-controls" class="field-row" style="display:none">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="html">html</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="include-cover">Cover Page</label>
+    <input type="checkbox" id="include-cover" checked />
+  </div>
+  <button id="download-report">Download</button>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/aoi_daily_report.js') }}"></script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add AOI Daily Report template with date picker, operator/assembly filters, and run/download controls
- Implement frontend logic to fetch dropdown data, preview results, and export the report
- Expose `/reports/aoi_daily` route to render the new page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c0ce8fc03c8325b3831c4d7ea59dce