### PR TITLE
Add Assembly Forecast link to Tools menu

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -25,6 +25,7 @@
           <div class="dropdown">
             <a href="#">Rework Stencil Lookup</a>
             <a href="#">Verified Part Markings</a>
+            <a href="{{ url_for('main.assembly_forecast') }}">Assembly Forecast</a>
           </div>
         </li>
         <li class="nav-item">


### PR DESCRIPTION
## Summary
- add Assembly Forecast link to Tools dropdown

## Testing
- `pytest` *(fails: Could not build url for endpoint 'main.assembly_forecast')*

------
https://chatgpt.com/codex/tasks/task_e_68c7e861d64883259c7ee8c99d0377a9