### PR TITLE
Refine TH/SMT model filters

### DIFF
--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -747,7 +747,10 @@ async function runPresetChart() {
     if (cols.model) {
       const m = String(row[cols.model] ?? '').toLowerCase();
       if (f.modelContains && !m.includes(f.modelContains)) return false;
-      if ((f.hasTH || f.hasSMT) && !(m.includes('th') || m.includes('smt'))) return false;
+      const groups = [];
+      if (f.hasTH) groups.push('th');
+      if (f.hasSMT) groups.push('smt');
+      if (groups.length && !groups.some((g) => m.includes(g))) return false;
     }
     return true;
   });


### PR DESCRIPTION
## Summary
- enforce TH and SMT filters individually on model names

## Testing
- `node - <<'NODE'\nfunction filterRows(rows, f) {\n  return rows.filter((row) => {\n    const cols = { model: 'model' };\n    const m = String(row[cols.model] ?? '').toLowerCase();\n    if (f.modelContains && !m.includes(f.modelContains)) return false;\n    const groups = [];\n    if (f.hasTH) groups.push('th');\n    if (f.hasSMT) groups.push('smt');\n    if (groups.length && !groups.some(g => m.includes(g))) return false;\n    return true;\n  });\n}\nconst rows = [{model:'ABC-TH1'}, {model:'XYZ-SMT'}, {model:'LMN-TH-SMT'}, {model:'NONE'}];\nconst scenarios = [\n  {hasTH:true, hasSMT:false, name:'TH only'},\n  {hasTH:false, hasSMT:true, name:'SMT only'},\n  {hasTH:true, hasSMT:true, name:'TH or SMT'},\n  {hasTH:false, hasSMT:false, name:'Neither'}\n];\nscenarios.forEach(s => {\n  const result = filterRows(rows, s).map(r => r.model);\n  console.log(s.name+':', result);\n});\nNODE`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7eefbdf2c8325953400df3108ea85