### PR TITLE
Separate report summaries from cover pages

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -391,6 +391,10 @@ pre,
         page-break-after: always;
     }
 
+    .summary-after-cover {
+        page-break-before: always;
+    }
+
     .combined-section {
         page-break-after: auto;
     }

--- a/templates/report/aoi_daily/cover.html
+++ b/templates/report/aoi_daily/cover.html
@@ -14,46 +14,5 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
-
-    <div class="summary section-card">
-        <h2>1st Shift Summary</h2>
-        <table class="data-table">
-            <thead>
-                <tr><th>Operator</th><th>Program</th><th>Assembly</th><th>Job Number</th><th>Quantity Inspected</th><th>Quantity Rejected</th></tr>
-            </thead>
-            <tbody>
-            {% for row in shift1 %}
-                <tr>
-                    <td>{{ row.operator }}</td>
-                    <td>{{ row.program }}</td>
-                    <td>{{ row.assembly }}</td>
-                    <td>{{ row.job }}</td>
-                    <td>{{ row.inspected }}</td>
-                    <td>{{ row.rejected }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-
-        <h2>2nd Shift Summary</h2>
-        <table class="data-table">
-            <thead>
-                <tr><th>Operator</th><th>Program</th><th>Assembly</th><th>Job Number</th><th>Quantity Inspected</th><th>Quantity Rejected</th></tr>
-            </thead>
-            <tbody>
-            {% for row in shift2 %}
-                <tr>
-                    <td>{{ row.operator }}</td>
-                    <td>{{ row.program }}</td>
-                    <td>{{ row.assembly }}</td>
-                    <td>{{ row.job }}</td>
-                    <td>{{ row.inspected }}</td>
-                    <td>{{ row.rejected }}</td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-        {% include 'report/aoi_daily/summary_toc.html' %}
-    </div>
 </section>
 

--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -10,6 +10,8 @@
         {% include 'report/aoi_daily/cover.html' %}
     {% endif %}
 
+    {% include 'report/aoi_daily/summary_toc.html' %}
+
     {% include 'report/aoi_daily/shift_summary.html' %}
     {% for asm in assemblies %}
         {% include 'report/aoi_daily/assembly_detail.html' %}

--- a/templates/report/aoi_daily/summary_toc.html
+++ b/templates/report/aoi_daily/summary_toc.html
@@ -1,9 +1,63 @@
-<div class="summary-break"></div>
-<div class="toc section-card">
-    <h2>Table of Contents</h2>
-    <ol>
-        <li><a href="#shift-summary">Shift Summary</a></li>
-        <li><a href="#assembly-history">Assembly Historical Yield</a></li>
-    </ol>
-</div>
+<section class="report-section summary-page avoid-break{% if show_cover %} summary-after-cover{% endif %}">
+    <div class="summary section-card">
+        <h2>1st Shift Summary</h2>
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Operator</th>
+                    <th>Program</th>
+                    <th>Assembly</th>
+                    <th>Job Number</th>
+                    <th>Quantity Inspected</th>
+                    <th>Quantity Rejected</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for row in shift1 %}
+                <tr>
+                    <td>{{ row.operator }}</td>
+                    <td>{{ row.program }}</td>
+                    <td>{{ row.assembly }}</td>
+                    <td>{{ row.job }}</td>
+                    <td>{{ row.inspected }}</td>
+                    <td>{{ row.rejected }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
 
+        <h2>2nd Shift Summary</h2>
+        <table class="data-table">
+            <thead>
+                <tr>
+                    <th>Operator</th>
+                    <th>Program</th>
+                    <th>Assembly</th>
+                    <th>Job Number</th>
+                    <th>Quantity Inspected</th>
+                    <th>Quantity Rejected</th>
+                </tr>
+            </thead>
+            <tbody>
+            {% for row in shift2 %}
+                <tr>
+                    <td>{{ row.operator }}</td>
+                    <td>{{ row.program }}</td>
+                    <td>{{ row.assembly }}</td>
+                    <td>{{ row.job }}</td>
+                    <td>{{ row.inspected }}</td>
+                    <td>{{ row.rejected }}</td>
+                </tr>
+            {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <div class="summary-break"></div>
+    <div class="toc section-card">
+        <h2>Table of Contents</h2>
+        <ol>
+            <li><a href="#shift-summary">Shift Summary</a></li>
+            <li><a href="#assembly-history">Assembly Historical Yield</a></li>
+        </ol>
+    </div>
+</section>

--- a/templates/report/integrated/cover.html
+++ b/templates/report/integrated/cover.html
@@ -14,31 +14,4 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
-    {% if show_summary %}
-    <div class="summary section-card">
-        <h2>Summary</h2>
-        <p class="section-desc">Provides key metrics from the reporting period.</p>
-        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
-        <p><strong>Average yield:</strong> {{ yieldSummary.avg|round(2) }}%</p>
-        <p><strong>Total boards:</strong> {{ operatorSummary.totalBoards }}</p>
-        <p><strong>Average false calls/board:</strong> {{ modelSummary.avgFalseCalls|round(2) }}</p>
-    </div>
-    <div class="summary-break"></div>
-    <div class="toc section-card">
-        <h2>Table of Contents</h2>
-        <ol>
-            <li><a href="#yield-trend">Yield Trend</a></li>
-            <li><a href="#operator-reject">Operator Reject</a></li>
-            <li><a href="#model-false-calls">Model False Calls</a></li>
-            <li><a href="#fc-vs-ng-rate">FC vs NG Rate</a></li>
-            <li><a href="#fc-ng-ratio">FC/NG Ratio</a></li>
-            <li><a href="#defect-intelligence">Defect Intelligence</a></li>
-            <li><a href="#operator-reliability">Operator Reliability</a></li>
-            <li><a href="#operator-production">Operator Production</a></li>
-            <li><a href="#low-yield-assemblies">Low Yield Assemblies</a></li>
-            <li><a href="#capa-action-register">CAPA / Action Register</a></li>
-            <li><a href="#appendix">Appendix</a></li>
-        </ol>
-    </div>
-    {% endif %}
 </section>

--- a/templates/report/integrated/index.html
+++ b/templates/report/integrated/index.html
@@ -8,7 +8,8 @@
 <body>
     {% if show_cover %}
         {% include 'report/integrated/cover.html' %}
-    {% elif show_summary %}
+    {% endif %}
+    {% if show_summary %}
         {% include 'report/summary_toc.html' %}
     {% endif %}
     {% include 'report/integrated/yield_trend.html' %}

--- a/templates/report/operator/cover.html
+++ b/templates/report/operator/cover.html
@@ -14,22 +14,4 @@
         <p><b>questions?:</b> &lt;{{ contact }}&gt;</p>
         <p>{{ confidentiality }}</p>
     </div>
-    {% if show_summary %}
-    <div class="summary section-card">
-        <h2>Summary</h2>
-        <p class="section-desc">Overview of operator performance.</p>
-        <p><strong>Date range:</strong> {{ start }} - {{ end }}</p>
-        <p><strong>Total Boards:</strong> {{ summary.totalBoards }}</p>
-        <p><strong>Average per shift:</strong> {{ summary.avgPerShift|round(2) }}</p>
-        <p><strong>Average reject rate:</strong> {{ summary.avgRejectRate|round(2) }}%</p>
-    </div>
-    <div class="summary-break"></div>
-    <div class="toc section-card">
-        <h2>Table of Contents</h2>
-        <ol>
-            <li><a href="#operator-daily">Daily Reject Rates</a></li>
-            <li><a href="#operator-assemblies">Assemblies</a></li>
-        </ol>
-    </div>
-    {% endif %}
 </section>

--- a/templates/report/operator/index.html
+++ b/templates/report/operator/index.html
@@ -8,7 +8,8 @@
 <body>
     {% if show_cover %}
         {% include 'report/operator/cover.html' %}
-    {% elif show_summary %}
+    {% endif %}
+    {% if show_summary %}
         {% include 'report/operator_summary_toc.html' %}
     {% endif %}
     {% include 'report/operator/operator_daily.html' %}

--- a/templates/report/operator_summary_toc.html
+++ b/templates/report/operator_summary_toc.html
@@ -1,4 +1,4 @@
-<section class="report-section summary-page avoid-break">
+<section class="report-section summary-page avoid-break{% if show_cover %} summary-after-cover{% endif %}">
     <div class="summary section-card">
         <h2>Summary</h2>
         <p class="section-desc">Overview of operator performance.</p>

--- a/templates/report/summary_toc.html
+++ b/templates/report/summary_toc.html
@@ -1,4 +1,4 @@
-<section class="report-section summary-page avoid-break">
+<section class="report-section summary-page avoid-break{% if show_cover %} summary-after-cover{% endif %}">
     <div class="summary section-card">
         <h2>Summary</h2>
         <p class="section-desc">Provides key metrics from the reporting period.</p>


### PR DESCRIPTION
## Summary
- ensure all report cover templates render only header and report details
- render summary and table of contents sections immediately after the cover with a forced page break when the cover is shown
- update AOI daily summary layout and automated tests to reflect the new cover/summary separation

## Testing
- pytest tests/test_export_report_rendering.py tests/test_operator_report_routes.py tests/test_aoi_daily_report.py

------
https://chatgpt.com/codex/tasks/task_e_68ce11d15ae88325a62166277129625a