### PR TITLE
Use workbook date for PPM uploads

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -440,7 +440,7 @@ def upload_ppm_reports():
             ),
         )
     start_date, end_date, line = m.groups()
-    report_date = end_date or start_date
+    report_date = None
 
     try:
         uploaded.stream.seek(0)
@@ -476,6 +476,9 @@ def upload_ppm_reports():
                     pass
     except Exception as exc:
         abort(400, description=f'Failed to read Excel file: {exc}')
+
+    if not report_date:
+        report_date = start_date
 
     rows = []
     row_idx = 7

--- a/tests/test_upload_ppm_reports.py
+++ b/tests/test_upload_ppm_reports.py
@@ -78,7 +78,7 @@ def test_upload_ppm_date_range(app_instance, monkeypatch):
     assert resp.status_code == 201
     assert resp.get_json()["inserted"] == 1
     assert captured["rows"][0]["Line"] == "L2"
-    assert captured["rows"][0]["Report Date"] == "2024-07-02"
+    assert captured["rows"][0]["Report Date"] == "2024-07-01"
 
 
 def test_upload_ppm_mixed_case_filename(app_instance, monkeypatch):
@@ -107,4 +107,4 @@ def test_upload_ppm_mixed_case_filename(app_instance, monkeypatch):
     assert resp.status_code == 201
     assert resp.get_json()["inserted"] == 1
     assert captured["rows"][0]["Line"] == "l3"
-    assert captured["rows"][0]["Report Date"] == "2024-07-02"
+    assert captured["rows"][0]["Report Date"] == "2024-07-01"


### PR DESCRIPTION
## Summary
- derive PPM report date from workbook contents when available and fall back to filename's first date
- adjust PPM upload tests to expect start date for date-range filenames

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8086045448325aa22a39728a0e305