### PR TITLE
Store reporter names with bug reports

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1201,6 +1201,7 @@ def submit_bug_report():
         'description': description,
         'priority': priority,
         'status': payload.get('status') or 'open',
+        'reporter_name': reporter_display_name,
     }
 
     if reporter_identifier is None:


### PR DESCRIPTION
## Summary
- persist the computed reporter display name when inserting a bug report
- update submission tests to confirm reporter_name is saved with the record
- cover the admin tracker view to ensure the reporter column shows the stored name

## Testing
- pytest tests/test_bug_report_submission.py

------
https://chatgpt.com/codex/tasks/task_e_68ce385caf2c83259316d5dc92a5ae86