### PR TITLE
Support macOS library hints for PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,23 @@ Remove the helper once the source data is fixed.
    ```
    This FastAPI service powers external integrations that require operator grade
    calculations.
+
+### WeasyPrint native dependencies
+PDF exports rely on [WeasyPrint](https://weasyprint.org/), which in turn needs
+platform-specific libraries for font handling and rendering. Install the native
+dependencies before attempting to generate Integrated, Operator, or AOI Daily
+report PDFs:
+
+- **macOS (Homebrew):** `brew install cairo gobject-introspection pango`. If your
+  Homebrew prefix is non-standard (for example, when using an Apple Silicon
+  machine), set the `WEASYPRINT_NATIVE_LIB_PATHS` environment variable to point
+  to the directories or specific libraries installed by Homebrew, e.g.:
+
+  ```bash
+  export WEASYPRINT_NATIVE_LIB_PATHS="/opt/homebrew/lib"
+  ```
+
+- **Debian/Ubuntu:** `sudo apt-get install libcairo2 libgdk-pixbuf2.0-0 libpango-1.0-0 gir1.2-pango-1.0`
+
+Once the packages are present, `pip install -r requirements.txt` will install
+WeasyPrint and the Flask endpoints will be able to stream PDF responses.

--- a/app/main/pdf_utils.py
+++ b/app/main/pdf_utils.py
@@ -1,0 +1,166 @@
+"""Utilities for generating PDFs via WeasyPrint."""
+from __future__ import annotations
+
+import ctypes.util
+import os
+import platform
+from pathlib import Path
+from typing import Iterable
+
+
+class PdfGenerationError(RuntimeError):
+    """Raised when WeasyPrint cannot generate a PDF due to missing libraries."""
+
+
+_REQUIRED_NATIVE_DEPS_MESSAGE = (
+    "Unable to generate PDF exports because WeasyPrint's native dependencies "
+    "are missing. Install the Pango, GObject, and Cairo libraries (see the "
+    "README for platform-specific instructions) to enable PDF generation."
+)
+
+
+_MAC_LIBRARY_ALIASES: dict[str, tuple[str, ...]] = {
+    "libgobject-2.0-0": ("libgobject-2.0.dylib", "libgobject-2.0.0.dylib", "gobject-2.0"),
+    "libpango-1.0-0": ("libpango-1.0.dylib", "pango-1.0"),
+    "libpangocairo-1.0-0": ("libpangocairo-1.0.dylib", "pangocairo-1.0"),
+    "libcairo-2": ("libcairo.2.dylib", "libcairo.dylib", "cairo"),
+}
+
+_MAC_LIBRARY_DIR_HINTS: tuple[Path, ...] = (
+    Path("/opt/homebrew/lib"),
+    Path("/usr/local/lib"),
+    Path("/usr/local/opt/pango/lib"),
+    Path("/usr/local/opt/cairo/lib"),
+    Path("/usr/local/opt/glib/lib"),
+)
+
+_PATCHED_FIND_LIBRARY = False
+_ORIGINAL_FIND_LIBRARY = ctypes.util.find_library
+
+
+def _iter_env_library_paths() -> Iterable[Path]:
+    """Yield additional library locations from the environment."""
+
+    env_value = os.environ.get("WEASYPRINT_NATIVE_LIB_PATHS", "")
+    if not env_value:
+        return []
+
+    paths: list[Path] = []
+    for raw_path in env_value.split(os.pathsep):
+        if not raw_path:
+            continue
+        candidate = Path(raw_path).expanduser()
+        paths.append(candidate)
+    return paths
+
+
+def _mac_library_candidates(name: str) -> list[str]:
+    """Return candidate library names for macOS to satisfy Windows aliases."""
+
+    candidates: list[str] = [name]
+    if name.startswith("lib"):
+        trimmed = name[3:]
+        if trimmed:
+            candidates.append(trimmed)
+    candidates.extend(_MAC_LIBRARY_ALIASES.get(name, ()))
+
+    # Deduplicate while preserving order.
+    deduped: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate and candidate not in seen:
+            deduped.append(candidate)
+            seen.add(candidate)
+    return deduped
+
+
+def _resolve_candidate_path(directory: Path, candidate: str) -> str | None:
+    """Resolve a library candidate inside the provided directory."""
+
+    if directory.is_file():
+        if directory.name == candidate:
+            return str(directory)
+        # Allow specifying a file without the lib prefix or suffix.
+        stem_match = directory.stem == candidate or directory.stem == candidate.lstrip("lib")
+        if stem_match:
+            return str(directory)
+        return None
+
+    if not directory.is_dir():
+        return None
+
+    direct_path = directory / candidate
+    if direct_path.exists():
+        return str(direct_path)
+
+    # Try common dynamic library suffixes on macOS.
+    for suffix in (".dylib", ".so", ".bundle"):
+        with_suffix = direct_path.with_suffix(suffix)
+        if with_suffix.exists():
+            return str(with_suffix)
+    return None
+
+
+def _patched_find_library(name: str) -> str | None:
+    """macOS-aware replacement for :func:`ctypes.util.find_library`."""
+
+    if platform.system() != "Darwin":
+        return _ORIGINAL_FIND_LIBRARY(name)
+
+    candidates = _mac_library_candidates(name)
+    for candidate in candidates:
+        located = _ORIGINAL_FIND_LIBRARY(candidate)
+        if located:
+            return located
+
+    search_paths: list[Path] = list(_iter_env_library_paths())
+    search_paths.extend(path for path in _MAC_LIBRARY_DIR_HINTS if path.exists())
+
+    for candidate in candidates:
+        for directory in search_paths:
+            resolved = _resolve_candidate_path(directory, candidate)
+            if resolved:
+                return resolved
+
+    return _ORIGINAL_FIND_LIBRARY(name)
+
+
+def _ensure_native_dependencies_configured() -> None:
+    """Ensure platform-specific configuration is applied before imports."""
+
+    global _PATCHED_FIND_LIBRARY
+    if _PATCHED_FIND_LIBRARY:
+        return
+
+    if platform.system() == "Darwin":
+        ctypes.util.find_library = _patched_find_library  # type: ignore[assignment]
+
+    _PATCHED_FIND_LIBRARY = True
+
+
+def render_html_to_pdf(html: str, base_url: str | None = None) -> bytes:
+    """Render HTML content to PDF bytes using WeasyPrint.
+
+    Args:
+        html: The HTML string to convert into a PDF document.
+        base_url: The base URL used by WeasyPrint to resolve relative assets.
+
+    Raises:
+        PdfGenerationError: If WeasyPrint or its native dependencies are not
+            available on the system.
+    """
+
+    try:
+        _ensure_native_dependencies_configured()
+        from weasyprint import HTML
+        from weasyprint.text.fonts import FontConfiguration
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_REQUIRED_NATIVE_DEPS_MESSAGE) from exc
+
+    try:
+        font_config = FontConfiguration()
+        return HTML(string=html, base_url=base_url).write_pdf(
+            font_config=font_config
+        )
+    except OSError as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_REQUIRED_NATIVE_DEPS_MESSAGE) from exc

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -62,6 +62,7 @@ from app.db import (
 )
 
 from app.grades import calculate_aoi_grades
+from app.main.pdf_utils import PdfGenerationError, render_html_to_pdf
 from app.auth import routes as auth_routes
 from fi_utils import parse_fi_rejections
 
@@ -2349,11 +2350,10 @@ def export_integrated_report():
     )
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(font_config=font_config)
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{start_str}_{end_str}_aoiIR.pdf"
         return send_file(
             io.BytesIO(pdf),
@@ -2413,11 +2413,10 @@ def export_aoi_daily_report():
 
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(font_config=font_config)
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{day.strftime('%y%m%d')}_aoi_daily_report.pdf"
         return send_file(
             io.BytesIO(pdf),
@@ -2882,13 +2881,10 @@ def export_operator_report():
 
     fmt = request.args.get('format')
     if fmt == 'pdf':
-        from weasyprint import HTML
-        from weasyprint.text.fonts import FontConfiguration
-
-        font_config = FontConfiguration()
-        pdf = HTML(string=html, base_url=request.url_root).write_pdf(
-            font_config=font_config
-        )
+        try:
+            pdf = render_html_to_pdf(html, base_url=request.url_root)
+        except PdfGenerationError as exc:
+            return jsonify({'message': str(exc)}), 503
         filename = f"{start_str}_{end_str}_operator_report.pdf"
         return send_file(
             io.BytesIO(pdf),

--- a/tests/test_pdf_utils.py
+++ b/tests/test_pdf_utils.py
@@ -1,0 +1,58 @@
+import ctypes.util
+import importlib
+
+import pytest
+
+from app.main import pdf_utils
+
+
+@pytest.fixture
+def reset_find_library():
+    """Reset ctypes.util.find_library after tests that monkeypatch it."""
+
+    original = ctypes.util.find_library
+    yield
+    ctypes.util.find_library = original
+    pdf_utils._PATCHED_FIND_LIBRARY = False
+
+
+def test_macos_env_hint_used_for_gobject(monkeypatch, tmp_path, reset_find_library):
+    # Reload the module to ensure the original finder is captured for the patch.
+    importlib.reload(pdf_utils)
+
+    libs_dir = tmp_path / "libs"
+    libs_dir.mkdir()
+    lib_path = libs_dir / "libgobject-2.0.dylib"
+    lib_path.write_text("")
+
+    monkeypatch.setenv("WEASYPRINT_NATIVE_LIB_PATHS", str(libs_dir))
+    monkeypatch.setattr(pdf_utils, "_ORIGINAL_FIND_LIBRARY", lambda name: None)
+    monkeypatch.setattr(pdf_utils.platform, "system", lambda: "Darwin")
+
+    pdf_utils._PATCHED_FIND_LIBRARY = False
+    pdf_utils._ensure_native_dependencies_configured()
+
+    resolved = ctypes.util.find_library("libgobject-2.0-0")
+    assert resolved == str(lib_path)
+
+
+def test_nonexistent_hint_falls_back(monkeypatch, reset_find_library):
+    importlib.reload(pdf_utils)
+
+    calls: list[str] = []
+
+    def fake_original(name: str) -> str | None:
+        calls.append(name)
+        return None
+
+    monkeypatch.setattr(pdf_utils, "_ORIGINAL_FIND_LIBRARY", fake_original)
+    monkeypatch.setattr(pdf_utils.platform, "system", lambda: "Darwin")
+
+    pdf_utils._PATCHED_FIND_LIBRARY = False
+    pdf_utils._ensure_native_dependencies_configured()
+
+    # Should return None when neither aliases nor hints can resolve the library.
+    result = ctypes.util.find_library("libunknown-1.0-0")
+    assert result is None
+    # Ensure the alias candidates were attempted.
+    assert "libunknown-1.0-0" in calls

--- a/tests/test_report_exports.py
+++ b/tests/test_report_exports.py
@@ -1,0 +1,49 @@
+import os
+import sys
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from app import create_app
+from app.main import routes
+from app.main.pdf_utils import PdfGenerationError, _REQUIRED_NATIVE_DEPS_MESSAGE
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def _mock_integrated_report(monkeypatch):
+    monkeypatch.setattr(routes, "build_report_payload", lambda start, end: {})
+    monkeypatch.setattr(routes, "_generate_report_charts", lambda payload: {})
+    monkeypatch.setattr(routes, "render_template", lambda template, **context: "<html></html>")
+
+
+def test_integrated_export_returns_dependency_error(app_instance, monkeypatch):
+    _mock_integrated_report(monkeypatch)
+    message = _REQUIRED_NATIVE_DEPS_MESSAGE
+
+    def _raise_pdf_error(*args, **kwargs):
+        raise PdfGenerationError(message)
+
+    monkeypatch.setattr(routes, "render_html_to_pdf", _raise_pdf_error)
+
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        response = client.get("/reports/integrated/export?format=pdf")
+
+    assert response.status_code == 503
+    payload = response.get_json()
+    assert payload == {"message": message}


### PR DESCRIPTION
## Summary
- add macOS-specific library resolution hints in the PDF utility, including support for the WEASYPRINT_NATIVE_LIB_PATHS environment variable
- update the export regression test to reuse the shared dependency message constant and add unit tests covering the macOS helper behaviour
- document how to set WEASYPRINT_NATIVE_LIB_PATHS when Homebrew installs libraries into a non-default prefix

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cde28a3e1083258331cf86454deab8