### PR TITLE
Include AOI-only program metrics in assembly forecasts

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -217,11 +217,10 @@ def _aggregate_forecast(
         false_calls = 0.0
         inspected = 0.0
         rejected = 0.0
-        prog_keys = {
-            p for a, p in moat_map.keys() if a == asm_key
-        } & {
-            p for a, p in aoi_map.keys() if a == asm_key
-        }
+        prog_keys = (
+            {p for a, p in moat_map.keys() if a == asm_key}
+            | {p for a, p in aoi_map.keys() if a == asm_key}
+        )
         for prog in prog_keys:
             m = moat_map.get((asm_key, prog), {})
             a = aoi_map.get((asm_key, prog), {})


### PR DESCRIPTION
## Summary
- aggregate AOI and MOAT program data using a union of program keys
- handle assemblies with only AOI data in forecast calculations
- test assemblies that appear only in AOI data to ensure metrics populate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c80ff744f88325b1bb2d1f5110906c