### PR TITLE
Add feature availability management

### DIFF
--- a/migrations/20240730_create_app_feature_states.sql
+++ b/migrations/20240730_create_app_feature_states.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS app_feature_states (
+    slug text PRIMARY KEY,
+    status text NOT NULL DEFAULT 'available',
+    message text,
+    bug_report_id bigint REFERENCES bug_reports(id) ON DELETE SET NULL,
+    updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_feature_states_bug_report
+    ON app_feature_states(bug_report_id);

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -478,6 +478,165 @@ p {
   gap: 12px;
 }
 
+.nav-item > a.is-locked,
+.dropdown a.is-locked {
+  color: var(--ink-subtle);
+  cursor: not-allowed;
+  opacity: 0.75;
+  position: relative;
+}
+
+.nav-item > a.is-locked:hover,
+.nav-item > a.is-locked:focus,
+.dropdown a.is-locked:hover,
+.dropdown a.is-locked:focus {
+  background: transparent;
+  color: var(--ink-subtle);
+  box-shadow: none;
+}
+
+.nav-lock-indicator {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 6px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--muted-dark);
+  color: var(--accent-strong);
+  font-size: 0.6rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+}
+
+.feature-alert {
+  border: var(--border-thin) solid var(--danger);
+  background: rgba(192, 57, 43, 0.08);
+  color: var(--danger);
+  padding: 12px 16px;
+  border-radius: 8px;
+}
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.feature-card {
+  background: var(--muted-light);
+  border: var(--border-thin) solid var(--border-muted);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: var(--shadow-ambient);
+}
+
+.feature-card.is-locked {
+  border-color: var(--danger);
+  background: rgba(192, 57, 43, 0.05);
+}
+
+.feature-card__header {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  align-items: flex-start;
+}
+
+.feature-card__description {
+  margin-top: 6px;
+  color: var(--ink-subtle);
+}
+
+.feature-card__meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin: 0;
+}
+
+.feature-card__meta div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.feature-card__meta dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--ink-subtle);
+}
+
+.feature-card__meta dd {
+  margin: 0;
+  color: var(--ink);
+}
+
+.feature-status {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  border: var(--border-thin) solid var(--border-muted);
+  background: var(--surface);
+}
+
+.feature-status--available {
+  color: var(--accent-strong);
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.feature-status--locked {
+  color: var(--danger);
+  border-color: var(--danger);
+  background: rgba(192, 57, 43, 0.12);
+}
+
+.feature-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.feature-form__row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
+}
+
+.feature-form__row label,
+.feature-form__message {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+}
+
+.feature-form__message textarea {
+  min-height: 72px;
+  resize: vertical;
+  padding: 10px;
+  border-radius: 8px;
+  border: var(--border-thin) solid var(--border-muted);
+}
+
+.feature-form__actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.feature-empty {
+  color: var(--ink-subtle);
+  font-style: italic;
+}
+
 .summary-block h3 {
   font-size: 1rem;
   text-transform: uppercase;

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -322,6 +322,62 @@ document.addEventListener('DOMContentLoaded', () => {
     }, { passive: true });
   }
 
