### PR TITLE
Add assembly detail pages to AOI daily report

### DIFF
--- a/templates/report/aoi_daily/assembly_detail.html
+++ b/templates/report/aoi_daily/assembly_detail.html
@@ -1,0 +1,23 @@
+<section class="report-section section-card">
+    <h2>{{ asm.assembly }}</h2>
+    <p><strong>Operators:</strong> {{ asm.operators|default([])|join(', ') }}</p>
+    <p><strong>Boards Processed:</strong> {{ asm.boards|default(0) }}</p>
+    <table class="data-table">
+        <thead>
+            <tr><th>Metric</th><th>Value</th></tr>
+        </thead>
+        <tbody>
+            <tr><td>Current Yield %</td><td>{{ '%.2f'|format(asm.yield|default(0)) }}</td></tr>
+            <tr><td>Historical Yield %</td><td>
+                {% if asm.past4Avg is string %}
+                    {{ asm.past4Avg }}
+                {% else %}
+                    {{ '%.2f'|format(asm.past4Avg|default(0)) }}
+                {% endif %}
+            </td></tr>
+            <tr><td>Current AOI Rejects</td><td>{{ asm.currentRejects|default(0) }}</td></tr>
+            <tr><td>Past AOI Rejects (Avg)</td><td>{{ asm.pastRejectsAvg|default(0)|round(2) }}</td></tr>
+            <tr><td>Typical FI Rejects</td><td>{{ asm.fiTypicalRejects|default(0)|round(2) }}</td></tr>
+        </tbody>
+    </table>
+</section>

--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -12,6 +12,9 @@
 
     {% include 'report/aoi_daily/shift_summary.html' %}
     {% include 'report/aoi_daily/summary_toc.html' %}
+    {% for asm in assemblies %}
+        {% include 'report/aoi_daily/assembly_detail.html' %}
+    {% endfor %}
     {% include 'report/aoi_daily/assembly_history.html' %}
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Group AOI daily data by assembly with operator lists, board totals, and historical metrics
- Include FI-based typical reject averages to compare against AOI rejects
- Render per-assembly detail pages in AOI daily report and test new stats

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c182d309508325ac62c1b13dd2741a