### PR TITLE
Enhance shift comparison metrics in AOI daily report

### DIFF
--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -146,9 +146,15 @@ def test_shift_chart_description_rendered(app_instance, monkeypatch):
         assert resp.status_code == 200
         html = resp.data.decode()
         assert (
-            "2nd shift inspected 10 more boards than 1st shift." in html
+            "2nd shift inspected 10 more boards than 1st shift and had a reject rate 1.00 percentage points higher." in html
             and "chart-desc" in html
         )
+        assert "1st Shift Total:</strong> 10" in html
+        assert "1st Shift Reject %:</strong> 1%" in html
+        assert "2nd Shift Total:</strong> 20" in html
+        assert "2nd Shift Reject %:</strong> 2%" in html
+        assert "Total Difference:</strong> 10" in html
+        assert "Reject % Difference:</strong> 1%" in html
 
 
 def test_assembly_detail_rendered(app_instance, monkeypatch):


### PR DESCRIPTION
## Summary
- Compute shift inspection totals, reject percentages, and differences within `build_aoi_daily_report_payload`
- Expand shift chart description to compare both board counts and reject-rate differences
- Validate chart description and summary fields with new unit tests

## Testing
- `pytest tests/test_aoi_daily_report.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18ace92f48325953fe7e5a3492a14