### PR TITLE
Move AOI daily TOC onto cover page

### DIFF
--- a/templates/report/aoi_daily/cover.html
+++ b/templates/report/aoi_daily/cover.html
@@ -52,6 +52,7 @@
             {% endfor %}
             </tbody>
         </table>
+        {% include 'report/aoi_daily/summary_toc.html' %}
     </div>
 </section>
 

--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -11,7 +11,6 @@
     {% endif %}
 
     {% include 'report/aoi_daily/shift_summary.html' %}
-    {% include 'report/aoi_daily/summary_toc.html' %}
     {% for asm in assemblies %}
         {% include 'report/aoi_daily/assembly_detail.html' %}
     {% endfor %}

--- a/templates/report/aoi_daily/summary_toc.html
+++ b/templates/report/aoi_daily/summary_toc.html
@@ -1,11 +1,9 @@
-<section class="report-section summary-page avoid-break">
-    <div class="summary-break"></div>
-    <div class="toc section-card">
-        <h2>Table of Contents</h2>
-        <ol>
-            <li><a href="#shift-summary">Shift Summary</a></li>
-            <li><a href="#assembly-history">Assembly Historical Yield</a></li>
-        </ol>
-    </div>
-</section>
+<div class="summary-break"></div>
+<div class="toc section-card">
+    <h2>Table of Contents</h2>
+    <ol>
+        <li><a href="#shift-summary">Shift Summary</a></li>
+        <li><a href="#assembly-history">Assembly Historical Yield</a></li>
+    </ol>
+</div>
 

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -194,18 +194,19 @@ def test_assembly_detail_rendered(app_instance, monkeypatch):
         assert "Typical FI Rejects</td><td>1" in html
 
 
-def test_toc_after_shift_summary(app_instance, monkeypatch):
+def test_toc_on_cover_before_shift_summary(app_instance, monkeypatch):
     _mock_payload(monkeypatch)
     client = app_instance.test_client()
     with app_instance.app_context():
         with client.session_transaction() as sess:
             sess["username"] = "tester"
-        resp = client.get("/reports/aoi_daily/export?date=2024-06-01")
+        resp = client.get("/reports/aoi_daily/export?date=2024-06-01&show_cover=1")
         assert resp.status_code == 200
         html = resp.data.decode()
-        shift_idx = html.index("Shift Comparison")
+        cover_idx = html.index('id="cover"')
         toc_idx = html.index("Table of Contents")
-        assert shift_idx < toc_idx
+        shift_idx = html.index("Shift Comparison")
+        assert cover_idx < toc_idx < shift_idx
 
 
 def test_historical_yield_uses_four_jobs(app_instance, monkeypatch):


### PR DESCRIPTION
## Summary
- Embed the AOI daily table of contents in the cover page after the second shift summary
- Remove redundant TOC include from main index template
- Adjust TOC markup to avoid nested sections on the cover
- Verify cover placement with updated test

## Testing
- `pytest tests/test_aoi_daily_report.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68c189d6a44483259b930fbc1e867fef