### PR TITLE
Handle missing WeasyPrint dependencies during PDF exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,15 @@ Remove the helper once the source data is fixed.
    ```
    This FastAPI service powers external integrations that require operator grade
    calculations.
+
+### WeasyPrint native dependencies
+PDF exports rely on [WeasyPrint](https://weasyprint.org/), which in turn needs
+platform-specific libraries for font handling and rendering. Install the native
+dependencies before attempting to generate Integrated, Operator, or AOI Daily
+report PDFs:
+
+- **macOS (Homebrew):** `brew install cairo gobject-introspection pango`
+- **Debian/Ubuntu:** `sudo apt-get install libcairo2 libgdk-pixbuf2.0-0 libpango-1.0-0 gir1.2-pango-1.0`
+
+Once the packages are present, `pip install -r requirements.txt` will install
+WeasyPrint and the Flask endpoints will be able to stream PDF responses.

--- a/app/main/pdf_utils.py
+++ b/app/main/pdf_utils.py
@@ -1,0 +1,40 @@
+"""Utilities for generating PDFs via WeasyPrint."""
+from __future__ import annotations
+
+
+class PdfGenerationError(RuntimeError):
+    """Raised when WeasyPrint cannot generate a PDF due to missing libraries."""
+
+
+_REQUIRED_NATIVE_DEPS_MESSAGE = (
+    "Unable to generate PDF exports because WeasyPrint's native dependencies "
+    "are missing. Install the Pango, GObject, and Cairo libraries to enable PDF "
+    "generation."
+)
+
+
+def render_html_to_pdf(html: str, base_url: str | None = None) -> bytes:
+    """Render HTML content to PDF bytes using WeasyPrint.
+
+    Args:
+        html: The HTML string to convert into a PDF document.
+        base_url: The base URL used by WeasyPrint to resolve relative assets.
+
+    Raises:
+        PdfGenerationError: If WeasyPrint or its native dependencies are not
+            available on the system.
+    """
+
+    try:
+        from weasyprint import HTML
+        from weasyprint.text.fonts import FontConfiguration
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_REQUIRED_NATIVE_DEPS_MESSAGE) from exc
+
+    try:
+        font_config = FontConfiguration()
+        return HTML(string=html, base_url=base_url).write_pdf(
+            font_config=font_config
+        )
+    except OSError as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_REQUIRED_NATIVE_DEPS_MESSAGE) from exc

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -62,6 +62,7 @@ from app.db import (
 )
 
 from app.grades import calculate_aoi_grades
+from app.main.pdf_utils import PdfGenerationError, render_html_to_pdf
 from app.auth import routes as auth_routes
 from fi_utils import parse_fi_rejections
 
@@ -2349,11 +2350,10 @@ def export_integrated_report():
     )
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(font_config=font_config)
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{start_str}_{end_str}_aoiIR.pdf"
         return send_file(
             io.BytesIO(pdf),
@@ -2413,11 +2413,10 @@ def export_aoi_daily_report():
 
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(font_config=font_config)
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{day.strftime('%y%m%d')}_aoi_daily_report.pdf"
         return send_file(
             io.BytesIO(pdf),
@@ -2882,13 +2881,10 @@ def export_operator_report():
 
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(
-            font_config=font_config
-        )
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{start_str}_{end_str}_operator_report.pdf"
         return send_file(
             io.BytesIO(pdf),

--- a/tests/test_report_exports.py
+++ b/tests/test_report_exports.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from app import create_app
+from app.main import routes
+from app.main.pdf_utils import PdfGenerationError
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def _mock_integrated_report(monkeypatch):
+    monkeypatch.setattr(routes, "build_report_payload", lambda start, end: {})
+    monkeypatch.setattr(routes, "_generate_report_charts", lambda payload: {})
+    monkeypatch.setattr(routes, "render_template", lambda template, **context: "<html></html>")
+
+
+def test_integrated_export_returns_dependency_error(app_instance, monkeypatch):
+    _mock_integrated_report(monkeypatch)
+    message = "Install Pango, GObject, and Cairo"
+
+    def _raise_pdf_error(*args, **kwargs):
+        raise PdfGenerationError(message)
+
+    monkeypatch.setattr(routes, "render_html_to_pdf", _raise_pdf_error)
+
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        response = client.get("/reports/integrated/export?format=pdf")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload == {"message": message}


### PR DESCRIPTION
## Summary
- add a pdf_utils helper that wraps WeasyPrint usage and raises PdfGenerationError when native libraries are missing
- update integrated, AOI daily, and operator export routes to delegate to the helper and return a 503 with the descriptive message when dependencies are absent
- document the native WeasyPrint packages required on macOS and Debian/Ubuntu and add regression coverage for the error response

## Testing
- pytest tests/test_report_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68cde28a3e1083258331cf86454deab8