### PR TITLE
Prefer Supabase id for bug report reporter

### DIFF
--- a/tests/test_bug_report_submission.py
+++ b/tests/test_bug_report_submission.py
@@ -23,7 +23,7 @@ def app_client(monkeypatch):
     return app, client
 
 
-def test_bug_report_uses_auth_uuid_for_supabase_user(app_client, monkeypatch):
+def test_bug_report_prefers_supabase_id_for_supabase_user(app_client, monkeypatch):
     app, client = app_client
 
     recorded = {}
@@ -37,6 +37,7 @@ def test_bug_report_uses_auth_uuid_for_supabase_user(app_client, monkeypatch):
     def fake_fetch(username):
         recorded["fetched_username"] = username
         return {
+            "id": 9876,
             "username": username,
             "display_name": "Ana Analyst",
             "auth_user_id": "00000000-0000-0000-0000-000000000123",
@@ -57,10 +58,10 @@ def test_bug_report_uses_auth_uuid_for_supabase_user(app_client, monkeypatch):
     assert response.status_code == 201
     assert recorded["fetched_username"] == "analyst"
     inserted_record = recorded["record"]
-    assert inserted_record["reporter_id"] == "00000000-0000-0000-0000-000000000123"
+    assert inserted_record["reporter_id"] == "9876"
 
     payload = response.get_json()
-    assert payload["reporter_id"] == "00000000-0000-0000-0000-000000000123"
+    assert payload["reporter_id"] == "9876"
     assert payload["reporter_display_name"] == "Ana Analyst"
 
 


### PR DESCRIPTION
## Summary
- prefer the Supabase account id when storing bug report reporter identifiers, falling back to the auth UUID only when necessary
- ensure reporter identifiers are stringified before persisting and returned in the response payload for admin resolution
- update the bug report submission test to cover the Supabase id preference

## Testing
- pytest tests/test_bug_report_submission.py

------
https://chatgpt.com/codex/tasks/task_e_68ce30e0886c8325b8701b6c298cb5fc