### PR TITLE
Include Program column in AOI report uploads

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -149,6 +149,7 @@ def upload_aoi_reports():
         'Shift',
         'Operator',
         'Customer',
+        'Program',
         'Assembly',
         'Rev',
         'Job Number',
@@ -161,6 +162,7 @@ def upload_aoi_reports():
 
     rows = []
     for row in reader:
+        # Copy required columns (including 'Program') for each record
         current = {col: row.get(col, '') for col in required_columns}
         date_str = current.get('Date')
         if date_str:

--- a/tests/test_upload_aoi_reports.py
+++ b/tests/test_upload_aoi_reports.py
@@ -1,0 +1,43 @@
+import os
+import io
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def test_upload_aoi_with_program_column(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = {}
+
+    def fake_insert(rows):
+        captured["rows"] = rows
+        return None, None
+
+    monkeypatch.setattr(routes, "insert_aoi_reports_bulk", fake_insert)
+    csv_content = (
+        "Date,Shift,Operator,Customer,Program,Assembly,Rev,Job Number,Quantity Inspected,Quantity Rejected,Additional Information\n"
+        "2024-07-01,1,Alice,ACME,Alpha,A1,R1,J1,10,1,Info\n"
+    )
+    data = {"file": (io.BytesIO(csv_content.encode("utf-8")), "aoi.csv")}
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/aoi_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured["rows"][0]["Program"] == "Alpha"


### PR DESCRIPTION
## Summary
- allow AOI report uploads to require and store a Program column
- add regression test ensuring Program values are accepted and forwarded

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3fe7490108325a46b9c718c6d3fe1