### PR TITLE
Display Supabase users on login form

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -11,10 +11,17 @@
     <form method="post">
       <label for="username">Username</label>
       <select name="username" id="username">
-        <option value="USER">USER</option>
-        <option value="ADMIN">ADMIN</option>
-        {% if employee_enabled %}
-        <option value="EMPLOYEE">EMPLOYEE</option>
+        {% if supabase_users %}
+          {% for username, display_name in supabase_users %}
+          <option value="{{ username }}">{{ display_name }}</option>
+          {% endfor %}
+        {% else %}
+          {% for username in environment_users %}
+          <option value="{{ username }}">{{ username }}</option>
+          {% endfor %}
+          {% if employee_enabled and 'EMPLOYEE' not in environment_users %}
+          <option value="EMPLOYEE">EMPLOYEE</option>
+          {% endif %}
         {% endif %}
       </select>
       <label for="password">Password</label>

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -192,6 +192,10 @@ def test_login_uses_supabase_accounts(admin_app):
     ]
     client = app.test_client()
 
+    get_response = client.get("/login")
+    assert get_response.status_code == 200
+    assert b"Ana Analyst" in get_response.data
+
     response = client.post(
         "/login",
         data={"username": "Analyst", "password": "s3cret"},


### PR DESCRIPTION
## Summary
- load Supabase users when rendering the login form and pass them to the template
- update the login template to show Supabase display names while falling back to built-in accounts
- extend the authentication test to confirm Supabase display names appear on the login page

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cd6cc4fbe08325be276000b3957e2f