### PR TITLE
Require operator signature acknowledgement in AOI employee submissions

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1332,6 +1332,10 @@ def _prepare_employee_aoi_record(
         else:
             record[column] = value
 
+    signature_value = str(payload.get('operator_signature_acknowledged') or '').strip().lower()
+    if signature_value not in {'true', '1', 'yes', 'on'}:
+        errors['operator_signature_acknowledged'] = 'Confirm the operator signature before submitting.'
+
     numeric_fields = (
         ('quantity_inspected', 'Quantity Inspected'),
         ('quantity_rejected', 'Quantity Rejected'),

--- a/templates/employee_home.html
+++ b/templates/employee_home.html
@@ -49,7 +49,7 @@
         <button type="button" class="employee-back" data-action="back-to-picker">&larr; Choose a different data sheet</button>
         <h3 class="inspection-sheet__heading" data-sheet-title></h3>
         <p class="inspection-sheet__subheading" data-sheet-subtitle hidden></p>
-        <form class="inspection-sheet" data-sheet-form novalidate>
+        <form class="inspection-sheet" data-sheet-form data-operator-username="{{ username or '' }}" novalidate>
           <div class="inspection-progress" data-progress>
             <div class="inspection-progress__track">
               <div class="inspection-progress__bar" data-progress-bar></div>
@@ -197,10 +197,13 @@
           </div>
 
           <section class="inspection-sheet__signoff" aria-label="Inspection sign-off" data-step-finish hidden>
-            <div class="inspection-signature">
+            <div class="inspection-signature" data-operator-signature>
               <span class="inspection-signature__label">Operator Signature</span>
-              <span class="inspection-signature__line" aria-hidden="true"></span>
-              <span class="inspection-signature__hint">Sign on file</span>
+              <button type="button" class="inspection-signature__line inspection-signature__control" data-action="operator-signature" aria-pressed="false">
+                <span data-signature-display>Sign on file</span>
+              </button>
+              <input type="hidden" name="operator_signature_acknowledged" data-signature-field>
+              <span class="inspection-signature__hint">Select to confirm</span>
             </div>
             <div class="inspection-signature">
               <span class="inspection-signature__label">Quality Approval</span>


### PR DESCRIPTION
## Summary
- add a focusable operator signature control to the employee AOI form and expose the signed-in username for client scripts
- update the employee portal script to capture operator signature acknowledgement and block submission until it is confirmed
- enforce signature acknowledgement on the server and extend employee AOI tests to cover the new workflow

## Testing
- pytest tests/test_employee_aoi_defects.py

------
https://chatgpt.com/codex/tasks/task_e_68d0415843948325babcff3a056c21df