### PR TITLE
Add MOAT false-call control charts to AOI daily report

### DIFF
--- a/templates/report/aoi_daily/assembly_detail.html
+++ b/templates/report/aoi_daily/assembly_detail.html
@@ -20,4 +20,20 @@
             <tr><td>Typical FI Rejects</td><td>{{ asm.fiTypicalRejects|default(0)|round(2) }}</td></tr>
         </tbody>
     </table>
+    {% if asm.smtChart or asm.thChart %}
+    <div class="moat-charts">
+        {% if asm.smtChart %}
+        <div class="chart">
+            <h3>SMT False Calls Control Chart</h3>
+            <img src="{{ asm.smtChart }}" alt="SMT Control Chart">
+        </div>
+        {% endif %}
+        {% if asm.thChart %}
+        <div class="chart">
+            <h3>TH False Calls Control Chart</h3>
+            <img src="{{ asm.thChart }}" alt="TH Control Chart">
+        </div>
+        {% endif %}
+    </div>
+    {% endif %}
 </section>


### PR DESCRIPTION
## Summary
- compute ±3σ control limits and build SMT/TH false-call charts from MOAT data for each assembly
- embed generated charts in AOI daily report assembly detail page
- test that both SMT and TH control charts render when MOAT data exists

## Testing
- `pytest tests/test_aoi_daily_report.py::test_smt_th_control_charts_render -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c18c4e3ec48325b0141353e91962da