### PR TITLE
Clarify macOS PDF fallback messaging

### DIFF
--- a/app/main/pdf_utils.py
+++ b/app/main/pdf_utils.py
@@ -32,8 +32,8 @@ _CHROMIUM_DEPENDENCY_MESSAGE = (
 )
 
 _MAC_UNSUPPORTED_MESSAGE = (
-    "Unable to generate PDF exports on macOS. PDF generation is supported only on "
-    "Linux or Windows hosts."
+    "WeasyPrint PDF rendering is skipped on macOS; attempting Chromium and "
+    "wkhtmltopdf fallbacks instead."
 )
 
 

--- a/tests/test_pdf_utils.py
+++ b/tests/test_pdf_utils.py
@@ -230,7 +230,10 @@ def test_render_html_to_pdf_on_macos_includes_message_when_fallbacks_fail(monkey
         pdf_utils.render_html_to_pdf("<p>Hello</p>")
 
     message = str(excinfo.value)
-    assert pdf_utils._MAC_UNSUPPORTED_MESSAGE in message
+    assert (
+        "WeasyPrint PDF rendering is skipped on macOS; attempting Chromium and "
+        "wkhtmltopdf fallbacks instead." in message
+    )
     assert "chromium failure" in message
     assert pdf_utils._FALLBACK_DEPENDENCY_MESSAGE in message
 


### PR DESCRIPTION
## Summary
- clarify the macOS WeasyPrint message to explain fallback attempts
- update the PDF utility test to check for the revised wording

## Testing
- pytest tests/test_pdf_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d219a428d48325b754d2056e0e64ee