### PR TITLE
Overlay SMT and TH control charts in AOI daily report

### DIFF
--- a/templates/report/aoi_daily/assembly_detail.html
+++ b/templates/report/aoi_daily/assembly_detail.html
@@ -20,20 +20,12 @@
             <tr><td>Typical FI Rejects</td><td>{{ asm.fiTypicalRejects|default(0)|round(2) }}</td></tr>
         </tbody>
     </table>
-    {% if asm.smtChart or asm.thChart %}
+    {% if asm.overlayChart %}
     <div class="moat-charts">
-        {% if asm.smtChart %}
         <div class="chart">
-            <h3>SMT False Calls Control Chart</h3>
-            <img src="{{ asm.smtChart }}" alt="SMT Control Chart">
+            <h3>SMT vs TH False Calls Control Chart</h3>
+            <img src="{{ asm.overlayChart }}" alt="SMT vs TH Control Chart">
         </div>
-        {% endif %}
-        {% if asm.thChart %}
-        <div class="chart">
-            <h3>TH False Calls Control Chart</h3>
-            <img src="{{ asm.thChart }}" alt="TH Control Chart">
-        </div>
-        {% endif %}
     </div>
     {% endif %}
 </section>

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -41,6 +41,7 @@ def _mock_payload(monkeypatch):
                 "currentRejects": 0,
                 "pastRejectsAvg": 1,
                 "fiTypicalRejects": 2,
+                "overlayChart": "img",
             }
         ],
         "shift1": [
@@ -319,5 +320,8 @@ def test_smt_th_control_charts_render(app_instance, monkeypatch):
         resp = client.get("/reports/aoi_daily/export?date=2024-06-01")
         assert resp.status_code == 200
         html = resp.data.decode()
-        assert "SMT Control Chart" in html
-        assert "TH Control Chart" in html
+        chart_section = re.search(
+            r'<div class="moat-charts">.*?</div>\s*</div>', html, re.DOTALL
+        ).group(0)
+        assert chart_section.count("<img") == 1
+        assert "SMT" in chart_section and "TH" in chart_section


### PR DESCRIPTION
## Summary
- Combine SMT and TH MOAT false call data into a single overlay control chart
- Render one consolidated chart per assembly in AOI daily report
- Update tests for merged control chart output

## Testing
- `pytest tests/test_aoi_daily_report.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c19352914c8325b2c144df307437af