### PR TITLE
Inline report CSS for exports

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -17,6 +17,7 @@ from functools import wraps
 import csv
 import io
 import os
+from pathlib import Path
 from urllib.parse import urlparse
 import re
 import json
@@ -76,6 +77,18 @@ from fi_utils import parse_fi_rejections
 # Helpers for AOI Grades analytics
 from collections import defaultdict, Counter
 from statistics import mean
+
+
+def _load_report_css() -> str:
+    """Load the shared report stylesheet so it can be inlined."""
+
+    static_folder = current_app.static_folder or ''
+    css_path = Path(static_folder) / 'css' / 'report.css'
+    try:
+        return css_path.read_text(encoding='utf-8')
+    except OSError as exc:  # pragma: no cover - log & fall back to default styling
+        current_app.logger.warning("Unable to load report CSS: %s", exc)
+    return ""
 
 
 def _normalize_header(value: str | None) -> str:
@@ -2980,6 +2993,8 @@ def export_integrated_report():
         payload.setdefault('operatorSummary', payload.get('summary', {}))
         payload.setdefault('modelSummary', {'avgFalseCalls': 0.0})
 
+    report_css = _load_report_css()
+
     html = render_template(
         'report/integrated/index.html',
         show_cover=show_cover,
@@ -2995,6 +3010,7 @@ def export_integrated_report():
         contact=contact,
         confidentiality=confidentiality,
         generated_at=generated_at,
+        report_css=report_css,
         **payload,
         **charts,
     )
@@ -3052,6 +3068,8 @@ def export_aoi_daily_report():
     payload.update(charts)
 
     show_cover = str(request.args.get('show_cover', 'false')).lower() not in {'0', 'false', 'no'}
+    report_css = _load_report_css()
+
     html = render_template(
         'report/aoi_daily/index.html',
         day=day.isoformat(),
@@ -3060,6 +3078,7 @@ def export_aoi_daily_report():
         end=end,
         generated_at=generated_at,
         contact=contact,
+        report_css=report_css,
         **payload,
     )
 
@@ -3516,6 +3535,8 @@ def export_operator_report():
         payload.setdefault('operatorSummary', payload.get('summary', {}))
         payload.setdefault('modelSummary', {'avgFalseCalls': 0.0})
 
+    report_css = _load_report_css()
+
     html = render_template(
         'report/operator/index.html',
         show_cover=show_cover,
@@ -3532,6 +3553,7 @@ def export_operator_report():
         confidentiality=confidentiality,
         generated_at=generated_at,
         operator=operator,
+        report_css=report_css,
         **payload,
     )
 

--- a/templates/report/aoi_daily/index.html
+++ b/templates/report/aoi_daily/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>AOI Daily Report</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+    <style>{{ report_css|safe }}</style>
 </head>
 <body>
     {% if show_cover %}

--- a/templates/report/integrated/index.html
+++ b/templates/report/integrated/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>AOI Integrated Report</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+    <style>{{ report_css|safe }}</style>
 </head>
 <body>
     {% if show_cover %}

--- a/templates/report/operator/index.html
+++ b/templates/report/operator/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <title>Operator Report</title>
     <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+    <style>{{ report_css|safe }}</style>
 </head>
 <body>
     {% if show_cover %}

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -85,6 +85,8 @@ def test_export_aoi_daily_report_cover_fields(app_instance, monkeypatch):
         )
         assert resp.status_code == 200
         html = resp.data.decode()
+        assert "<style>" in html
+        assert "--font-body" in html
         assert "report_range:</b> 2024-06-01 - 2024-06-01" in html
         assert "&lt;help@example.com&gt;" in html
         assert re.search(

--- a/tests/test_export_integrated_report_date_range.py
+++ b/tests/test_export_integrated_report_date_range.py
@@ -88,6 +88,8 @@ def test_export_integrated_report_respects_date_range(app_instance, monkeypatch)
         )
         assert resp.status_code == 200
         html = resp.data.decode("utf-8")
+        assert "<style>" in html
+        assert "--font-body" in html
         # Only in-range data should be present
         assert "2024-07-01" in html
         assert "2024-08-01" not in html

--- a/tests/test_operator_report_routes.py
+++ b/tests/test_operator_report_routes.py
@@ -82,6 +82,8 @@ def test_export_operator_report(app_instance, monkeypatch):
         )
         assert resp.status_code == 200
         html = resp.data.decode()
+        assert "<style>" in html
+        assert "--font-body" in html
         assert "Total Boards" in html
         # Assemblies for Alice are A1 and A2
         assert "A1" in html and "A2" in html
@@ -186,4 +188,4 @@ def test_operator_cover_page(app_instance, monkeypatch):
         )
         assert resp.status_code == 200
         html = resp.data.decode()
-        assert "cover-page" not in html
+        assert 'class="cover-page"' not in html


### PR DESCRIPTION
## Summary
- load the shared report stylesheet in the export routes and pass it to templates
- embed the report CSS inline inside the integrated, AOI daily, and operator report templates
- assert the inline style block is present in HTML export tests and adjust expectations accordingly

## Testing
- PYTHONPATH=. pytest tests/test_export_integrated_report_date_range.py tests/test_aoi_daily_report.py tests/test_operator_report_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c5b67f688325a86994ffa4e7e7a8