### PR TITLE
Enable Supabase-backed user management from admin console

### DIFF
--- a/app/auth/routes.py
+++ b/app/auth/routes.py
@@ -2,14 +2,17 @@ import os
 
 from flask import (
     Blueprint,
+    current_app,
+    flash,
+    redirect,
     render_template,
     request,
-    redirect,
-    url_for,
     session,
-    flash,
+    url_for,
 )
 from werkzeug.security import check_password_hash, generate_password_hash
+
+from app import db as db_module
 
 auth_bp = Blueprint('auth', __name__)
 
@@ -18,14 +21,50 @@ REQUIRED_USERS = {
     'ADMIN': 'ADMIN_PASSWORD',
 }
 
-USERS = {
-    role: generate_password_hash(os.environ[env_key])
-    for role, env_key in REQUIRED_USERS.items()
-}
 
-optional_employee_password = os.environ.get('EMPLOYEE_PASSWORD')
-if optional_employee_password:
-    USERS['EMPLOYEE'] = generate_password_hash(optional_employee_password)
+def _load_environment_users() -> dict[str, str]:
+    users = {
+        role: generate_password_hash(os.environ[env_key])
+        for role, env_key in REQUIRED_USERS.items()
+        if os.environ.get(env_key)
+    }
+    optional_employee_password = os.environ.get('EMPLOYEE_PASSWORD')
+    if optional_employee_password:
+        users['EMPLOYEE'] = generate_password_hash(optional_employee_password)
+    return users
+
+
+ENVIRONMENT_USERS = _load_environment_users()
+
+
+def _fetch_supabase_user(username: str) -> tuple[dict | None, str | None]:
+    supabase = current_app.config.get('SUPABASE')
+    if not supabase or not hasattr(supabase, 'table'):
+        return None, None
+
+    try:
+        return db_module.fetch_app_user_credentials(username)
+    except Exception as exc:  # pragma: no cover - defensive guard
+        current_app.logger.warning("Failed to fetch Supabase credentials: %s", exc)
+        return None, str(exc)
+
+
+def _employee_login_enabled() -> bool:
+    if 'EMPLOYEE' in ENVIRONMENT_USERS:
+        return True
+
+    try:
+        records, error = db_module.fetch_app_users()
+    except Exception:  # pragma: no cover - defensive guard
+        return False
+
+    if error or not records:
+        return False
+
+    for record in records:
+        if (record.get('role') or '').upper() == 'EMPLOYEE':
+            return True
+    return False
 
 
 @auth_bp.route('/', methods=['GET', 'POST'])
@@ -35,19 +74,42 @@ def login():
         submitted_username = (request.form.get('username') or '').strip()
         password = request.form.get('password') or ''
         normalized_username = submitted_username.upper()
+
+        supabase_user = None
+        supabase_error = None
+        if submitted_username:
+            supabase_user, supabase_error = _fetch_supabase_user(submitted_username)
+
+        if supabase_user and supabase_user.get('password_hash'):
+            if check_password_hash(supabase_user['password_hash'], password):
+                session['user_id'] = supabase_user.get('id')
+                session['username'] = (
+                    supabase_user.get('display_name')
+                    or supabase_user.get('username')
+                    or submitted_username
+                )
+                session['role'] = (supabase_user.get('role') or 'USER').upper()
+                return redirect(url_for('main.home'))
+        elif supabase_error:
+            flash(
+                'Supabase user lookup failed; falling back to built-in credentials.',
+                'warning',
+            )
+
         if (
-            normalized_username in USERS
-            and check_password_hash(USERS[normalized_username], password)
+            normalized_username in ENVIRONMENT_USERS
+            and check_password_hash(ENVIRONMENT_USERS[normalized_username], password)
         ):
             session['username'] = submitted_username or normalized_username
             session['role'] = normalized_username
             return redirect(url_for('main.home'))
         flash('Invalid credentials.')
-    return render_template('login.html', employee_enabled='EMPLOYEE' in USERS)
+    return render_template('login.html', employee_enabled=_employee_login_enabled())
 
 
 @auth_bp.route('/logout')
 def logout():
     session.pop('username', None)
     session.pop('role', None)
