### PR TITLE
Validate required fields during AOI/FI uploads

### DIFF
--- a/tests/test_upload_fi_reports.py
+++ b/tests/test_upload_fi_reports.py
@@ -59,3 +59,45 @@ def test_upload_fi_reports_headers_with_spaces(app_instance, monkeypatch):
     assert resp.get_json()["inserted"] == 1
     assert captured[0]["Date"] == "07/01/2024"
     assert captured[0]["Quantity Inspected"] == "10"
+
+
+def test_upload_fi_reports_missing_required_data(app_instance):
+    client = app_instance.test_client()
+    csv_content = (
+        "Date,Shift,Operator,Customer,Assembly,Rev,Job Number,Quantity Inspected,Quantity Rejected,Additional Information\n"
+        "07/01/2024,1,Alice,ACME,A1,R1,J1,10,1,\n"
+        "07/01/2024,1,,ACME,A1,R1,J2,5,0,\n"
+        ",,,,,,,,,\n"
+    )
+    data = {"file": (io.BytesIO(csv_content.encode("utf-8")), "fi.csv")}
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/fi_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 400
+    body = resp.get_data(as_text=True)
+    assert "Missing required data in rows - Row 3: Operator" in body
+
+
+def test_upload_fi_reports_ignores_blank_rows(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = []
+
+    def fake_insert(row):
+        captured.append(row)
+        return {}, None
+
+    monkeypatch.setattr(routes, "insert_fi_report", fake_insert)
+    csv_content = (
+        "Date,Shift,Operator,Customer,Assembly,Rev,Job Number,Quantity Inspected,Quantity Rejected,Additional Information\n"
+        "07/01/2024,1,Alice,ACME,A1,R1,J1,10,1,\n"
+        ",,,,,,,,,\n"
+    )
+    data = {"file": (io.BytesIO(csv_content.encode("utf-8")), "fi.csv")}
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/fi_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured[0]["Operator"] == "Alice"


### PR DESCRIPTION
## Summary
- validate AOI and FI upload rows to ensure required fields are populated
- skip entirely blank rows when processing uploads and surface descriptive errors
- add tests covering missing data handling and blank row skipping for both AOI and FI uploads

## Testing
- PYTHONPATH=. pytest tests/test_upload_aoi_reports.py tests/test_upload_fi_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68caab4a766483259e7fa3d976b70383