### PR TITLE
Normalize MOAT model name matching for assembly forecast

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -146,11 +146,18 @@ def _aggregate_forecast(
         lambda: {"boards": 0.0, "falseCalls": 0.0}
     )
     for row in moat_rows or []:
-        asm_guess, prog_guess = _split_model_name(row.get("Model Name"))
+        model_name = row.get("Model Name") or ""
+        model_norm = _norm(model_name)
+        asm_guess, prog_guess = _split_model_name(model_name)
         asm_raw = row.get("Assembly") or row.get("Model") or asm_guess
         prog_raw = row.get("Program") or row.get("program") or prog_guess
         cust_raw = row.get("Customer") or row.get("customer") or ""
-        asm_key = _norm(asm_raw)
+
+        matched_asm = next(
+            (a for a in sorted(by_name.keys(), key=len, reverse=True) if a in model_norm),
+            None,
+        )
+        asm_key = matched_asm or _norm(asm_raw)
         prog_key = _norm(prog_raw)
         if asm_key and cust_raw and asm_key not in assembly_customer:
             assembly_customer[asm_key] = cust_raw


### PR DESCRIPTION
## Summary
- Match MOAT rows to selected assemblies by normalizing `Model Name` and using the detected assembly as the key
- Aggregate MOAT data across rows where multiple model names refer to the same assembly
- Add regression test ensuring forecast includes MOAT rows with extra tokens in `Model Name`

## Testing
- `PYTHONPATH=. pytest tests/test_assembly_forecast.py::test_api_assemblies_forecast_model_name_with_revision -q`
- `PYTHONPATH=. pytest tests/test_assembly_forecast.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c814e4dd088325adfef348ef9809f6