### PR TITLE
Revise report cover metadata styling

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -16,9 +16,9 @@
     --muted: #e9edf5;
     --muted-light: #f3f6fb;
     --muted-dark: #d8deeb;
-    --accent: #0d3b66;
-    --accent-strong: #06284a;
-    --accent-soft: #c5d6ea;
+    --accent: #0d9ba8;
+    --accent-strong: #0b6b74;
+    --accent-soft: #d3f0f2;
     --border: #d0d7de;
     --border-muted: #e2e8f0;
     --border-light: #f1f5f9;
@@ -105,6 +105,11 @@ header {
 header img {
     height: 48px;
     margin-right: 14px;
+}
+
+header h1 {
+    color: #fff;
+    border-bottom-color: rgba(255, 255, 255, 0.4);
 }
 
 .company-logo-pdf {

--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -8,11 +8,12 @@
     </header>
     <br />
     <div class="report-details">
-        <p><b>report_range:</b> {{ start }} - {{ end }}</p>
-        <p><b>generated_at:</b> {{ generated_at }}</p>
-        <p>{{ report_id }}</p>
-        <p><b>report author:</b> Thomas Schwartz</p>
-        <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
-        <p>{{ confidentiality }}</p>
+        <p>
+            <b>report_range:</b> {{ start }} - {{ end }}
+            &nbsp;•&nbsp;
+            <b>generated_at:</b> {{ generated_at }}
+            {% if report_id %}&nbsp;•&nbsp;{{ report_id }}{% endif %}
+            {% if confidentiality %}&nbsp;•&nbsp;{{ confidentiality }}{% endif %}
+        </p>
     </div>
 </section>


### PR DESCRIPTION
## Summary
- collapse report cover metadata into a single line and remove author/contact fields
- recolor the report theme accents to match the application's teal palette and ensure the title text renders white over the header gradient

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce0d4c500483259d9e6ac888c87e77