### PR TITLE
Handle bug report update errors with JSON responses

### DIFF
--- a/templates/analysis_tracker_logs.html
+++ b/templates/analysis_tracker_logs.html
@@ -1110,14 +1110,40 @@
 
             if (!response.ok) {
               let message = 'Failed to update bug report.';
+              let parsed;
               try {
-                const data = await response.json();
-                if (data && data.description) {
-                  message = data.description;
-                }
+                parsed = await response.clone().json();
               } catch (error) {
-                // Response was not JSON; ignore.
+                try {
+                  const text = await response.text();
+                  if (text) {
+                    message = text;
+                  }
+                } catch (_) {
+                  // Ignore fallback errors.
+                }
+                throw new Error(message);
               }
+
+              if (parsed && typeof parsed === 'object') {
+                if (parsed.description) {
+                  message = parsed.description;
+                } else if (parsed.error) {
+                  message = parsed.error;
+                } else if (parsed.detail) {
+                  message = parsed.detail;
+                } else {
+                  try {
+                    const text = await response.text();
+                    if (text) {
+                      message = text;
+                    }
+                  } catch (_) {
+                    // Ignore fallback errors.
+                  }
+                }
+              }
+
               throw new Error(message);
             }
 


### PR DESCRIPTION
## Summary
- return JSON payloads when updating a bug report fails and log the server-side error
- adjust the admin tracker dashboard client to surface the new JSON error fields and fall back to plain text
- add a regression test confirming the update endpoint returns the Supabase failure details in JSON

## Testing
- pytest tests/test_bug_report_submission.py

------
https://chatgpt.com/codex/tasks/task_e_68cf057271488325b231d6050951c54a