### PR TITLE
Redesign integrated report form with Supabase defect catalog

### DIFF
--- a/static/css/integrated_report.css
+++ b/static/css/integrated_report.css
@@ -1,0 +1,260 @@
+.integrated-report-page {
+  max-width: 1200px;
+  margin: 24px auto;
+  padding: 32px;
+  background: var(--surface);
+  border: var(--border-thin) solid var(--border-muted);
+  box-shadow: var(--shadow-ambient);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.ir-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 24px;
+  border: var(--border-thin) solid var(--border-muted);
+  background: var(--muted);
+  padding: 20px;
+}
+
+.ir-header-text h1 {
+  font-size: 1.65rem;
+  margin-bottom: 8px;
+}
+
+.ir-subtitle {
+  color: var(--ink-subtle);
+  font-size: 0.95rem;
+  margin: 0;
+}
+
+.ir-header-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 12px;
+  min-width: 260px;
+}
+
+.ir-header-meta label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.85rem;
+  gap: 6px;
+}
+
+.ir-header-meta input,
+.ir-header-meta select {
+  font-size: 1rem;
+  padding: 10px;
+  border: var(--border-thick) solid var(--border-muted);
+  background: var(--surface);
+}
+
+.ir-section {
+  border: var(--border-thick) solid var(--border-muted);
+  background: var(--surface);
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ir-section--info {
+  gap: 20px;
+}
+
+.ir-section-title {
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.ir-section-desc {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink-subtle);
+}
+
+.ir-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.ir-field-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+}
+
+.ir-field-grid--compact {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.ir-field-grid--full {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.ir-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.ir-field--wide {
+  min-height: 100%;
+}
+
+.ir-field-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.ir-field-grid input,
+.ir-field-grid select,
+.ir-field-grid textarea {
+  padding: 10px;
+  border: var(--border-thick) solid var(--border-muted);
+  background: var(--surface-alt);
+  font-size: 1rem;
+  min-height: 44px;
+}
+
+.ir-field-grid textarea {
+  resize: vertical;
+}
+
+.integrated-report-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) 1fr;
+  gap: 24px;
+}
+
+.ir-defect-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ir-defect-table-wrapper {
+  border: var(--border-thick) solid var(--border-muted);
+  background: var(--muted);
+  max-height: 420px;
+  overflow: auto;
+}
+
+.ir-defect-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.ir-defect-table th,
+.ir-defect-table td {
+  border-bottom: var(--border-thin) solid var(--border-muted);
+  padding: 8px 12px;
+  text-align: left;
+  font-size: 0.9rem;
+}
+
+.ir-defect-table tbody tr:nth-child(even) {
+  background: var(--surface);
+}
+
+.ir-defect-table tbody tr.is-placeholder td {
+  text-align: center;
+  font-style: italic;
+  color: var(--ink-subtle);
+}
+
+.ir-refresh {
+  border: none;
+  background: var(--accent);
+  color: var(--surface);
+  padding: 8px 14px;
+  border-radius: 4px;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+}
+
+.ir-refresh:hover,
+.ir-refresh:focus {
+  background: var(--accent-strong);
+}
+
+.ir-defect-status {
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.ir-defect-status[data-tone='success'] {
+  color: #0b8457;
+}
+
+.ir-defect-status[data-tone='error'] {
+  color: var(--danger);
+}
+
+.ir-defect-status[data-tone='info'] {
+  color: var(--ink-subtle);
+}
+
+.ir-legacy {
+  border: var(--border-thick) solid var(--border-muted);
+  background: var(--muted);
+  padding: 0 20px 20px;
+}
+
+.ir-legacy > summary {
+  font-weight: 600;
+  padding: 16px 0;
+  cursor: pointer;
+}
+
+.ir-legacy-content {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.ir-legacy-note {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--ink-subtle);
+}
+
+@media (max-width: 1024px) {
+  .integrated-report-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ir-defect-table-wrapper {
+    max-height: none;
+  }
+}
+
+@media (max-width: 640px) {
+  .integrated-report-page {
+    padding: 20px;
+  }
+
+  .ir-header {
+    padding: 16px;
+  }
+
+  .ir-field-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .ir-field-grid--compact,
+  .ir-field-grid--full {
+    grid-template-columns: 1fr;
+  }
+}

--- a/static/js/employee.js
+++ b/static/js/employee.js
@@ -69,23 +69,34 @@ function setupAoiArea(container) {
       }
       const payload = await response.json();
       const rawDefects = Array.isArray(payload && payload.defects) ? payload.defects : [];
-      const unique = Array.from(new Set(
-        rawDefects
-          .filter((value) => value !== null && value !== undefined)
-          .map((value) => String(value).trim())
-          .filter(Boolean)
-      ));
-      unique.sort((a, b) => a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' }));
+      const unique = [];
+      const seen = new Set();
+      rawDefects.forEach((item) => {
+        if (!item || typeof item !== 'object') return;
+        const rawId = item.id;
+        const rawName = item.name;
+        const id = rawId === undefined || rawId === null ? '' : String(rawId).trim();
+        const name = rawName === undefined || rawName === null ? '' : String(rawName).trim();
+        if (!id) return;
+        const key = id.toLowerCase();
+        if (seen.has(key)) return;
+        seen.add(key);
+        unique.push({ id, name });
+      });
+      unique.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
       if (!unique.length) {
         setDefectPlaceholder('No defects available', true);
         return;
       }
       setDefectPlaceholder('Select defect', false);
       const fragment = document.createDocumentFragment();
-      unique.forEach((value) => {
+      unique.forEach(({ id, name }) => {
         const option = document.createElement('option');
-        option.value = value;
-        option.textContent = value;
+        option.value = id;
+        option.textContent = name ? `${id} — ${name}` : id;
+        if (name) {
+          option.dataset.defectName = name;
+        }
         fragment.appendChild(option);
       });
       defectSelect.appendChild(fragment);

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,11 +1,142 @@
 import { showSpinner, hideSpinner } from './utils.js';
 
+function normalizeDefectRecords(rawList) {
+  const records = [];
+  const seen = new Set();
+  (rawList || []).forEach((item) => {
+    if (!item || typeof item !== 'object') return;
+    const rawId = item.id;
+    const rawName = item.name;
+    const id = rawId === undefined || rawId === null ? '' : String(rawId).trim();
+    const name = rawName === undefined || rawName === null ? '' : String(rawName).trim();
+    if (!id) return;
+    const key = id.toLowerCase();
+    if (seen.has(key)) return;
+    seen.add(key);
+    records.push({ id, name });
+  });
+  records.sort((a, b) => a.id.localeCompare(b.id, undefined, { numeric: true, sensitivity: 'base' }));
+  return records;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
+  const defectTableBody = document.querySelector('[data-defect-body]');
+  const reasonSelect = document.getElementById('rejection-reason');
+  const defectStatus = document.querySelector('[data-defect-status]');
+  const defectRefresh = document.querySelector('[data-defect-refresh]');
   const runBtn = document.getElementById('run-report');
   const downloadControls = document.getElementById('download-controls');
   const downloadBtn = document.getElementById('download-report');
   let reportData = null;
   let yieldChart, operatorChart, modelChart, fcVsNgChart, fcNgRatioChart;
+
+  function setDefectStatus(message, tone = 'info') {
+    if (!defectStatus) return;
+    if (!message) {
+      defectStatus.textContent = '';
+      defectStatus.hidden = true;
+      defectStatus.dataset.tone = '';
+      return;
+    }
+    defectStatus.textContent = message;
+    defectStatus.dataset.tone = tone;
+    defectStatus.hidden = false;
+  }
+
+  function renderDefectOptions(defects) {
+    if (!reasonSelect) return;
+    reasonSelect.innerHTML = '';
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.disabled = true;
+    placeholder.selected = true;
+    placeholder.defaultSelected = true;
+    if (!defects.length) {
+      placeholder.textContent = 'No defects available';
+      reasonSelect.disabled = true;
+    } else {
+      placeholder.textContent = 'Select reason for rejection';
+      reasonSelect.disabled = false;
+    }
+    reasonSelect.appendChild(placeholder);
+    defects.forEach(({ id, name }) => {
+      const option = document.createElement('option');
+      option.value = id;
+      option.textContent = name ? `${id} — ${name}` : id;
+      if (name) {
+        option.dataset.defectName = name;
+      }
+      reasonSelect.appendChild(option);
+    });
+  }
+
+  function renderDefectTable(defects) {
+    if (!defectTableBody) return;
+    defectTableBody.innerHTML = '';
+    if (!defects.length) {
+      const row = document.createElement('tr');
+      row.classList.add('is-placeholder');
+      const cell = document.createElement('td');
+      cell.colSpan = 2;
+      cell.textContent = 'No defects available';
+      row.appendChild(cell);
+      defectTableBody.appendChild(row);
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    defects.forEach(({ id, name }) => {
+      const row = document.createElement('tr');
+      const idCell = document.createElement('td');
+      idCell.textContent = id;
+      const nameCell = document.createElement('td');
+      nameCell.textContent = name || '—';
+      row.appendChild(idCell);
+      row.appendChild(nameCell);
+      fragment.appendChild(row);
+    });
+    defectTableBody.appendChild(fragment);
+  }
+
+  async function loadDefectCatalog({ showFeedback = false } = {}) {
+    if (!defectTableBody && !reasonSelect) return;
+    if (showFeedback) {
+      setDefectStatus('Refreshing defect catalog…', 'info');
+    }
+    try {
+      const response = await fetch('/api/defects');
+      if (!response.ok) {
+        throw new Error('Failed to fetch defects');
+      }
+      const payload = await response.json();
+      const defects = normalizeDefectRecords(payload && payload.defects);
+      renderDefectOptions(defects);
+      renderDefectTable(defects);
+      if (defects.length) {
+        setDefectStatus(`Loaded ${defects.length} defect${defects.length === 1 ? '' : 's'} from Supabase.`, 'success');
+      } else {
+        setDefectStatus('No defects are defined in Supabase.', 'info');
+      }
+    } catch (error) {
+      renderDefectOptions([]);
+      if (reasonSelect && reasonSelect.options.length) {
+        reasonSelect.options[0].textContent = 'Unable to load defects';
+        reasonSelect.disabled = true;
+      }
+      renderDefectTable([]);
+      if (defectTableBody && defectTableBody.firstChild) {
+        defectTableBody.firstChild.firstChild.textContent = 'Unable to load defects';
+      }
+      setDefectStatus('Unable to load defect catalog. Try again later.', 'error');
+    }
+  }
+
+  if (defectTableBody || reasonSelect) {
+    loadDefectCatalog();
+  }
+
+  defectRefresh?.addEventListener('click', () => {
+    loadDefectCatalog({ showFeedback: true });
+  });
 
   if (downloadControls) downloadControls.style.display = 'none';
 

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -1,103 +1,291 @@
 {% extends 'base.html' %}
 
+{% block extra_head %}
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/integrated_report.css') }}">
+{% endblock %}
+
 {% block content %}
-<h2>AOI Integrated Report</h2>
+<div class="integrated-report-page">
+  <header class="ir-header">
+    <div class="ir-header-text">
+      <h1>AOI Integrated Report</h1>
+      <p class="ir-subtitle">Document inspection findings with the same layout as the paper intake form.</p>
+    </div>
+    <div class="ir-header-meta">
+      <label>
+        Report Date
+        <input type="date" id="report-date" name="report-date">
+      </label>
+      <label>
+        Prepared By
+        <input type="text" id="prepared-by" name="prepared-by" placeholder="Name">
+      </label>
+    </div>
+  </header>
 
-<div class="section-card">
-  <div class="field-row">
-    <div class="field">
-      <label for="start-date">Start Date</label>
-      <input type="date" id="start-date" />
+  <section class="ir-section ir-section--info">
+    <h2 class="ir-section-title">Job &amp; Schedule Information</h2>
+    <div class="ir-field-grid">
+      <label>
+        Customer
+        <input type="text" id="customer" name="customer">
+      </label>
+      <label>
+        Program
+        <input type="text" id="program" name="program">
+      </label>
+      <label>
+        Assembly
+        <input type="text" id="assembly" name="assembly">
+      </label>
+      <label>
+        Job Number
+        <input type="text" id="job-number" name="job-number">
+      </label>
     </div>
-    <div class="field">
-      <label for="end-date">End Date</label>
-      <input type="date" id="end-date" />
+    <div class="ir-field-grid">
+      <label>
+        Production Line
+        <input type="text" id="line" name="line">
+      </label>
+      <label>
+        Shift
+        <select id="shift" name="shift">
+          <option value="" selected disabled>Select shift</option>
+          <option value="1st">1st</option>
+          <option value="2nd">2nd</option>
+          <option value="3rd">3rd</option>
+        </select>
+      </label>
+      <label>
+        Lot / Work Order
+        <input type="text" id="lot" name="lot">
+      </label>
+      <label>
+        Inspector
+        <input type="text" id="inspector" name="inspector">
+      </label>
     </div>
-    <button type="button" id="run-report">Run</button>
+    <div class="ir-field-grid">
+      <label>
+        Inspection Start
+        <input type="date" id="inspection-start" name="inspection-start">
+      </label>
+      <label>
+        Inspection End
+        <input type="date" id="inspection-end" name="inspection-end">
+      </label>
+      <label>
+        Time In
+        <input type="time" id="time-in" name="time-in">
+      </label>
+      <label>
+        Time Out
+        <input type="time" id="time-out" name="time-out">
+      </label>
+    </div>
+  </section>
+
+  <div class="integrated-report-grid">
+    <aside class="ir-defect-panel">
+      <div class="ir-section">
+        <div class="ir-section-header">
+          <h2 class="ir-section-title">Defect Reference</h2>
+          <button type="button" class="ir-refresh" data-defect-refresh>Refresh</button>
+        </div>
+        <p class="ir-section-desc">Codes remain synchronised with the reason-for-rejection selector.</p>
+        <div class="ir-defect-table-wrapper">
+          <table id="defect-catalog" class="ir-defect-table">
+            <thead>
+              <tr>
+                <th scope="col">ID</th>
+                <th scope="col">Name</th>
+              </tr>
+            </thead>
+            <tbody data-defect-body>
+              <tr class="is-placeholder">
+                <td colspan="2">Loading defects…</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="ir-defect-status" data-defect-status hidden></p>
+      </div>
+    </aside>
+
+    <section class="ir-form-panel">
+      <div class="ir-section">
+        <h2 class="ir-section-title">Inspection Summary</h2>
+        <div class="ir-field-grid ir-field-grid--compact">
+          <label>
+            Boards Inspected
+            <input type="number" id="boards-inspected" name="boards-inspected" min="0" step="1">
+          </label>
+          <label>
+            Boards Rejected
+            <input type="number" id="boards-rejected" name="boards-rejected" min="0" step="1">
+          </label>
+          <label>
+            Rework Quantity
+            <input type="number" id="rework-qty" name="rework-qty" min="0" step="1">
+          </label>
+          <label>
+            Lot Status
+            <input type="text" id="lot-status" name="lot-status" placeholder="Accept / Rework / Scrap">
+          </label>
+        </div>
+        <div class="ir-field-grid ir-field-grid--full">
+          <label class="ir-field ir-field--wide">
+            Reason for Rejection
+            <select id="rejection-reason" name="rejection-reason" data-defect-select disabled>
+              <option value="" selected disabled>Loading defects…</option>
+            </select>
+          </label>
+          <label class="ir-field ir-field--wide">
+            Defect Notes
+            <textarea id="defect-notes" name="defect-notes" rows="3" placeholder="Summarise location, symptoms, or tooling"></textarea>
+          </label>
+        </div>
+        <div class="ir-field-grid ir-field-grid--full">
+          <label class="ir-field ir-field--wide">
+            Corrective Action
+            <textarea id="corrective-action" name="corrective-action" rows="3"></textarea>
+          </label>
+        </div>
+      </div>
+
+      <div class="ir-section">
+        <h2 class="ir-section-title">Verification &amp; Follow-up</h2>
+        <div class="ir-field-grid ir-field-grid--compact">
+          <label>
+            QA Sign-off
+            <input type="text" id="qa-signoff" name="qa-signoff" placeholder="Initials or name">
+          </label>
+          <label>
+            Completion Date
+            <input type="date" id="completion-date" name="completion-date">
+          </label>
+          <label>
+            Follow-up Owner
+            <input type="text" id="follow-up-owner" name="follow-up-owner">
+          </label>
+          <label>
+            Follow-up Due
+            <input type="date" id="follow-up-due" name="follow-up-due">
+          </label>
+        </div>
+        <div class="ir-field-grid ir-field-grid--full">
+          <label class="ir-field ir-field--wide">
+            Additional Notes
+            <textarea id="additional-notes" name="additional-notes" rows="3" placeholder="Use this space for communication or escalation details."></textarea>
+          </label>
+        </div>
+      </div>
+    </section>
   </div>
-</div>
 
-  <details id="charts" class="section-card">
-    <summary>Preview Charts</summary>
-    <div>
-      <div class="chart-block">
-        <canvas id="yieldTrendChart"></canvas>
-        <div class="chart-summary">
-          <p id="yieldTrendDesc"></p>
-          <table id="yieldTrendTable" class="data-table"><tbody></tbody></table>
+  <details class="ir-legacy">
+    <summary>Legacy analytics &amp; exports</summary>
+    <div class="ir-legacy-content">
+      <p class="ir-legacy-note">The previous interactive workflow remains available here for teams that still depend on the charts or exports.</p>
+      <div class="section-card">
+        <div class="field-row">
+          <div class="field">
+            <label for="start-date">Start Date</label>
+            <input type="date" id="start-date" />
+          </div>
+          <div class="field">
+            <label for="end-date">End Date</label>
+            <input type="date" id="end-date" />
+          </div>
+          <button type="button" id="run-report">Run</button>
         </div>
       </div>
-      <div class="chart-block">
-        <canvas id="operatorRejectChart"></canvas>
-        <div class="chart-summary">
-          <p id="operatorRejectDesc"></p>
-          <table id="operatorRejectTable" class="data-table">
-            <thead>
-              <tr>
-                <th>Operator</th>
-                <th>Inspected</th>
-                <th>Rejected</th>
-                <th>Reject %</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
+
+      <details id="charts" class="section-card">
+        <summary>Preview Charts</summary>
+        <div>
+          <div class="chart-block">
+            <canvas id="yieldTrendChart"></canvas>
+            <div class="chart-summary">
+              <p id="yieldTrendDesc"></p>
+              <table id="yieldTrendTable" class="data-table"><tbody></tbody></table>
+            </div>
+          </div>
+          <div class="chart-block">
+            <canvas id="operatorRejectChart"></canvas>
+            <div class="chart-summary">
+              <p id="operatorRejectDesc"></p>
+              <table id="operatorRejectTable" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Operator</th>
+                    <th>Inspected</th>
+                    <th>Rejected</th>
+                    <th>Reject %</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
+          <div class="chart-block">
+            <canvas id="modelFalseCallsChart"></canvas>
+            <div class="chart-summary">
+              <p id="modelFalseCallsDesc"></p>
+              <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
+            </div>
+          </div>
+          <div class="chart-block">
+            <canvas id="fcVsNgRateChart"></canvas>
+            <div class="chart-summary">
+              <p id="fcVsNgDesc"></p>
+              <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
+            </div>
+          </div>
+          <div class="chart-block">
+            <canvas id="fcNgRatioChart"></canvas>
+            <div class="chart-summary">
+              <p id="fcNgRatioDesc"></p>
+              <table id="fcNgRatioTable" class="data-table">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th>FalseCall Parts</th>
+                    <th>NG Parts</th>
+                    <th>FC/NG Ratio</th>
+                  </tr>
+                </thead>
+                <tbody></tbody>
+              </table>
+            </div>
+          </div>
         </div>
-      </div>
-      <div class="chart-block">
-        <canvas id="modelFalseCallsChart"></canvas>
-        <div class="chart-summary">
-          <p id="modelFalseCallsDesc"></p>
-          <table id="problem-assemblies" class="data-table"><tbody></tbody></table>
+      </details>
+
+      <div class="field-row" id="download-controls">
+        <div class="field">
+          <label for="file-format">Format</label>
+          <select id="file-format">
+            <option value="pdf">pdf</option>
+            <option value="xlsx">xlsx</option>
+            <option value="html">html</option>
+          </select>
         </div>
-      </div>
-      <div class="chart-block">
-        <canvas id="fcVsNgRateChart"></canvas>
-        <div class="chart-summary">
-          <p id="fcVsNgDesc"></p>
-          <table id="fcVsNgRateTable" class="data-table"><tbody></tbody></table>
+        <div class="field">
+          <label for="include-cover">Cover Page</label>
+          <input type="checkbox" id="include-cover" checked />
         </div>
-      </div>
-      <div class="chart-block">
-        <canvas id="fcNgRatioChart"></canvas>
-        <div class="chart-summary">
-          <p id="fcNgRatioDesc"></p>
-          <table id="fcNgRatioTable" class="data-table">
-            <thead>
-              <tr>
-                <th>Model</th>
-                <th>FalseCall Parts</th>
-                <th>NG Parts</th>
-                <th>FC/NG Ratio</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
+        <button id="download-report">Download</button>
+        <span class="spinner" id="download-spinner" hidden></span>
+        <button id="email-report">Email Report</button>
       </div>
     </div>
   </details>
-
-<div class="field-row" id="download-controls">
-  <div class="field">
-    <label for="file-format">Format</label>
-    <select id="file-format">
-      <option value="pdf">pdf</option>
-      <option value="xlsx">xlsx</option>
-      <option value="html">html</option>
-    </select>
-  </div>
-  <div class="field">
-    <label for="include-cover">Cover Page</label>
-    <input type="checkbox" id="include-cover" checked />
-  </div>
-  <button id="download-report">Download</button>
-  <span class="spinner" id="download-spinner" hidden></span>
-  <button id="email-report">Email Report</button>
 </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-<script type="module" src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>
+  {{ super() }}
+  <script type="module" src="{{ url_for('static', filename='js/integrated_report.js') }}"></script>
 {% endblock %}

--- a/tests/test_employee_aoi_defects.py
+++ b/tests/test_employee_aoi_defects.py
@@ -60,11 +60,11 @@ def _login_employee(client):
 def test_employee_defect_endpoint_returns_unique_ids(employee_app):
     app, supabase = employee_app
     supabase.tables['defect'] = [
-        {'id': 'DEF-2'},
-        {'id': 'DEF-1'},
-        {'id': 'DEF-2'},
-        {'id': None},
-        {'id': '   '},
+        {'id': 'DEF-2', 'name': 'Solder Bridge'},
+        {'id': 'DEF-1', 'name': 'Component Shift'},
+        {'id': 'DEF-2', 'name': 'Solder Bridge'},
+        {'id': None, 'name': 'Ignore'},
+        {'id': '   ', 'name': 'Whitespace'},
     ]
 
     client = app.test_client()
@@ -73,7 +73,12 @@ def test_employee_defect_endpoint_returns_unique_ids(employee_app):
 
     assert response.status_code == 200
     payload = response.get_json()
-    assert payload == {'defects': ['DEF-1', 'DEF-2']}
+    assert payload == {
+        'defects': [
+            {'id': 'DEF-1', 'name': 'Component Shift'},
+            {'id': 'DEF-2', 'name': 'Solder Bridge'},
+        ]
+    }
 
 
 def test_employee_submission_validates_defect_selection(employee_app, monkeypatch):


### PR DESCRIPTION
## Summary
- redesign the integrated report page with a static form layout that mirrors the paper template while keeping legacy charts hidden behind a details panel
- add a Supabase-backed defect catalog helper and shared API endpoint so both the integrated form and employee portal use the same ID/name data
- populate the reason-for-rejection select and new defect reference table from the Supabase catalog

## Testing
- pytest tests/test_employee_aoi_defects.py

------
https://chatgpt.com/codex/tasks/task_e_68cdb0d0a1b883259a056051f5c2a5a4