### PR TITLE
Allow macOS PDF rendering via fallbacks

### DIFF
--- a/app/main/pdf_utils.py
+++ b/app/main/pdf_utils.py
@@ -269,14 +269,16 @@ def _render_html_to_pdf_with_wkhtmltopdf(
 def render_html_to_pdf(html: str, base_url: str | None = None) -> bytes:
     """Render HTML content to PDF bytes using WeasyPrint."""
 
-    if platform.system() == "Darwin":
-        raise PdfGenerationError(_MAC_UNSUPPORTED_MESSAGE)
+    system = platform.system()
 
     weasyprint_error: PdfGenerationError | None = None
-    try:
-        return _render_html_to_pdf_with_weasyprint(html, base_url=base_url)
-    except PdfGenerationError as exc:
-        weasyprint_error = exc
+    if system == "Darwin":
+        weasyprint_error = PdfGenerationError(_MAC_UNSUPPORTED_MESSAGE)
+    else:
+        try:
+            return _render_html_to_pdf_with_weasyprint(html, base_url=base_url)
+        except PdfGenerationError as exc:
+            weasyprint_error = exc
 
     chromium_error: PdfGenerationError | None = None
     try:


### PR DESCRIPTION
## Summary
- allow macOS hosts to skip WeasyPrint but still try Chromium and wkhtmltopdf fallbacks when generating PDFs
- add tests that exercise macOS fallback success and failure flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d215892af08325b5f500af862824eb