### PR TITLE
Handle optional headers in AOI and FI uploads

### DIFF
--- a/tests/test_upload_fi_reports.py
+++ b/tests/test_upload_fi_reports.py
@@ -59,6 +59,8 @@ def test_upload_fi_reports_headers_with_spaces(app_instance, monkeypatch):
     assert resp.get_json()["inserted"] == 1
     assert captured[0]["Date"] == "07/01/2024"
     assert captured[0]["Quantity Inspected"] == "10"
+    assert captured[0]["Rev"] == "R1"
+    assert captured[0]["Additional Information"] == "Info"
 
 
 def test_upload_fi_reports_missing_required_data(app_instance):
@@ -101,3 +103,28 @@ def test_upload_fi_reports_ignores_blank_rows(app_instance, monkeypatch):
     assert resp.status_code == 201
     assert resp.get_json()["inserted"] == 1
     assert captured[0]["Operator"] == "Alice"
+
+
+def test_upload_fi_reports_without_optional_headers(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = []
+
+    def fake_insert(row):
+        captured.append(row)
+        return {}, None
+
+    monkeypatch.setattr(routes, "insert_fi_report", fake_insert)
+    csv_content = (
+        "Date,Shift,Operator,Customer,Assembly,Job Number,Quantity Inspected,Quantity Rejected\n"
+        "07/01/2024,1,Alice,ACME,A1,J1,10,1\n"
+    )
+    data = {"file": (io.BytesIO(csv_content.encode("utf-8")), "fi.csv")}
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/fi_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured[0]["Customer"] == "ACME"
+    assert "Rev" not in captured[0]
+    assert "Additional Information" not in captured[0]


### PR DESCRIPTION
## Summary
- allow the CSV header comparison helper to accept optional columns so order validation ignores missing optional fields
- update the AOI and FI upload handlers to treat "Rev" and "Additional Information" as optional while still capturing values when provided
- add regression tests that cover uploads with and without the optional headers for both AOI and FI CSVs

## Testing
- PYTHONPATH=. pytest tests/test_upload_aoi_reports.py tests/test_upload_fi_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68caae34b08483259f4735d89d0704ac