### PR TITLE
Join MOAT and AOI forecast metrics by program

### DIFF
--- a/tests/test_assembly_forecast.py
+++ b/tests/test_assembly_forecast.py
@@ -68,12 +68,18 @@ def test_api_assemblies_forecast(app_instance, monkeypatch):
         from app.main import routes
 
         moat_rows = [
-            {"Assembly": "Asm1", "Total Boards": 100, "FalseCall Parts": 5},
-            {"Model": "Asm2", "total_boards": 50, "falsecall_parts": 2},
+            {"Model Name": "Asm1 SMT", "Total Boards": 100, "FalseCall Parts": 5},
+            {"Model Name": "Asm1 TH", "Total Boards": 50, "FalseCall Parts": 2},
+            {"Model Name": "Asm2 SMT", "total_boards": 50, "falsecall_parts": 2},
         ]
         aoi_rows = [
-            {"Assembly": "Asm1", "Quantity Inspected": 80, "Quantity Rejected": 4},
-            {"Assembly": "Asm2", "aoi_Quantity Inspected": 40, "aoi_Quantity Rejected": 1},
+            {"Assembly": "Asm1", "Program": "SMT", "Quantity Inspected": 80, "Quantity Rejected": 4},
+            {
+                "Assembly": "Asm2",
+                "Program": "SMT",
+                "aoi_Quantity Inspected": 40,
+                "aoi_Quantity Rejected": 1,
+            },
         ]
         monkeypatch.setattr(routes, "fetch_moat", lambda: (moat_rows, None))
         monkeypatch.setattr(routes, "fetch_aoi_reports", lambda: (aoi_rows, None))


### PR DESCRIPTION
## Summary
- parse `Model Name` into separate assembly and program fields
- normalize assembly and program names and join MOAT/AOI data on both
- test forecast aggregation with program-aware MOAT and AOI rows

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7f48b7d9c8325b39c81087da971ab