+    session.pop('user_id', None)
     return redirect(url_for('auth.login'))

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -234,6 +234,7 @@
           <thead>
             <tr>
               <th>Username</th>
+              <th>Display Name</th>
               <th>Role</th>
               <th>Source</th>
             </tr>
@@ -242,6 +243,7 @@
             {% for user in users %}
             <tr>
               <td>{{ user.username }}</td>
+              <td>{{ user.display_name or user.username }}</td>
               <td>{{ user.role }}</td>
               <td>{{ user.source }}</td>
             </tr>
@@ -251,19 +253,22 @@
       </div>
 
       <form class="config-form" method="post" action="{{ url_for('main.admin_user_action') }}">
-        <h3>Request User Change</h3>
+        <h3>Create Account</h3>
         <div class="form-grid">
           <label>
             Username
             <input type="text" name="username" placeholder="New user name">
           </label>
           <label>
+            Display Name
+            <input type="text" name="display_name" placeholder="Shown in navigation" autocomplete="name">
+          </label>
+          <label>
             Role
             <select name="role">
-              <option value="viewer">Viewer</option>
-              <option value="analyst">Analyst</option>
-              <option value="manager">Manager</option>
-              <option value="admin">Administrator</option>
+              {% for code, label in user_role_choices %}
+              <option value="{{ code }}">{{ label }}</option>
+              {% endfor %}
             </select>
           </label>
           <label>
@@ -273,10 +278,25 @@
         </div>
         <div class="form-actions">
           <input type="hidden" name="action" value="invite">
-          <button type="submit" class="primary">Submit Request</button>
+          <button type="submit" class="primary">Create User</button>
           <button type="button" class="ghost" onclick="this.closest('form').reset()">Clear</button>
         </div>
