### PR TITLE
Fallback bug report reporter id to session user id

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1203,6 +1203,11 @@ def submit_bug_report():
         'status': payload.get('status') or 'open',
     }
 
+    if reporter_identifier is None:
+        session_user_id = user.get('user_id')
+        if session_user_id not in (None, ''):
+            reporter_identifier = str(session_user_id)
+
     if reporter_identifier is not None:
         record['reporter_id'] = str(reporter_identifier)
 


### PR DESCRIPTION
## Summary
- fall back to the session user id when bug report submissions lack a linked Supabase auth user
- extend bug report submission tests to cover the new reporter id fallback logic

## Testing
- pytest tests/test_bug_report_submission.py

------
https://chatgpt.com/codex/tasks/task_e_68ce37eac78c83258553cb32914969b2