+  const featureModal = document.querySelector('[data-feature-lock-modal]');
+  const featureMessageEl = featureModal ? featureModal.querySelector('[data-feature-lock-message]') : null;
+  const featureCloseBtn = featureModal ? featureModal.querySelector('[data-feature-lock-close]') : null;
+  const featureTitleEl = featureModal ? featureModal.querySelector('#feature-lock-title') : null;
+
+  const hideFeatureModal = () => {
+    if (!featureModal) return;
+    featureModal.setAttribute('hidden', '');
+    featureModal.style.display = 'none';
+  };
+
+  const showFeatureModal = (label, message) => {
+    if (!featureModal) return;
+    if (featureTitleEl) {
+      featureTitleEl.textContent = `${label} temporarily unavailable`;
+    }
+    if (featureMessageEl) {
+      featureMessageEl.textContent = message;
+    }
+    featureModal.style.display = 'flex';
+    featureModal.removeAttribute('hidden');
+    if (typeof featureModal.focus === 'function') {
+      featureModal.focus();
+    }
+  };
+
+  const lockedFeatureLinks = document.querySelectorAll('[data-feature-lock="true"]');
+  lockedFeatureLinks.forEach((link) => {
+    link.addEventListener('click', (event) => {
+      const status = (link.dataset.featureStatus || '').toLowerCase();
+      if (status && status !== 'available') {
+        event.preventDefault();
+        const label = (link.dataset.featureLabel || 'This feature').trim();
+        const message = (link.dataset.featureMessage || `${label} is temporarily unavailable.`).trim();
+        showFeatureModal(label, message);
+      }
+    });
+  });
+
+  if (featureCloseBtn) {
+    featureCloseBtn.addEventListener('click', hideFeatureModal);
+  }
+
+  if (featureModal) {
+    featureModal.addEventListener('click', (event) => {
+      if (event.target === featureModal) {
+        hideFeatureModal();
+      }
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !featureModal.hasAttribute('hidden')) {
+        hideFeatureModal();
+      }
+    });
+  }
+
   // Tab navigation for admin console and other tabbed layouts
   const tabContainers = document.querySelectorAll('[data-tabs]');
   tabContainers.forEach((container) => {

--- a/templates/admin.html
+++ b/templates/admin.html
@@ -23,16 +23,18 @@
 {% endwith %}
 
 <section class="admin-console" data-tabs>
+  {% set current_tab = active_tab or 'overview' %}
   <aside class="tab-nav" role="tablist" aria-label="Administration Sections">
-    <button class="tab-link is-active" type="button" role="tab" aria-selected="true" tabindex="0" data-tab-target="overview">Overview</button>
-    <button class="tab-link" type="button" role="tab" aria-selected="false" tabindex="-1" data-tab-target="data">Data Connections</button>
-    <button class="tab-link" type="button" role="tab" aria-selected="false" tabindex="-1" data-tab-target="users">User Accounts</button>
-    <button class="tab-link" type="button" role="tab" aria-selected="false" tabindex="-1" data-tab-target="roles">Roles &amp; Permissions</button>
-    <button class="tab-link" type="button" role="tab" aria-selected="false" tabindex="-1" data-tab-target="system">System Policies</button>
+    <button class="tab-link {% if current_tab == 'overview' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'overview' else 'false' }}" tabindex="{{ '0' if current_tab == 'overview' else '-1' }}" data-tab-target="overview">Overview</button>
+    <button class="tab-link {% if current_tab == 'features' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'features' else 'false' }}" tabindex="{{ '0' if current_tab == 'features' else '-1' }}" data-tab-target="features">Feature Availability</button>
+    <button class="tab-link {% if current_tab == 'data' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'data' else 'false' }}" tabindex="{{ '0' if current_tab == 'data' else '-1' }}" data-tab-target="data">Data Connections</button>
+    <button class="tab-link {% if current_tab == 'users' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'users' else 'false' }}" tabindex="{{ '0' if current_tab == 'users' else '-1' }}" data-tab-target="users">User Accounts</button>
+    <button class="tab-link {% if current_tab == 'roles' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'roles' else 'false' }}" tabindex="{{ '0' if current_tab == 'roles' else '-1' }}" data-tab-target="roles">Roles &amp; Permissions</button>
+    <button class="tab-link {% if current_tab == 'system' %}is-active{% endif %}" type="button" role="tab" aria-selected="{{ 'true' if current_tab == 'system' else 'false' }}" tabindex="{{ '0' if current_tab == 'system' else '-1' }}" data-tab-target="system">System Policies</button>
   </aside>
 
   <div class="tab-panels">
-    <article class="tab-panel is-active" role="tabpanel" data-tab-panel="overview" aria-hidden="false">
+    <article class="tab-panel {% if current_tab == 'overview' %}is-active{% endif %}" role="tabpanel" data-tab-panel="overview" aria-hidden="{{ 'false' if current_tab == 'overview' else 'true' }}">
       <h2>Operational Snapshot</h2>
       {% set available_tables = overview.tracked_tables | selectattr('status', 'equalto', 'Available') | list %}
       {% set unavailable_tables = overview.tracked_tables | selectattr('status', 'equalto', 'Unavailable') | list %}
@@ -113,7 +115,80 @@
       {% endif %}
     </article>
 
-    <article class="tab-panel" role="tabpanel" data-tab-panel="data" aria-hidden="true">
+    <article class="tab-panel {% if current_tab == 'features' %}is-active{% endif %}" role="tabpanel" data-tab-panel="features" aria-hidden="{{ 'false' if current_tab == 'features' else 'true' }}">
+      <h2>Feature Availability</h2>
+      <p>Control which application areas are available to end users and communicate planned maintenance.</p>
+      {% if feature_state_error %}
+      <div class="feature-alert" role="alert">Feature state data is unavailable: {{ feature_state_error }}</div>
+      {% endif %}
+      {% if feature_bug_error %}
+      <div class="feature-alert" role="alert">Bug report metadata could not be fully loaded: {{ feature_bug_error }}</div>
+      {% endif %}
+      {% if feature_cards %}
+      <div class="feature-grid">
+        {% for feature in feature_cards %}
+        <section class="feature-card {% if feature.status != 'available' %}is-locked{% endif %}">
+          <header class="feature-card__header">
+            <div>
+              <h3>{{ feature.label }}</h3>
+              <p class="feature-card__description">{{ feature.description }}</p>
+            </div>
+            <span class="feature-status feature-status--{{ feature.status }}">{{ feature.status.replace('_', ' ') | title }}</span>
+          </header>
+          <dl class="feature-card__meta">
+            {% if feature.updated_at %}
+            <div>
+              <dt>Updated</dt>
+              <dd>{{ feature.updated_at }}</dd>
+            </div>
+            {% endif %}
+            {% if feature.bug_summary %}
+            <div>
+              <dt>Linked bug</dt>
+              <dd>{{ feature.bug_summary }}{% if feature.bug_status %} &middot; {{ feature.bug_status.replace('_', ' ') | title }}{% endif %}</dd>
+            </div>
+            {% endif %}
+          </dl>
+          <form class="feature-form" method="post" action="{{ url_for('main.admin_feature_action') }}">
+            <input type="hidden" name="slug" value="{{ feature.slug }}">
+            <div class="feature-form__row">
+              <label>
+                <span>Availability</span>
+                <select name="status">
+                  <option value="available" {% if feature.status == 'available' %}selected{% endif %}>Available</option>
+                  <option value="locked" {% if feature.status != 'available' %}selected{% endif %}>Locked for maintenance</option>
+                </select>
+              </label>
+              <label>
+                <span>Linked bug report</span>
+                <select name="bug_report_id">
+                  <option value="">None</option>
+                  {% if feature.bug_report_id and not feature_bug_options | selectattr('id', 'equalto', feature.bug_report_id) | list %}
+                  <option value="{{ feature.bug_report_id }}" selected>#{{ feature.bug_report_id }}</option>
+                  {% endif %}
+                  {% for option in feature_bug_options %}
+                  <option value="{{ option.id }}" {% if option.id == feature.bug_report_id %}selected{% endif %}>{{ option.label }}</option>
+                  {% endfor %}
+                </select>
+              </label>
+            </div>
+            <label class="feature-form__message">
+              <span>User-facing notice</span>
+              <textarea name="message" rows="2" placeholder="Share a maintenance message">{{ feature.message }}</textarea>
+            </label>
+            <div class="feature-form__actions">
+              <button type="submit" class="primary">Save changes</button>
+            </div>
+          </form>
+        </section>
+        {% endfor %}
+      </div>
+      {% else %}
+      <p class="feature-empty">Feature toggles will appear once Supabase connectivity is configured.</p>
+      {% endif %}
+    </article>
+
+    <article class="tab-panel {% if current_tab == 'data' %}is-active{% endif %}" role="tabpanel" data-tab-panel="data" aria-hidden="{{ 'false' if current_tab == 'data' else 'true' }}">
       <h2>Data Connections</h2>
       <p>Link production databases and control how data synchronizes with Spectra Operations Suite.</p>
       <div class="summary-block">
@@ -224,7 +299,7 @@
       </form>
     </article>
 
-    <article class="tab-panel" role="tabpanel" data-tab-panel="users" aria-hidden="true">
+    <article class="tab-panel {% if current_tab == 'users' %}is-active{% endif %}" role="tabpanel" data-tab-panel="users" aria-hidden="{{ 'false' if current_tab == 'users' else 'true' }}">
       <h2>User Accounts</h2>
       <p>Create and deactivate user accounts to control who can access Spectra Operations Suite.</p>
 
@@ -300,7 +375,7 @@
       </form>
     </article>
 
-    <article class="tab-panel" role="tabpanel" data-tab-panel="roles" aria-hidden="true">
+    <article class="tab-panel {% if current_tab == 'roles' %}is-active{% endif %}" role="tabpanel" data-tab-panel="roles" aria-hidden="{{ 'false' if current_tab == 'roles' else 'true' }}">
       <h2>Roles &amp; Permissions</h2>
       <div class="summary-block">
         <p>{{ missing_feeds.roles }}</p>
@@ -308,7 +383,7 @@
       </div>
     </article>
 
-    <article class="tab-panel" role="tabpanel" data-tab-panel="system" aria-hidden="true">
+    <article class="tab-panel {% if current_tab == 'system' %}is-active{% endif %}" role="tabpanel" data-tab-panel="system" aria-hidden="{{ 'false' if current_tab == 'system' else 'true' }}">
       <h2>System Policies</h2>
       <div class="summary-block">
         <p>{{ missing_feeds.system_policies }}</p>

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,6 +8,27 @@
   {% block extra_head %}{% endblock %}
 </head>
 <body class="{% if user_role == 'EMPLOYEE' %}employee-layout{% endif %}">
+  {% macro feature_nav_link(label, href, slug) -%}
+    {% set feature = (feature_states.get(slug) if feature_states else {}) %}
+    {% set status = feature.get('status', 'available') %}
+    {% set globally_locked = status != 'available' %}
+    {% set locked_for_user = globally_locked and user_role != 'ADMIN' %}
+    {% set message = feature.get('message') or feature.get('description') or '' %}
+    <a
+      href="{{ href }}"
+      class="{% if locked_for_user %}is-locked{% endif %}"
+      data-feature-slug="{{ slug }}"
+      data-feature-status="{{ status }}"
+      data-feature-label="{{ feature.get('label', label) }}"
+      data-feature-message="{{ message }}"
+      {% if locked_for_user %}data-feature-lock="true" aria-disabled="true"{% endif %}
+    >
+      {{ label }}
+      {% if globally_locked %}
+      <span class="nav-lock-indicator" aria-hidden="true">Locked</span>
+      {% endif %}
+    </a>
+  {%- endmacro %}
   {% if user_role != 'EMPLOYEE' %}
   <header class="app-header">
     <nav class="navbar" role="navigation" aria-label="Primary">
@@ -26,10 +47,10 @@
           <li class="nav-item">
             <a href="#">Analysis <span class="arrow">&#9662;</span></a>
             <div class="dropdown" role="menu">
-              <a href="{{ url_for('main.ppm_analysis') }}">PPM Analysis</a>
-              <a href="{{ url_for('main.aoi_grades_page') }}">AOI &amp; FI Analysis</a>
-              <a href="{{ url_for('main.aoi_daily_reports') }}">AOI Daily Reports</a>
-              <a href="{{ url_for('main.fi_daily_reports') }}">FI Daily Reports</a>
+              {{ feature_nav_link('PPM Analysis', url_for('main.ppm_analysis'), 'analysis_ppm') }}
+              {{ feature_nav_link('AOI & FI Analysis', url_for('main.aoi_grades_page'), 'analysis_aoi_grades') }}
+              {{ feature_nav_link('AOI Daily Reports', url_for('main.aoi_daily_reports'), 'analysis_aoi_daily') }}
+              {{ feature_nav_link('FI Daily Reports', url_for('main.fi_daily_reports'), 'analysis_fi_daily') }}
               {% if user_role == 'ADMIN' %}
               <a href="{{ url_for('main.analysis_tracker_logs') }}">Application Tracker Logs</a>
               {% endif %}
@@ -40,7 +61,7 @@
             <div class="dropdown" role="menu">
               <a href="#">Rework Stencil Lookup</a>
               <a href="#">Verified Part Markings</a>
-              <a href="{{ url_for('main.assembly_forecast') }}">Assembly Forecast</a>
+              {{ feature_nav_link('Assembly Forecast', url_for('main.assembly_forecast'), 'tools_assembly_forecast') }}
             </div>
           </li>
           <li class="nav-item">
@@ -53,9 +74,9 @@
           <li class="nav-item">
             <a href="#">Reports <span class="arrow">&#9662;</span></a>
             <div class="dropdown" role="menu">
-              <a href="{{ url_for('main.integrated_report') }}">AOI Integrated Report</a>
-              <a href="{{ url_for('main.operator_report') }}">Operator Report</a>
-              <a href="{{ url_for('main.aoi_daily_report_page') }}">AOI Daily Report</a>
+              {{ feature_nav_link('AOI Integrated Report', url_for('main.integrated_report'), 'reports_integrated') }}
+              {{ feature_nav_link('Operator Report', url_for('main.operator_report'), 'reports_operator') }}
+              {{ feature_nav_link('AOI Daily Report', url_for('main.aoi_daily_report_page'), 'reports_aoi_daily') }}
             </div>
           </li>
         </ul>
@@ -76,6 +97,18 @@
   <main class="content" role="main">
     {% block content %}{% endblock %}
   </main>
+
+  <div class="modal-overlay" data-feature-lock-modal hidden tabindex="-1">
+    <div class="modal" role="dialog" aria-modal="true" aria-labelledby="feature-lock-title">
+      <div class="modal-header">
+        <h2 id="feature-lock-title">Feature temporarily unavailable</h2>
+        <button type="button" class="modal-close" data-feature-lock-close aria-label="Close">Close</button>
+      </div>
+      <div class="modal-body">
+        <p data-feature-lock-message></p>
+      </div>
+    </div>
+  </div>
 
   <div
     id="bug-chat-container"


### PR DESCRIPTION
## Summary
- add a Supabase migration and helper functions to persist feature availability metadata
- gate major analysis and reporting routes with a reusable decorator that respects feature state
- surface feature lock indicators in the main navigation, show maintenance messaging, and extend the admin console with a management UI
- sync bug report status changes with linked feature locks so on-hold items automatically close affected features

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce1fec6dc8832587619ea22b9313d0