### PR TITLE
Add floating bug report chat panel

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -39,6 +39,17 @@ body {
   flex-direction: column;
 }
 
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
 h1,
 h2,
 h3 {
@@ -1391,6 +1402,275 @@ body.employee-layout .content {
   }
 
   .employee-field-grid {
+    flex-direction: column;
+  }
+}
+
+.bug-chat-container {
+  position: fixed;
+  right: 24px;
+  bottom: 24px;
+  z-index: 500;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 12px;
+}
+
+.bug-chat-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  background: var(--button-bg);
+  color: var(--surface);
+  border: none;
+  border-radius: 32px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  box-shadow: var(--shadow-soft);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.bug-chat-trigger:focus,
+.bug-chat-trigger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(13, 155, 168, 0.25);
+}
+
+.bug-chat-trigger:active {
+  transform: translateY(1px);
+  box-shadow: var(--shadow-ambient);
+}
+
+.bug-chat-container.is-open .bug-chat-trigger {
+  background: var(--accent-strong);
+}
+
+.bug-chat-panel {
+  width: 360px;
+  max-width: calc(100vw - 32px);
+  max-height: calc(100vh - 120px);
+  background: var(--surface);
+  border-radius: 18px;
+  box-shadow: var(--shadow-soft);
+  border: var(--border-thin) solid var(--border-muted);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.bug-chat-panel[hidden] {
+  display: none;
+}
+
+.bug-chat-container.is-open .bug-chat-panel {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.bug-chat-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 20px 24px 12px;
+  background: var(--muted);
+  border-bottom: var(--border-thin) solid var(--border-muted);
+}
+
+.bug-chat-header h2 {
+  font-size: 1.05rem;
+  margin-bottom: 4px;
+}
+
+.header-subtitle {
+  margin: 0;
+  color: var(--ink-subtle);
+  font-size: 0.85rem;
+}
+
+.bug-chat-close {
+  background: transparent;
+  border: none;
+  font-size: 1.75rem;
+  line-height: 1;
+  cursor: pointer;
+  color: var(--ink-subtle);
+}
+
+.bug-chat-close:hover,
+.bug-chat-close:focus {
+  color: var(--ink);
+}
+
+.bug-chat-body {
+  display: flex;
+  flex-direction: column;
+  padding: 16px 24px 20px;
+  gap: 16px;
+  overflow: hidden;
+}
+
+.bug-chat-messages {
+  flex: 1;
+  min-height: 80px;
+  max-height: 200px;
+  overflow-y: auto;
+  padding-right: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.bug-chat-message {
+  padding: 10px 12px;
+  border-radius: 12px;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  box-shadow: var(--shadow-ambient);
+}
+
+.bug-chat-message.system {
+  background: var(--muted);
+  color: var(--ink);
+}
+
+.bug-chat-message.user {
+  background: var(--accent-soft);
+  color: var(--ink);
+  align-self: flex-end;
+}
+
+.bug-chat-message.status {
+  background: #eef7ee;
+  color: #0f8a5f;
+}
+
+.bug-chat-message.error {
+  background: #fdeaea;
+  color: var(--danger);
+}
+
+.bug-chat-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.bug-chat-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: none;
+  padding: 0;
+  margin: 0;
+}
+
+.bug-chat-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+}
+
+.bug-chat-field input,
+.bug-chat-field textarea,
+.bug-chat-field select {
+  width: 100%;
+  border: var(--border-thin) solid var(--border-muted);
+  border-radius: 8px;
+  padding: 10px 12px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: var(--surface);
+}
+
+.bug-chat-field textarea {
+  resize: vertical;
+  min-height: 96px;
+}
+
+.bug-chat-row {
+  display: flex;
+  gap: 12px;
+}
+
+.bug-chat-row .bug-chat-field {
+  flex: 1;
+}
+
+.bug-chat-actions {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.bug-chat-submit,
+.bug-chat-reset {
+  padding: 10px 18px;
+  border-radius: 8px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.bug-chat-submit {
+  background: var(--button-bg);
+  color: var(--surface);
+}
+
+.bug-chat-submit[disabled] {
+  opacity: 0.7;
+  cursor: not-allowed;
+}
+
+.bug-chat-reset {
+  background: var(--muted);
+  color: var(--ink);
+}
+
+.bug-chat-reset:hover,
+.bug-chat-reset:focus {
+  background: var(--muted-dark);
+}
+
+.bug-chat-auth-guard {
+  border: none;
+  padding: 12px;
+  margin: 0;
+  border-radius: 8px;
+  background: #fff4d9;
+  color: #8a650f;
+  font-size: 0.9rem;
+}
+
+.bug-chat-auth-guard a {
+  color: inherit;
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .bug-chat-container {
+    right: 16px;
+    bottom: 16px;
+  }
+
+  .bug-chat-trigger {
+    padding: 10px 16px;
+  }
+
+  .bug-chat-panel {
+    width: min(100vw - 16px, 340px);
+  }
+
+  .bug-chat-row {
     flex-direction: column;
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -363,4 +363,288 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     });
   });
