### PR TITLE
Include metadata in AOI daily report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1251,13 +1251,24 @@ def export_aoi_daily_report():
     operator = request.args.get('operator') or None
     assembly = request.args.get('assembly') or None
 
+    start = end = day.isoformat()
+    generated_at = datetime.now(ZoneInfo('EST')).strftime('%Y-%m-%d %H:%M:%S %Z')
+    contact = request.args.get('contact', 'tschawtz@4spectra.com')
+
     payload = build_aoi_daily_report_payload(day, operator, assembly)
     charts = _generate_aoi_daily_report_charts(payload)
     payload.update(charts)
 
     show_cover = str(request.args.get('show_cover', 'false')).lower() not in {'0', 'false', 'no'}
     html = render_template(
-        'report/aoi_daily/index.html', day=day.isoformat(), show_cover=show_cover, **payload
+        'report/aoi_daily/index.html',
+        day=day.isoformat(),
+        show_cover=show_cover,
+        start=start,
+        end=end,
+        generated_at=generated_at,
+        contact=contact,
+        **payload,
     )
 
     fmt = request.args.get('format')

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -1,0 +1,90 @@
+import os
+import re
+import sys
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def _mock_payload(monkeypatch):
+    sample_payload = {
+        "shiftImg": "img",
+        "shift1_total": 10,
+        "shift1_reject_pct": 1,
+        "shift2_total": 20,
+        "shift2_reject_pct": 2,
+        "shift_total_diff": 10,
+        "shift_reject_pct_diff": 1,
+        "assemblies": [{"assembly": "Asm1", "yield": 95.0, "past4Avg": 96.0}],
+        "shift1": [
+            {
+                "operator": "Op1",
+                "assembly": "Asm1",
+                "job": "J1",
+                "inspected": 5,
+                "rejected": 0,
+            }
+        ],
+        "shift2": [
+            {
+                "operator": "Op2",
+                "assembly": "Asm2",
+                "job": "J2",
+                "inspected": 10,
+                "rejected": 1,
+            }
+        ],
+    }
+    monkeypatch.setattr(
+        routes,
+        "build_aoi_daily_report_payload",
+        lambda day, operator, assembly: sample_payload,
+    )
+    monkeypatch.setattr(routes, "_generate_aoi_daily_report_charts", lambda payload: {})
+
+
+
+def test_export_aoi_daily_report_cover_fields(app_instance, monkeypatch):
+    _mock_payload(monkeypatch)
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get(
+            "/reports/aoi_daily/export?date=2024-06-01&show_cover=1&contact=help@example.com"
+        )
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "report_range:</b> 2024-06-01 - 2024-06-01" in html
+        assert "&lt;help@example.com&gt;" in html
+        assert re.search(
+            r"generated_at:</b> \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} EST", html
+        )
+
+
+def test_export_aoi_daily_report_default_contact(app_instance, monkeypatch):
+    _mock_payload(monkeypatch)
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/reports/aoi_daily/export?date=2024-06-01&show_cover=1")
+        assert resp.status_code == 200
+        html = resp.data.decode()
+        assert "&lt;tschawtz@4spectra.com&gt;" in html


### PR DESCRIPTION
## Summary
- Pass start/end dates, generation timestamp, and contact into AOI daily report rendering
- Add tests ensuring cover page includes range, timestamp, and contact information

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c17f92d00c83258af4eba346b6a627