### PR TITLE
Add Supabase bug report endpoints and migration

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -24,6 +24,9 @@ def create_app():
     )
     app.config["SUPABASE"] = supabase
     app.config["SUPABASE_URL"] = os.environ["SUPABASE_URL"]
+    app.config["BUG_REPORT_BUCKET"] = os.environ.get(
+        "BUG_REPORT_BUCKET", "bug-report-attachments"
+    )
 
     phrases_path = (
         os.environ.get("NON_AOI_PHRASES_FILE")

--- a/migrations/20240720_add_reporter_name_to_bug_reports.sql
+++ b/migrations/20240720_add_reporter_name_to_bug_reports.sql
@@ -1,0 +1,2 @@
+ALTER TABLE bug_reports
+    ADD COLUMN IF NOT EXISTS reporter_name text;


### PR DESCRIPTION
## Summary
- add Supabase helpers for bug report CRUD including attachment handling and timestamps
- expose JSON bug report routes for reporters and admins with Supabase storage uploads
- persist optional reporter display names via a new migration and bucket configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce188a5d9083258e02a574cff891dd