### PR TITLE
Stop forcing password reset for admin-invited users

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -633,14 +633,13 @@ def admin_user_action():
                     'display_name': display_name or username,
                     'role': role,
                     'password_hash': generate_password_hash(temporary_password),
-                    'must_reset_password': True,
                 }
                 inserted, error = insert_app_user(payload)
                 if error:
                     flash(error, 'error')
                 else:
                     flash(
-                        f"User '{username}' has been created and must reset their password on next login.",
+                        f"User '{username}' has been created with the provided temporary password.",
                         'success',
                     )
     elif action in {'remove', 'delete', 'deactivate'}:

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -144,13 +144,14 @@ def test_admin_can_create_supabase_user(admin_app):
     )
 
     assert response.status_code == 200
+    assert b"has been created with the provided temporary password." in response.data
     stored = supabase.tables.get("app_users", [])
     assert len(stored) == 1
     user = stored[0]
     assert user["username"] == "analyst"
     assert user["display_name"] == "Ana Analyst"
     assert user["role"] == "ANALYST"
-    assert user.get("must_reset_password") is True
+    assert user.get("must_reset_password") in (None, False)
     assert check_password_hash(user["password_hash"], "s3cret")
 
 


### PR DESCRIPTION
## Summary
- remove the `must_reset_password` flag from admin-created user payloads
- update the admin success flash message to reflect the new behavior
- adjust the admin user management test expectations accordingly

## Testing
- pytest tests/test_admin_user_management.py

------
https://chatgpt.com/codex/tasks/task_e_68cd6da2c86083259b67dc1f166da4f4