+
+  const chatContainer = document.getElementById('bug-chat-container');
+  if (chatContainer) {
+    const endpoint = chatContainer.dataset.endpoint;
+    const trigger = chatContainer.querySelector('.bug-chat-trigger');
+    const panel = chatContainer.querySelector('.bug-chat-panel');
+    const closeButton = chatContainer.querySelector('.bug-chat-close');
+    const messageStream = chatContainer.querySelector('.bug-chat-messages');
+    const form = chatContainer.querySelector('.bug-chat-form');
+    const fields = chatContainer.querySelector('.bug-chat-fields');
+    const authGuard = chatContainer.querySelector('.bug-chat-auth-guard');
+    const submitButton = chatContainer.querySelector('.bug-chat-submit');
+    const resetButton = chatContainer.querySelector('.bug-chat-reset');
+    const attachmentsInput = form ? form.querySelector('input[name="attachments"]') : null;
+
+    if (panel) {
+      panel.setAttribute('aria-hidden', 'true');
+    }
+
+    let isSignedIn = chatContainer.dataset.signedIn === 'true';
+    let isSubmitting = false;
+    let lastSubmissionKey = null;
+    let lastSubmissionTime = 0;
+
+    const defaultSubmitLabel = submitButton ? submitButton.textContent : '';
+    const userDisplayName = (chatContainer.dataset.username || '').trim() || 'there';
+
+    const appendMessage = (text, role = 'system') => {
+      if (!messageStream || !text) return;
+      const wrapper = document.createElement('div');
+      wrapper.classList.add('bug-chat-message');
+      if (role) {
+        wrapper.classList.add(role);
+      }
+      const paragraph = document.createElement('p');
+      paragraph.textContent = text;
+      wrapper.appendChild(paragraph);
+      messageStream.appendChild(wrapper);
+      messageStream.scrollTop = messageStream.scrollHeight;
+    };
+
+    const updateAuthState = () => {
+      if (!form) return;
+      const shouldLock = !isSignedIn;
+      if (authGuard) {
+        authGuard.hidden = !shouldLock;
+      }
+      if (fields) {
+        fields.disabled = shouldLock;
+      }
+      if (submitButton) {
+        submitButton.disabled = shouldLock || isSubmitting;
+      }
+    };
+
+    const primeConversation = () => {
+      if (messageStream) {
+        messageStream.innerHTML = '';
+      }
+      appendMessage(`Hi ${userDisplayName}!`, 'system');
+      appendMessage('Use this space to report bugs or share quick feedback with the support team.', 'system');
+      if (!isSignedIn) {
+        appendMessage('Sign in to send a new report.', 'system');
+      }
+    };
+
+    const setSubmitting = (state) => {
+      isSubmitting = state;
+      if (submitButton) {
+        submitButton.disabled = state || !isSignedIn;
+        submitButton.textContent = state ? 'Sending…' : defaultSubmitLabel;
+      }
+    };
+
+    const openPanel = () => {
+      if (!panel || !trigger) return;
+      chatContainer.classList.add('is-open');
+      panel.hidden = false;
+      panel.setAttribute('aria-hidden', 'false');
+      trigger.setAttribute('aria-expanded', 'true');
+      window.requestAnimationFrame(() => {
+        panel.focus();
+      });
+    };
+
+    const closePanel = () => {
+      if (!panel || !trigger) return;
+      chatContainer.classList.remove('is-open');
+      panel.hidden = true;
+      panel.setAttribute('aria-hidden', 'true');
+      trigger.setAttribute('aria-expanded', 'false');
+      trigger.focus();
+    };
+
+    const togglePanel = () => {
+      if (!panel) return;
+      const willOpen = panel.hasAttribute('hidden');
+      if (willOpen) openPanel();
+      else closePanel();
+    };
+
+    const buildSubmissionKey = (values) => {
+      return JSON.stringify([
+        values.title,
+        values.description,
+        values.priority,
+        values.severity,
+        values.environment,
+      ]);
+    };
+
+    const parseResponse = async (response) => {
+      const contentType = response.headers.get('content-type') || '';
+      let payload = null;
+      if (contentType.includes('application/json')) {
+        payload = await response.json().catch(() => null);
+      } else {
+        const text = await response.text().catch(() => '');
+        if (text) {
+          payload = { message: text };
+        }
+      }
+      if (!response.ok) {
+        const error = new Error(
+          (payload && (payload.message || payload.error)) || 'Unable to submit the bug report.'
+        );
+        error.status = response.status;
+        error.payload = payload;
+        throw error;
+      }
+      return payload;
+    };
+
+    const markComplete = (data) => {
+      if (submitButton) {
+        submitButton.textContent = 'Report sent';
+        submitButton.disabled = true;
+      }
+      if (fields) {
+        fields.disabled = true;
+      }
+      if (resetButton) {
+        resetButton.hidden = false;
+      }
+      const identifier = data && (data.id || data.report_id);
+      if (identifier) {
+        appendMessage(`Report #${identifier} has been submitted successfully.`, 'status');
+      } else {
+        appendMessage('Your report has been submitted successfully.', 'status');
+      }
+    };
+
+    const resetForm = () => {
+      if (!form) return;
+      form.reset();
+      if (fields) {
+        fields.disabled = !isSignedIn;
+      }
+      if (submitButton) {
+        submitButton.textContent = defaultSubmitLabel;
+        submitButton.disabled = !isSignedIn;
+      }
+      if (resetButton) {
+        resetButton.hidden = true;
+      }
+      lastSubmissionKey = null;
+      lastSubmissionTime = 0;
+      primeConversation();
+    };
+
+    if (resetButton) {
+      resetButton.addEventListener('click', () => {
+        resetForm();
+        if (!panel || panel.hasAttribute('hidden')) {
+          openPanel();
+        }
+      });
+    }
+
+    if (trigger) {
+      trigger.addEventListener('click', () => {
+        togglePanel();
+      });
+    }
+
+    if (closeButton) {
+      closeButton.addEventListener('click', () => {
+        closePanel();
+      });
+    }
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && chatContainer.classList.contains('is-open')) {
+        closePanel();
+      }
+    });
+
+    if (form && endpoint) {
+      form.addEventListener('submit', (event) => {
+        event.preventDefault();
+        if (!isSignedIn) {
+          appendMessage('Please sign in to send your report.', 'error');
+          return;
+        }
+        if (isSubmitting) {
+          return;
+        }
+
+        const formData = new FormData(form);
+        const values = {
+          title: (formData.get('title') || '').toString().trim(),
+          description: (formData.get('description') || '').toString().trim(),
+          priority: (formData.get('priority') || '').toString().trim(),
+          severity: (formData.get('severity') || '').toString().trim(),
+          environment: (formData.get('environment') || '').toString().trim(),
+        };
+
+        if (!values.title || !values.description) {
+          appendMessage('A title and description are required before submitting.', 'error');
+          return;
+        }
+
+        const submissionKey = buildSubmissionKey(values);
+        const now = Date.now();
+        if (
+          lastSubmissionKey &&
+          submissionKey === lastSubmissionKey &&
+          now - lastSubmissionTime < 15000
+        ) {
+          appendMessage(
+            'It looks like you already submitted this report. Add more details or wait a moment before trying again.',
+            'system'
+          );
+          return;
+        }
+
+        appendMessage(`"${values.title}"`, 'user');
+        if (values.description) {
+          appendMessage(values.description, 'user');
+        }
+        appendMessage('Submitting your report…', 'system');
+
+        setSubmitting(true);
+
+        const payload = new FormData();
+        payload.append('title', values.title);
+        payload.append('description', values.description);
+        if (values.priority) payload.append('priority', values.priority);
+        if (values.severity) payload.append('severity', values.severity);
+        if (values.environment) payload.append('environment', values.environment);
+        if (attachmentsInput && attachmentsInput.files) {
+          Array.from(attachmentsInput.files).forEach((file) => {
+            payload.append('attachments', file);
+          });
+        }
+
+        fetch(endpoint, {
+          method: 'POST',
+          body: payload,
+          credentials: 'same-origin',
+        })
+          .then((response) => parseResponse(response))
+          .then((data) => {
+            setSubmitting(false);
+            lastSubmissionKey = submissionKey;
+            lastSubmissionTime = Date.now();
+            markComplete(data || {});
+          })
+          .catch((error) => {
+            setSubmitting(false);
+            if (error.status === 401 || error.status === 403) {
+              isSignedIn = false;
+              updateAuthState();
+              appendMessage('Please sign in to continue.', 'error');
+              return;
+            }
+            appendMessage(error.message || 'Something went wrong while submitting your report.', 'error');
+          });
+      });
+    }
+
+    primeConversation();
+    updateAuthState();
+  }
 });

