### PR TITLE
Expand assembly historical yield to four job average

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1527,7 +1527,7 @@ def build_aoi_daily_report_payload(
         rej = vals["rejected"]
         today_yield = ((ins - rej) / ins * 100) if ins else 0
 
-        # Past 3 job average yield
+        # Past 4 job average yield
         past_rows = [
             r
             for r in rows or []
@@ -1547,7 +1547,7 @@ def build_aoi_daily_report_payload(
 
         jobs = sorted(job_groups.values(), key=lambda g: g.get("date") or date.min, reverse=True)
         yields = []
-        for g in jobs[:3]:
+        for g in jobs[:4]:
             i = g["inspected"]
             rj = g["rejected"]
             if i:
@@ -1558,7 +1558,7 @@ def build_aoi_daily_report_payload(
         else:
             past_avg = "first run"
 
-        assembly_info.append({"assembly": asm, "yield": today_yield, "past3Avg": past_avg})
+        assembly_info.append({"assembly": asm, "yield": today_yield, "past4Avg": past_avg})
 
     return {
         "date": day.isoformat(),

--- a/templates/report/aoi_daily/assembly_history.html
+++ b/templates/report/aoi_daily/assembly_history.html
@@ -1,9 +1,9 @@
 <section id="assembly-history" class="report-section section-card last">
     <h2>Assembly Historical Yield</h2>
-    <p class="section-desc">Yield performance and three-job average for recent runs.</p>
+    <p class="section-desc">Yield performance and four-job average for recent runs.</p>
     <table class="data-table">
         <thead>
-            <tr><th>Assembly</th><th>Yield %</th><th>Historical Yield (Past 3 Job Avg)</th></tr>
+            <tr><th>Assembly</th><th>Yield %</th><th>Historical Yield (Past 4 Job Avg)</th></tr>
         </thead>
         <tbody>
         {% for asm in assemblies %}
@@ -11,10 +11,10 @@
                 <td>{{ asm.assembly }}</td>
                 <td>{{ asm.yield if asm.yield is string else '%.2f'|format(asm.yield) }}</td>
                 <td>
-                    {% if asm.past3Avg is string %}
-                        {{ asm.past3Avg }}
+                    {% if asm.past4Avg is string %}
+                        {{ asm.past4Avg }}
                     {% else %}
-                        {{ '%.2f'|format(asm.past3Avg) }}
+                        {{ '%.2f'|format(asm.past4Avg) }}
                     {% endif %}
                 </td>
             </tr>


### PR DESCRIPTION
## Summary
- Include last four jobs when computing assembly historical yield
- Display four-job average in the AOI daily report

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17e4ad88c8325b8f0ec54baf0d48a