### PR TITLE
Add rejection detail capture to AOI form

### DIFF
--- a/templates/employee_home.html
+++ b/templates/employee_home.html
@@ -144,6 +144,52 @@
                     <option value="" disabled selected>Loading defects...</option>
                   </select>
                 </label>
+                <input type="hidden" name="rejection_details" data-rejection-json>
+                <section class="inspection-rejection" data-rejection-details hidden aria-label="Reason for rejection details">
+                  <header class="inspection-rejection__header">
+                    <h4>Rejection Details</h4>
+                    <p>List each rejected assembly, the related defect code, and the rejected quantity.</p>
+                  </header>
+                  <div class="inspection-rejection__controls">
+                    <button type="button" class="inspection-rejection__add" data-action="add-rejection-row">Add rejection reason</button>
+                  </div>
+                  <div class="inspection-rejection__table">
+                    <table>
+                      <caption class="sr-only">Rejected assemblies and associated defect codes</caption>
+                      <thead>
+                        <tr>
+                          <th scope="col">Reference Designator</th>
+                          <th scope="col">Defect Code</th>
+                          <th scope="col">Quantity</th>
+                          <th scope="col"><span class="sr-only">Actions</span></th>
+                        </tr>
+                      </thead>
+                      <tbody data-rejection-rows>
+                        <tr data-rejection-empty>
+                          <td colspan="4">Add rows to capture each rejected assembly.</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+                <template data-rejection-row-template>
+                  <tr data-rejection-row>
+                    <td data-label="Reference Designator">
+                      <input type="text" data-rejection-ref placeholder="e.g. R15" autocomplete="off">
+                    </td>
+                    <td data-label="Defect Code">
+                      <select data-rejection-defect disabled>
+                        <option value="" disabled selected>Loading defects...</option>
+                      </select>
+                    </td>
+                    <td data-label="Quantity">
+                      <input type="number" data-rejection-quantity min="1" step="1" placeholder="0">
+                    </td>
+                    <td data-label="Actions">
+                      <button type="button" class="inspection-rejection__remove" data-action="remove-rejection-row">Remove</button>
+                    </td>
+                  </tr>
+                </template>
               </div>
             </fieldset>
 


### PR DESCRIPTION
## Summary
- add a rejection details table scaffold to the AOI employee form with row controls
- extend the employee portal script to manage rejection detail rows and load defect options
- validate and serialize rejection detail entries into the AOI report submission payload

## Testing
- pytest tests/test_employee_aoi_defects.py

------
https://chatgpt.com/codex/tasks/task_e_68cf1594bea88325981b1ce1316d5b1b