### PR TITLE
Remove beforeunload session end trigger

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -304,9 +304,9 @@ document.addEventListener('DOMContentLoaded', () => {
       tracker.recordClick(eventName, context);
     });
 
-    window.addEventListener('beforeunload', () => {
-      tracker.end('page-unload', { useBeacon: true });
-    });
+    // Session tracking should only end on explicit sign-outs triggered via
+    // data-track-session-end="true" elements. Removing the beforeunload
+    // listener prevents refreshes from prematurely closing the session.
   }
 
   // Auto-hide navbar on scroll down; reveal on scroll up


### PR DESCRIPTION
## Summary
- remove the beforeunload handler so tracking sessions only end when a logout control marked with data-track-session-end triggers it
- document the intent inline to keep tracker.end from firing on refresh

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cdb06586c48325a4499fc17f8b1e93