### PR TITLE
Add control charts and extended metrics to assembly forecast

### DIFF
--- a/templates/assembly_forecast.html
+++ b/templates/assembly_forecast.html
@@ -11,6 +11,13 @@
   <div class="preview-card" style="height:300px;">
     <canvas id="forecastChart"></canvas>
   </div>
+  <div class="preview-card" style="height:300px; margin-top:16px;">
+    <canvas id="falseCallChart"></canvas>
+  </div>
+  <div class="preview-card" style="height:300px; margin-top:16px;">
+    <canvas id="ngRatioChart"></canvas>
+  </div>
+  <div id="missing-msg" style="display:none; margin-top:16px;"></div>
   <table id="forecast-table" class="data-table" style="margin-top:16px;">
     <thead>
       <tr>
@@ -19,11 +26,15 @@
         <th>False Calls</th>
         <th>Avg FC/Board</th>
         <th>Pred FC</th>
+        <th>Pred FC/Board</th>
         <th>Inspected</th>
         <th>Rejected</th>
+        <th>NG Ratio %</th>
         <th>Yield %</th>
         <th>Pred Rej</th>
+        <th>Pred NG/Board</th>
         <th>Pred Yield %</th>
+        <th>Cust Yield %</th>
       </tr>
     </thead>
     <tbody></tbody>


### PR DESCRIPTION
## Summary
- add canvases for false-call and NG-ratio control charts with missing-assembly alerts
- expand forecast table with NG ratio, per-board predictions, and customer yield
- render new control charts using horizontal-line plugin and overlay customer yield on existing chart

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c805ac7d408325a6f75c404c4d2702