### PR TITLE
Refactor dashboard previews and centralize Chart.js

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,160 +1,145 @@
-function renderPreview(endpoint, canvasId, infoId) {
+function renderLinePreview({ endpoint, canvasId, infoId, onClickHref }) {
+  const canvas = document.getElementById(canvasId);
+  if (!canvas) return;
+
+  if (onClickHref) {
+    canvas.style.cursor = 'pointer';
+    canvas.addEventListener('click', () => {
+      window.location.href = onClickHref;
+    });
+  }
+
+  if (!endpoint) return;
+
   fetch(endpoint)
-    .then((res) => res.json())
+    .then((res) => {
+      if (!res.ok) {
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      return res.json();
+    })
     .then((data) => {
-      const ctx = document.getElementById(canvasId).getContext('2d');
-      const hLinePlugin = {
-        id: 'hLines',
-        afterDraw(chart) {
-          const {
-            ctx,
-            chartArea: { left, right, top, bottom },
-            scales,
-          } = chart;
-          const yScale = scales.y;
-          if (!yScale) return;
-          const lines = [
-            { value: 20, color: 'red' },
-            { value: 10, color: 'gold' },
-            { value: 5, color: 'green' },
-          ];
-          ctx.save();
-          ctx.setLineDash([4, 4]);
-          lines.forEach((ln) => {
-            const y = yScale.getPixelForValue(ln.value);
-            if (y >= top && y <= bottom) {
-              ctx.beginPath();
-              ctx.moveTo(left, y);
-              ctx.lineTo(right, y);
-              ctx.strokeStyle = ln.color;
-              ctx.lineWidth = 1;
-              ctx.stroke();
-            }
-          });
-          ctx.restore();
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const isFalseCallPreview = Array.isArray(data.avg_false_calls);
+      const labels = (isFalseCallPreview ? data.models : data.labels) || [];
+      const values = (isFalseCallPreview
+        ? data.avg_false_calls
+        : data.yields || data.avg_false_calls || data.values) || [];
+
+      const chartConfig = {
+        type: 'line',
+        data: {
+          labels,
+          datasets: [
+            {
+              data: values,
+              borderColor: '#000',
+              backgroundColor: '#000',
+              pointBackgroundColor: '#000',
+              pointBorderColor: '#000',
+              pointRadius: 3,
+              fill: false,
+              tension: 0,
+              borderWidth: 2,
+            },
+          ],
         },
+        options: {
+          responsive: true,
+          maintainAspectRatio: false,
+          plugins: {
+            legend: { display: false },
+            tooltip: { enabled: false },
+          },
+          elements: {
+            line: { borderWidth: 2 },
+          },
+          scales: isFalseCallPreview
+            ? {
+                x: { display: false, grid: { display: false }, ticks: { display: false } },
+                y: { beginAtZero: true, display: false, grid: { display: false }, ticks: { display: false } },
+              }
+            : {
+                x: {
+                  display: true,
+                  title: { display: true, text: 'Date' },
+                  grid: { display: false },
+                  ticks: { display: true },
+                  border: { display: true },
+                },
+                y: {
+                  beginAtZero: true,
+                  display: true,
+                  title: { display: true, text: 'Yield' },
+                  grid: { display: false },
+                  ticks: { display: true },
+                  border: { display: true },
+                },
+              },
+        },
+        plugins: [],
       };
 
-      // eslint-disable-next-line no-undef
-      const chart = new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: data.models,
-          datasets: [
-            {
-              data: data.avg_false_calls,
-              borderColor: '#000',
-              backgroundColor: '#000',
-              pointBackgroundColor: '#000',
-              pointBorderColor: '#000',
-              pointRadius: 3,
-              fill: false,
-              tension: 0,
-              borderWidth: 2,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: { display: false },
-            tooltip: { enabled: false },
-          },
-          elements: {
-            line: { borderWidth: 2 },
-          },
-          scales: {
-            x: { display: false, grid: { display: false }, ticks: { display: false } },
-            y: { beginAtZero: true, display: false, grid: { display: false }, ticks: { display: false } },
-          },
-        },
-        plugins: [hLinePlugin],
-      });
+      if (isFalseCallPreview) {
+        chartConfig.plugins.push({
+          id: 'hLines',
+          afterDraw(chart) {
+            const {
+              ctx: chartCtx,
+              chartArea: { left, right, top, bottom },
+              scales,
+            } = chart;
+            const yScale = scales.y;
+            if (!yScale) return;
 
-      const infoEl = document.getElementById(infoId);
-      if (infoEl) {
-        const avg = data.overall_avg ? data.overall_avg.toFixed(2) : '0';
-        infoEl.textContent = `${data.start_date} to ${data.end_date} | Avg False Calls: ${avg}`;
-      }
+            const lines = [
+              { value: 20, color: 'red' },
+              { value: 10, color: 'gold' },
+              { value: 5, color: 'green' },
+            ];
 
-      // Navigate to PPM Analysis if "many" points are above red (20)
-      const overRed = (data.avg_false_calls || []).filter((v) => Number(v) > 20).length;
-      const canvas = document.getElementById(canvasId);
-      if (canvas) {
-        canvas.style.cursor = overRed >= 3 ? 'pointer' : 'default';
-        canvas.addEventListener('click', () => {
-          if (overRed >= 3) {
-            window.location.href = '/analysis/ppm?preset=avg_false_calls_per_assembly';
-          }
+            chartCtx.save();
+            chartCtx.setLineDash([4, 4]);
+            lines.forEach((line) => {
+              const y = yScale.getPixelForValue(line.value);
+              if (y >= top && y <= bottom) {
+                chartCtx.beginPath();
+                chartCtx.moveTo(left, y);
+                chartCtx.lineTo(right, y);
+                chartCtx.strokeStyle = line.color;
+                chartCtx.lineWidth = 1;
+                chartCtx.stroke();
+              }
+            });
+            chartCtx.restore();
+          },
         });
       }
-    })
-    .catch((err) => {
-      // eslint-disable-next-line no-console
-      console.error('Failed to load preview', err);
-    });
-}
-
-function renderYieldPreview(endpoint, canvasId, infoId) {
-  fetch(endpoint)
-    .then((res) => res.json())
-    .then((data) => {
-      const ctx = document.getElementById(canvasId).getContext('2d');
 
       // eslint-disable-next-line no-undef
-      new Chart(ctx, {
-        type: 'line',
-        data: {
-          labels: data.labels,
-          datasets: [
-            {
-              data: data.yields,
-              borderColor: '#000',
-              backgroundColor: '#000',
-              pointBackgroundColor: '#000',
-              pointBorderColor: '#000',
-              pointRadius: 3,
-              fill: false,
-              tension: 0,
-              borderWidth: 2,
-            },
-          ],
-        },
-        options: {
-          responsive: true,
-          maintainAspectRatio: false,
-          plugins: {
-            legend: { display: false },
-            tooltip: { enabled: false },
-          },
-          elements: {
-            line: { borderWidth: 2 },
-          },
-          scales: {
-            x: {
-              display: true,
-              title: { display: true, text: 'Date' },
-              grid: { display: false },
-              ticks: { display: true },
-              border: { display: true },
-            },
-            y: {
-              beginAtZero: true,
-              display: true,
-              title: { display: true, text: 'Yield' },
-              grid: { display: false },
-              ticks: { display: true },
-              border: { display: true },
-            },
-          },
-        },
-      });
+      new Chart(ctx, chartConfig);
 
-      const infoEl = document.getElementById(infoId);
-      if (infoEl) {
-        const avg = data.avg_yield ? data.avg_yield.toFixed(1) : '0';
-        infoEl.textContent = `${data.start_date} to ${data.end_date} | Avg Yield: ${avg}%`;
+      if (infoId) {
+        const infoEl = document.getElementById(infoId);
+        if (infoEl) {
+          if (isFalseCallPreview) {
+            const avg = Number.isFinite(Number(data.overall_avg))
+              ? Number(data.overall_avg).toFixed(2)
+              : '0';
+            const start = data.start_date || 'N/A';
+            const end = data.end_date || 'N/A';
+            infoEl.textContent = `${start} to ${end} | Avg False Calls: ${avg}`;
+          } else if (data && Object.prototype.hasOwnProperty.call(data, 'avg_yield')) {
+            const avgYield = Number.isFinite(Number(data.avg_yield))
+              ? Number(data.avg_yield).toFixed(1)
+              : '0';
+            const start = data.start_date || 'N/A';
+            const end = data.end_date || 'N/A';
+            infoEl.textContent = `${start} to ${end} | Avg Yield: ${avgYield}%`;
+          }
+        }
       }
     })
     .catch((err) => {
@@ -164,15 +149,32 @@ function renderYieldPreview(endpoint, canvasId, infoId) {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-  if (document.getElementById('moatChart')) {
-    renderPreview('/moat_preview', 'moatChart', 'moat-info');
-  }
-  if (document.getElementById('aoi-preview')) {
-    renderYieldPreview('/aoi_preview', 'aoiChart', 'aoi-info');
-  }
-  if (document.getElementById('fi-preview')) {
-    renderYieldPreview('/fi_preview', 'fiChart', 'fi-info');
-  }
+  const previewConfigs = [
+    {
+      endpoint: '/moat_preview',
+      canvasId: 'ppmAnalysisPreview',
+      onClickHref: '/analysis/ppm?preset=avg_false_calls_per_assembly',
+    },
+    {
+      endpoint: '/aoi_preview',
+      canvasId: 'aoiFiAnalysisPreview',
+      onClickHref: '/analysis/aoi/grades/view',
+    },
+    {
+      endpoint: '/fi_preview',
+      canvasId: 'dailyReportsPreview',
+      onClickHref: '/reports/aoi_daily',
+    },
+    {
+      canvasId: 'assemblyForecastPreview',
+      onClickHref: '/tools/assembly-forecast',
+    },
+  ];
+
+  previewConfigs.forEach((config) => {
+    renderLinePreview(config);
+  });
+
   // Auto-hide navbar on scroll down; reveal on scroll up
   const nav = document.querySelector('.navbar');
   if (nav) {

--- a/templates/base.html
+++ b/templates/base.html
@@ -59,6 +59,7 @@
   <div class="content">
     {% block content %}{% endblock %}
   </div>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script src="{{ url_for('static', filename='js/main.js') }}"></script>
   {% block scripts %}{% endblock %}
 </body>

--- a/templates/home.html
+++ b/templates/home.html
@@ -30,6 +30,3 @@
 </section>
 {% endblock %}
 
-{% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-{% endblock %}


### PR DESCRIPTION
## Summary
- replace the separate preview helpers with a configurable `renderLinePreview` that handles endpoint fetching, chart rendering, and click navigation for dashboard canvases
- drive preview initialization through a configuration list so each card wires up its fetch target and destination route
- load Chart.js from the base template so it is available before `main.js`, removing the redundant include from the home page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8894cd4008325a82ac357434373f2