--- a/templates/base.html
+++ b/templates/base.html
@@ -76,6 +76,99 @@
   <main class="content" role="main">
     {% block content %}{% endblock %}
   </main>
+
+  <div
+    id="bug-chat-container"
+    class="bug-chat-container"
+    data-endpoint="{{ url_for('main.submit_bug_report') }}"
+    data-signed-in="{{ 'true' if user_id else 'false' }}"
+    data-username="{{ username or '' }}"
+  >
+    <button
+      type="button"
+      class="bug-chat-trigger"
+      aria-haspopup="dialog"
+      aria-controls="bug-chat-panel"
+      aria-expanded="false"
+    >
+      <span class="trigger-label">Report an issue</span>
+      <span class="trigger-icon" aria-hidden="true">&#9993;</span>
+    </button>
+
+    <section
+      id="bug-chat-panel"
+      class="bug-chat-panel"
+      role="dialog"
+      aria-modal="false"
+      aria-labelledby="bug-chat-title"
+      tabindex="-1"
+      hidden
+    >
+      <header class="bug-chat-header">
+        <div class="header-text">
+          <h2 id="bug-chat-title">Need help or found a bug?</h2>
+          <p class="header-subtitle">Send a quick note to the support team.</p>
+        </div>
+        <button type="button" class="bug-chat-close" aria-label="Close support chat">&times;</button>
+      </header>
+
+      <div class="bug-chat-body">
+        <div class="bug-chat-messages" aria-live="polite" aria-atomic="false"></div>
+
+        <form class="bug-chat-form" novalidate>
+          <fieldset class="bug-chat-auth-guard" hidden>
+            <legend>Sign in required</legend>
+            <p class="auth-message">Please <a href="{{ url_for('auth.login') }}">sign in</a> to report an issue.</p>
+          </fieldset>
+
+          <fieldset class="bug-chat-fields">
+            <legend class="sr-only">Bug details</legend>
+            <label class="bug-chat-field">
+              <span>Title</span>
+              <input type="text" name="title" required maxlength="200" autocomplete="off" />
+            </label>
+            <label class="bug-chat-field">
+              <span>Description</span>
+              <textarea name="description" rows="4" required></textarea>
+            </label>
+            <div class="bug-chat-row">
+              <label class="bug-chat-field">
+                <span>Priority</span>
+                <select name="priority">
+                  <option value="">Select</option>
+                  <option value="low">Low</option>
+                  <option value="medium">Medium</option>
+                  <option value="high">High</option>
+                </select>
+              </label>
+              <label class="bug-chat-field">
+                <span>Severity</span>
+                <select name="severity">
+                  <option value="">Select</option>
+                  <option value="minor">Minor</option>
+                  <option value="major">Major</option>
+                  <option value="critical">Critical</option>
+                </select>
+              </label>
+            </div>
+            <label class="bug-chat-field">
+              <span>Environment</span>
+              <input type="text" name="environment" placeholder="e.g. Production, Chrome 124" />
+            </label>
+            <label class="bug-chat-field">
+              <span>Attachments (optional)</span>
+              <input type="file" name="attachments" multiple />
+            </label>
+          </fieldset>
+
+          <div class="bug-chat-actions">
+            <button type="submit" class="bug-chat-submit">Send report</button>
+            <button type="button" class="bug-chat-reset" hidden>Report another issue</button>
+          </div>
+        </form>
+      </div>
+    </section>
+  </div>
   {% set tracking_context = {
     'user': {
       'id': user_id,


### PR DESCRIPTION
## Summary
- add a floating bug-report launcher and panel so every role can submit issues
- style the new support chat UI with responsive positioning and safe layout spacing
- implement front-end logic for toggling, duplicate guards, unauth prompts, attachments, and submissions to /bug-reports

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce19c911b48325a676255c67559a21