### PR TITLE
Fix dashboard preview canvas height

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -202,6 +202,10 @@ h2 {
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
 }
 
+.dashboard-card canvas {
+  height: 140px !important;
+}
+
 .dashboard-card:hover {
   border-color: var(--accent);
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
## Summary
- set dashboard preview canvases in dashboard cards to a fixed 140px height to prevent stretching during initial render

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68c89f0957cc8325b080e709b340e4c4