### PR TITLE
Style rejection details table in employee portal

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1571,6 +1571,32 @@ body.employee-layout .content {
   gap: 16px;
 }
 
+.inspection-rejection__table-grid {
+  width: 100%;
+  border-collapse: collapse;
+  border: var(--border-thick) solid var(--ink);
+}
+
+.inspection-rejection__table-grid thead th {
+  background: var(--muted);
+  color: var(--ink);
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-align: left;
+}
+
+.inspection-rejection__table-grid th,
+.inspection-rejection__table-grid td {
+  border: var(--border-thin) solid var(--border-strong);
+  padding: 10px 12px;
+  vertical-align: top;
+}
+
+.inspection-rejection__table-grid tbody tr:nth-child(even) {
+  background: var(--muted-light);
+}
+
 .employee-form {
   display: flex;
   flex-direction: column;

--- a/templates/employee_home.html
+++ b/templates/employee_home.html
@@ -148,7 +148,7 @@
                     <button type="button" class="inspection-rejection__add" data-action="add-rejection-row">Add rejection reason</button>
                   </div>
                   <div class="inspection-rejection__table">
-                    <table>
+                    <table class="inspection-rejection__table-grid">
                       <caption class="sr-only">Rejected assemblies and associated reasons</caption>
                       <thead>
                         <tr>


### PR DESCRIPTION
## Summary
- add a dedicated class to the rejection details table on the employee AOI sheet so it can be styled directly
- extend the global stylesheet with table, header, and cell border rules to create a bordered inspection details grid

## Testing
- manual verification of the AOI data sheet in the running app

------
https://chatgpt.com/codex/tasks/task_e_68d03c34a0988325a36abf6ebf406996