### PR TITLE
Track bug tables in admin overview

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -709,6 +709,8 @@ TRACKED_SUPABASE_TABLES = {
     "moat": "MOAT data feeding the integrated performance report.",
     "combined_reports": "Joined AOI/FI views surfaced in integrated analytics.",
     "app_users": "Application login accounts managed from this console.",
+    "bug_reports": "In-app feedback collected to triage feature issues and bugs.",
+    "defect": "Defect catalog entries referenced when analysing bug submissions.",
 }
 
 


### PR DESCRIPTION
## Summary
- include the bug_reports and defect tables in the tracked Supabase metadata so the admin overview lists all bug data sources
- extend the admin console tests to capture the rendered overview context and assert the new tables are present

## Testing
- pytest tests/test_admin_user_management.py

------
https://chatgpt.com/codex/tasks/task_e_68ce26c67d888325b94b4999beb6dd44