### PR TITLE
Add AOI daily report API and navigation entry

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
           <div class="dropdown">
             <a href="{{ url_for('main.integrated_report') }}">AOI Integrated Report</a>
             <a href="{{ url_for('main.operator_report') }}">Operator Report</a>
+            <a href="{{ url_for('main.aoi_daily_report_page') }}">AOI Daily Report</a>
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- expose `/api/reports/aoi_daily` so the report page pulls real data
- allow filtering by operator and assembly in `build_aoi_daily_report_payload`
- link the AOI Daily Report from the navigation menu

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c0cbbacf588325b3514881eeac660a