### PR TITLE
Add assembly forecast tools and APIs

### DIFF
--- a/templates/assembly_forecast.html
+++ b/templates/assembly_forecast.html
@@ -1,0 +1,8 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h1>Assembly Forecast</h1>
+{% endblock %}
+
+{% block scripts %}
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add helpers to aggregate MOAT/AOI data and predict yields
- Provide endpoints for assembly search and forecasting
- Render new Assembly Forecast tool page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c7e8f3b7908325991331e0e1d96a1e