### PR TITLE
Adjust MOAT report dates to original run day

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,11 @@ The file contains a simple JSON array of strings, e.g.:
 
 Administrators can modify this file at any time to adjust the ignore list
 without rebuilding the application.
+
+## MOAT Report Date Offset
+
+Historically, MOAT records store the `Report Date` one day after the actual run
+date.  Until those historical values are corrected, the application subtracts
+one day from `Report Date` whenever MOAT data is retrieved.  This temporary
+offset allows PPM analysis and reports to display the original run date.  Once
+the source data is fixed, remove the offset logic in `app/db.py`.

--- a/tests/test_moat_date_offset.py
+++ b/tests/test_moat_date_offset.py
@@ -1,0 +1,14 @@
+from app.db import _apply_report_date_offset
+
+
+def test_apply_report_date_offset():
+    rows = [
+        {"Report Date": "2024-08-02"},
+        {"report_date": "2024-08-03"},
+        {"Report Date": None},
+    ]
+    adjusted = _apply_report_date_offset(rows)
+    assert adjusted[0]["Report Date"] == "2024-08-01"
+    assert adjusted[1]["report_date"] == "2024-08-02"
+    # None values should be left untouched
+    assert adjusted[2]["Report Date"] is None


### PR DESCRIPTION
## Summary
- offset MOAT `Report Date` by one day via new helper
- use the offset for all MOAT queries to show original run date
- document the temporary offset workaround and add unit test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c8099bd56083258f1f1b8286663f31