### PR TITLE
Normalize assembly search names

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -118,7 +118,7 @@ def _split_model_name(name: str) -> tuple[str, str]:
 
 def _norm(value: str) -> str:
     """Normalize an assembly or program string for comparisons."""
-    return value.strip().lower() if value else ""
+    return re.sub(r'[-\s]+', ' ', value).strip().lower() if value else ''
 
 
 def _aggregate_forecast(
@@ -764,7 +764,7 @@ def api_assemblies_search():
     """Search distinct assembly names across MOAT and AOI data."""
     if 'username' not in session:
         return redirect(url_for('auth.login'))
-    q = (request.args.get('q') or '').strip().lower()
+    q = _norm(request.args.get('q') or '')
     assemblies: set[str] = set()
     moat_rows, moat_error = fetch_moat()
     if moat_error:
@@ -773,7 +773,8 @@ def api_assemblies_search():
         asm, _ = _split_model_name(row.get("Model Name"))
         if not asm:
             continue
-        if q and q not in asm.lower():
+        asm_norm = _norm(asm)
+        if q and q not in asm_norm:
             continue
         assemblies.add(asm)
     aoi_rows, aoi_error = fetch_aoi_reports()
@@ -783,7 +784,8 @@ def api_assemblies_search():
         asm = row.get("Assembly") or ""
         if not asm:
             continue
-        if q and q not in asm.lower():
+        asm_norm = _norm(asm)
+        if q and q not in asm_norm:
             continue
         assemblies.add(asm)
     return jsonify(sorted(assemblies))

--- a/tests/test_assembly_forecast.py
+++ b/tests/test_assembly_forecast.py
@@ -63,6 +63,21 @@ def test_api_assemblies_search(app_instance, monkeypatch):
         assert resp.get_json() == ["Asm1", "Asm2", "Asm3"]
 
 
+def test_api_assemblies_search_normalization(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        from app.main import routes
+
+        moat_rows = [{"Model Name": "Asm-4 SMT"}]
+        aoi_rows = [{"Assembly": "Asm 4", "Program": "SMT"}]
+        monkeypatch.setattr(routes, "fetch_moat", lambda: (moat_rows, None))
+        monkeypatch.setattr(routes, "fetch_aoi_reports", lambda: (aoi_rows, None))
+        _login(client)
+        resp = client.get("/api/assemblies/search?q=asm-4")
+        assert resp.status_code == 200
+        assert set(resp.get_json()) == {"Asm-4", "Asm 4"}
+
+
 def test_api_assemblies_forecast(app_instance, monkeypatch):
     client = app_instance.test_client()
     with app_instance.app_context():


### PR DESCRIPTION
## Summary
- Normalize strings by replacing hyphens with spaces and collapsing whitespace
- Use common normalization in assembly search API instead of raw `.lower()` calls
- Test assembly search normalization with hyphen and space variations

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c80bc132b883258b668e089599bfd8