### PR TITLE
Fix defect catalog table name

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -390,7 +390,7 @@ def fetch_defect_catalog() -> tuple[list[dict[str, str]] | None, str | None]:
         return None, error
 
     try:
-        response = supabase.table("defect").select("id,name").execute()
+        response = supabase.table("defects").select("id,name").execute()
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to fetch defects: {exc}"
 
@@ -414,7 +414,7 @@ def fetch_defect_catalog() -> tuple[list[dict[str, str]] | None, str | None]:
 
 
 def fetch_distinct_defect_ids() -> tuple[list[str] | None, str | None]:
-    """Return unique defect identifiers from the ``defect`` table."""
+    """Return unique defect identifiers from the ``defects`` table."""
 
     catalog, error = fetch_defect_catalog()
     if error:

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -710,7 +710,7 @@ TRACKED_SUPABASE_TABLES = {
     "combined_reports": "Joined AOI/FI views surfaced in integrated analytics.",
     "app_users": "Application login accounts managed from this console.",
     "bug_reports": "In-app feedback collected to triage feature issues and bugs.",
-    "defect": "Defect catalog entries referenced when analysing bug submissions.",
+    "defects": "Defect catalog entries referenced when analysing bug submissions.",
 }
 
 

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -154,7 +154,7 @@ def test_admin_overview_lists_tracked_tables(admin_app):
             "aoi_reports": [],
             "fi_reports": [],
             "bug_reports": [],
-            "defect": [],
+            "defects": [],
         }
     )
 
@@ -167,7 +167,7 @@ def test_admin_overview_lists_tracked_tables(admin_app):
     overview = context["overview"]
     table_names = [table_info["name"] for table_info in overview["tracked_tables"]]
     assert "bug_reports" in table_names
-    assert "defect" in table_names
+    assert "defects" in table_names
 
 
 def test_admin_can_create_supabase_user(admin_app):

--- a/tests/test_employee_aoi_defects.py
+++ b/tests/test_employee_aoi_defects.py
@@ -59,7 +59,7 @@ def _login_employee(client):
 
 def test_employee_defect_endpoint_returns_unique_ids(employee_app):
     app, supabase = employee_app
-    supabase.tables['defect'] = [
+    supabase.tables['defects'] = [
         {'id': 'DEF-2', 'name': 'Solder Bridge'},
         {'id': 'DEF-1', 'name': 'Component Shift'},
         {'id': 'DEF-2', 'name': 'Solder Bridge'},


### PR DESCRIPTION
## Summary
- switch defect catalog queries and diagnostics to use the `defects` Supabase table
- align Supabase stubs and admin overview expectations with the updated table name

## Testing
- pytest tests/test_employee_aoi_defects.py

------
https://chatgpt.com/codex/tasks/task_e_68ce28d067b08325a53b8557f8b32964