### PR TITLE
Add macOS Chromium fallback for PDF generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,22 @@ The fallback runner also honours `app.config["WKHTMLTOPDF_CMD"]` if you prefer
 to configure the command within the Flask application. With the binary
 configured, PDF generation will transparently switch to wkhtmltopdf whenever
 WeasyPrint fails to load.
+
+### macOS Chromium fallback
+On macOS machines where both WeasyPrint and wkhtmltopdf are unavailable, the
+application falls back to a headless Chromium renderer powered by
+[`pyppeteer`](https://github.com/pyppeteer/pyppeteer). To enable this helper:
+
+1. Install the Python dependency:
+   ```bash
+   pip install pyppeteer
+   ```
+2. Download a compatible Chromium binary (pyppeteer can handle this step):
+   ```bash
+   python -m pyppeteer install
+   ```
+
+The macOS helper runs only when both of the other backends fail, so Linux and
+Windows environments are unaffected. If PDF generation continues to raise
+errors, verify that Chromium launches correctly in headless mode and consult the
+console output for additional details.

--- a/app/main/pdf_utils_macos.py
+++ b/app/main/pdf_utils_macos.py
@@ -1,0 +1,91 @@
+"""macOS-specific PDF rendering utilities."""
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used only for type checking
+    from .pdf_utils import PdfGenerationError
+
+_MAC_FALLBACK_DEPENDENCY_MESSAGE = (
+    "Unable to generate PDF exports using the macOS Chromium fallback because the "
+    "pyppeteer package or a compatible headless Chromium binary is unavailable. "
+    "Install pyppeteer and ensure Chromium is downloaded (see the README for "
+    "instructions)."
+)
+
+
+def _run_asyncio_task(coro: "asyncio.Future[bytes]") -> bytes:
+    """Execute an asyncio coroutine from synchronous code."""
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        try:
+            asyncio.set_event_loop(loop)
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    if loop.is_running():
+        new_loop = asyncio.new_event_loop()
+        try:
+            return new_loop.run_until_complete(coro)
+        finally:
+            new_loop.close()
+
+    return loop.run_until_complete(coro)
+
+
+async def _async_render_html_to_pdf(
+    html: str, base_url: str | None = None
+) -> bytes:
+    """Render HTML to PDF using pyppeteer and headless Chromium."""
+
+    from .pdf_utils import PdfGenerationError
+
+    try:
+        from pyppeteer import launch
+    except ImportError as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_MAC_FALLBACK_DEPENDENCY_MESSAGE) from exc
+
+    browser = await launch(
+        headless=True,
+        args=[
+            "--no-sandbox",
+            "--disable-dev-shm-usage",
+            "--disable-gpu",
+        ],
+    )
+    try:
+        page = await browser.newPage()
+        try:
+            content = html
+            if base_url:
+                content = f'<base href="{base_url}">{html}'
+            await page.setContent(content, waitUntil="networkidle0")
+            pdf_bytes = await page.pdf(printBackground=True)
+        finally:
+            await page.close()
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_MAC_FALLBACK_DEPENDENCY_MESSAGE) from exc
+    finally:
+        await browser.close()
+
+    return pdf_bytes
+
+
+def render_html_to_pdf_with_macos_fallback(
+    html: str, base_url: str | None = None
+) -> bytes:
+    """Render HTML to PDF on macOS using a Chromium-based fallback."""
+
+    from .pdf_utils import PdfGenerationError
+
+    try:
+        return _run_asyncio_task(_async_render_html_to_pdf(html, base_url=base_url))
+    except PdfGenerationError:
+        raise
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        raise PdfGenerationError(_MAC_FALLBACK_DEPENDENCY_MESSAGE) from exc

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,4 +10,5 @@ pytest
 numpy
 weasyprint
 pdfkit
+pyppeteer
 matplotlib


### PR DESCRIPTION
## Summary
- add a macOS-specific PDF helper that renders HTML via a headless Chromium session driven by pyppeteer
- update the primary PDF renderer to invoke the Chromium fallback when WeasyPrint and wkhtmltopdf both fail on macOS
- extend the PDF utility test suite to cover the macOS success and failure paths and document the new requirements

## Testing
- PYTHONPATH=. pytest tests/test_pdf_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68cef58c64d083259cfb025985a85d9e