-        <p class="form-helper">User accounts are loaded from environment variables (e.g., <code>ADMIN_PASSWORD</code>, <code>USER_PASSWORD</code>). To fully automate this panel, store credentials in a Supabase table such as <code>app_users</code> and update authentication to read from it.</p>
+        <p class="form-helper">Accounts created here are stored in the Supabase table <code>app_users</code>. New users must change their temporary password the first time they sign in.</p>
+      </form>
+
+      <form class="config-form" method="post" action="{{ url_for('main.admin_user_action') }}">
+        <h3>Remove Account</h3>
+        <div class="form-grid">
+          <label>
+            Username
+            <input type="text" name="username" placeholder="Existing user name">
+          </label>
+        </div>
+        <div class="form-actions">
+          <input type="hidden" name="action" value="remove">
+          <button type="submit" class="ghost">Remove User</button>
+        </div>
+        <p class="form-helper">Only Supabase-managed accounts can be removed here. Environment-backed users such as <code>ADMIN</code> remain available for emergency access.</p>
       </form>
     </article>
 

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -1,0 +1,205 @@
+import os
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from werkzeug.security import check_password_hash, generate_password_hash
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+
+
+class FakeQuery:
+    def __init__(self, supabase, table_name):
+        self.supabase = supabase
+        self.table_name = table_name
+        self._operation = None
+        self._payload = None
+        self._filters = []
+        self._limit = None
+        self._select = "*"
+
+    def select(self, columns="*"):
+        self._operation = "select"
+        self._select = columns
+        return self
+
+    def insert(self, rows):
+        self._operation = "insert"
+        self._payload = rows
+        return self
+
+    def delete(self):
+        self._operation = "delete"
+        return self
+
+    def eq(self, column, value):
+        self._filters.append(("eq", column, value))
+        return self
+
+    def order(self, *args, **kwargs):
+        return self
+
+    def limit(self, value):
+        self._limit = value
+        return self
+
+    def execute(self):
+        table = self.supabase.tables.setdefault(self.table_name, [])
+        if self._operation == "select":
+            data = list(table)
+            for op, column, value in self._filters:
+                if op == "eq":
+                    data = [row for row in data if row.get(column) == value]
+            if self._limit is not None:
+                data = data[: self._limit]
+            if self._select != "*":
+                columns = [col.strip() for col in self._select.split(",")]
+                data = [
+                    {col: row.get(col) for col in columns if col in row}
+                    for row in data
+                ]
+            return SimpleNamespace(data=data, count=len(data))
+        if self._operation == "insert":
+            rows = self._payload
+            if isinstance(rows, dict):
+                rows = [rows]
+            inserted = []
+            for row in rows:
+                new_row = row.copy()
+                new_row.setdefault(
+                    "id", f"fake-{len(table) + len(inserted) + 1}"
+                )
+                table.append(new_row)
+                inserted.append(new_row)
+            return SimpleNamespace(data=inserted, count=len(inserted))
+        if self._operation == "delete":
+            deleted = []
+            remaining = []
+            for row in table:
+                match = True
+                for op, column, value in self._filters:
+                    if op == "eq" and row.get(column) != value:
+                        match = False
+                        break
+                if match and self._filters:
+                    deleted.append(row)
+                else:
+                    remaining.append(row)
+            if not self._filters:
+                deleted = table[:]
+                remaining = []
+            self.supabase.tables[self.table_name] = remaining
+            return SimpleNamespace(data=deleted, count=len(deleted))
+        return SimpleNamespace(data=None, count=None)
+
+
+class FakeSupabase:
+    def __init__(self):
+        self.tables: dict[str, list[dict]] = {}
+
+    def table(self, name):
+        return FakeQuery(self, name)
+
+
+@pytest.fixture
+def admin_app(monkeypatch):
+    fake_supabase = FakeSupabase()
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: fake_supabase)
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    app.testing = True
+    return app, fake_supabase
+
+
+def _login_admin(client):
+    with client.session_transaction() as sess:
+        sess["username"] = "ADMIN"
+        sess["role"] = "ADMIN"
+
+
+def test_admin_can_create_supabase_user(admin_app):
+    app, supabase = admin_app
+    client = app.test_client()
+    _login_admin(client)
+
+    response = client.post(
+        "/admin/users",
+        data={
+            "action": "invite",
+            "username": "analyst",
+            "display_name": "Ana Analyst",
+            "role": "ANALYST",
+            "temporary_password": "s3cret",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    stored = supabase.tables.get("app_users", [])
+    assert len(stored) == 1
+    user = stored[0]
+    assert user["username"] == "analyst"
+    assert user["display_name"] == "Ana Analyst"
+    assert user["role"] == "ANALYST"
+    assert user.get("must_reset_password") is True
+    assert check_password_hash(user["password_hash"], "s3cret")
+
+
+def test_admin_can_remove_supabase_user(admin_app):
+    app, supabase = admin_app
+    supabase.tables["app_users"] = [
+        {
+            "id": "fake-1",
+            "username": "tempuser",
+            "display_name": "Temp User",
+            "role": "USER",
+            "password_hash": generate_password_hash("temp"),
+        }
+    ]
+    client = app.test_client()
+    _login_admin(client)
+
+    response = client.post(
+        "/admin/users",
+        data={"action": "remove", "username": "tempuser"},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert supabase.tables["app_users"] == []
+    assert b"has been removed" in response.data
+
+
+def test_login_uses_supabase_accounts(admin_app):
+    app, supabase = admin_app
+    supabase.tables["app_users"] = [
+        {
+            "id": "fake-42",
+            "username": "analyst",
+            "display_name": "Ana Analyst",
+            "role": "ANALYST",
+            "password_hash": generate_password_hash("s3cret"),
+        }
+    ]
+    client = app.test_client()
+
+    response = client.post(
+        "/login",
+        data={"username": "Analyst", "password": "s3cret"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith("/home")
+    with client.session_transaction() as sess:
+        assert sess["username"] == "Ana Analyst"
+        assert sess["role"] == "ANALYST"


### PR DESCRIPTION
## Summary
- add Supabase helpers for listing, creating, and removing `app_users`, and fall back to environment accounts during login
- wire the admin console to show Supabase accounts, create new users with reset-required passwords, and remove existing Supabase users
- cover the new flows with integration-style tests that exercise the admin endpoints and Supabase-powered login

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68cd5e52376c8325a83fee676a4e1604