### PR TITLE
Use full job history for historical yield averages

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -592,7 +592,7 @@ def _build_metrics_chart(info: dict) -> str:
     ]
     values = [
         info.get("yield") or 0,
-        info.get("past4Avg") if isinstance(info.get("past4Avg"), (int, float)) else 0,
+        info.get("pastAvg") if isinstance(info.get("pastAvg"), (int, float)) else 0,
         info.get("currentRejects") or 0,
         info.get("pastRejectsAvg") or 0,
         info.get("fiTypicalRejects") or 0,
@@ -1757,7 +1757,7 @@ def build_aoi_daily_report_payload(
         )
         yields: list[float] = []
         rejects: list[int] = []
-        for g in jobs[:4]:
+        for g in jobs:
             i = g["inspected"]
             rj = g["rejected"]
             rejects.append(rj)
@@ -1778,7 +1778,7 @@ def build_aoi_daily_report_payload(
             "operators": sorted(vals.get("operators", set())),
             "boards": ins,
             "yield": today_yield,
-            "past4Avg": past_avg,
+            "pastAvg": past_avg,
             "currentRejects": rej,
             "pastRejectsAvg": past_rej_avg,
             "fiTypicalRejects": fi_typical,

--- a/templates/report/aoi_daily/assembly_detail.html
+++ b/templates/report/aoi_daily/assembly_detail.html
@@ -8,11 +8,11 @@
         </thead>
         <tbody>
             <tr><td>Current Yield %</td><td>{{ '%.2f%%'|format(asm.yield|default(0)) }}</td></tr>
-            <tr><td>Historical Yield %</td><td>
-                {% if asm.past4Avg is string %}
-                    {{ asm.past4Avg }}
+            <tr><td>Historical Yield (Avg of All Past Jobs)</td><td>
+                {% if asm.pastAvg is string %}
+                    {{ asm.pastAvg }}
                 {% else %}
-                    {{ '%.2f%%'|format(asm.past4Avg|default(0)) }}
+                    {{ '%.2f%%'|format(asm.pastAvg|default(0)) }}
                 {% endif %}
             </td></tr>
             <tr><td>Current AOI Rejects</td><td>{{ asm.currentRejects|default(0) }} rejects</td></tr>

--- a/templates/report/aoi_daily/assembly_history.html
+++ b/templates/report/aoi_daily/assembly_history.html
@@ -1,9 +1,9 @@
 <section id="assembly-history" class="report-section section-card last">
     <h2>Assembly Historical Yield</h2>
-    <p class="section-desc">Yield performance and four-job average for recent runs.</p>
+    <p class="section-desc">Yield performance and historical average for all past jobs.</p>
     <table class="data-table">
         <thead>
-            <tr><th>Assembly</th><th>Yield %</th><th>Historical Yield (Past 4 Job Avg)</th></tr>
+            <tr><th>Assembly</th><th>Yield %</th><th>Historical Yield (Avg of All Past Jobs)</th></tr>
         </thead>
         <tbody>
         {% for asm in assemblies %}
@@ -11,10 +11,10 @@
                 <td>{{ asm.assembly }}</td>
                 <td>{{ asm.yield if asm.yield is string else '%.2f'|format(asm.yield) }}</td>
                 <td>
-                    {% if asm.past4Avg is string %}
-                        {{ asm.past4Avg }}
+                    {% if asm.pastAvg is string %}
+                        {{ asm.pastAvg }}
                     {% else %}
-                        {{ '%.2f'|format(asm.past4Avg) }}
+                        {{ '%.2f'|format(asm.pastAvg) }}
                     {% endif %}
                 </td>
             </tr>

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -35,7 +35,7 @@ def _mock_payload(monkeypatch):
             {
                 "assembly": "Asm1",
                 "yield": 95.0,
-                "past4Avg": 96.0,
+                "pastAvg": 96.0,
                 "operators": ["Op1"],
                 "boards": 5,
                 "currentRejects": 0,
@@ -114,7 +114,7 @@ def test_shift_chart_description_rendered(app_instance, monkeypatch):
             "shift1": {"inspected": 10},
             "shift2": {"inspected": 20},
         },
-        "assemblies": [{"assembly": "Asm1", "yield": 95.0, "past4Avg": 96.0}],
+        "assemblies": [{"assembly": "Asm1", "yield": 95.0, "pastAvg": 96.0}],
         "shift1": [
             {
                 "operator": "Op1",
@@ -164,7 +164,7 @@ def test_assembly_detail_rendered(app_instance, monkeypatch):
             {
                 "assembly": "Asm1",
                 "yield": 90.0,
-                "past4Avg": 95.0,
+                "pastAvg": 95.0,
                 "operators": ["Op1", "Op2"],
                 "boards": 20,
                 "currentRejects": 2,
@@ -196,7 +196,7 @@ def test_assembly_detail_rendered(app_instance, monkeypatch):
         assert "Operators:</strong> Op1, Op2" in html
         assert "Boards Processed:</strong> 20 boards" in html
         assert "Current Yield %</td><td>90.00%" in html
-        assert re.search(r"Historical Yield %</td><td>\s*95.00%", html)
+        assert re.search(r"Historical Yield \(Avg of All Past Jobs\)</td><td>\s*95.00%", html)
         assert "Current AOI Rejects</td><td>2 rejects" in html
         assert re.search(r"Past AOI Rejects \(Avg\)</td><td>\s*1.50 rejects", html)
         assert "Typical FI Rejects</td><td>1.00 rejects" in html
@@ -218,7 +218,7 @@ def test_toc_on_cover_before_shift_summary(app_instance, monkeypatch):
         assert cover_idx < toc_idx < shift_idx
 
 
-def test_historical_yield_uses_four_jobs(app_instance, monkeypatch):
+def test_historical_yield_uses_all_jobs(app_instance, monkeypatch):
     client = app_instance.test_client()
     with app_instance.app_context():
         rows = [
@@ -280,8 +280,8 @@ def test_historical_yield_uses_four_jobs(app_instance, monkeypatch):
         assert resp.status_code == 200
         data = resp.get_json()
         asm = data["assemblies"][0]
-        assert asm["past4Avg"] == pytest.approx(75.0)
-        assert asm["pastRejectsAvg"] == pytest.approx(25.0)
+        assert asm["pastAvg"] == pytest.approx(70.0)
+        assert asm["pastRejectsAvg"] == pytest.approx(30.0)
 
 
 def test_smt_th_control_charts_render(app_instance, monkeypatch):


### PR DESCRIPTION
## Summary
- Compute historical yield and reject averages across all past jobs
- Expose the new `pastAvg` metric in metrics chart and templates
- Update tests to expect full history averages and rename accordingly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1d29d61c483259fdda9fc3d720e92