### PR TITLE
Remove rounded corners from report components

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -98,7 +98,7 @@ header {
     background: linear-gradient(90deg, var(--accent) 0%, var(--accent-strong) 100%);
     color: #fff;
     padding: 18px 24px;
-    border-radius: 14px;
+    border-radius: 0;
     box-shadow: var(--shadow-soft);
 }
 
@@ -145,7 +145,7 @@ header h1 {
     background: var(--surface);
     padding: 20px 24px;
     margin-bottom: calc(var(--base-spacing) * 1.5);
-    border-radius: 16px;
+    border-radius: 0;
     box-shadow: var(--shadow-soft);
 }
 
@@ -158,7 +158,7 @@ header h1 {
     height: 40px;
     background: var(--accent);
     opacity: 0.15;
-    border-radius: 3px;
+    border-radius: 0;
 }
 
 .cover-page .summary {
@@ -185,7 +185,7 @@ header h1 {
 
 .toc li {
     padding: 8px 12px;
-    border-radius: 10px;
+    border-radius: 0;
     margin-bottom: 6px;
     background: var(--muted-light);
     border: 1px solid var(--border-muted);
@@ -212,7 +212,7 @@ header h1 {
     background: var(--surface);
     padding: 18px;
     margin-bottom: 24px;
-    border-radius: 16px;
+    border-radius: 0;
     box-shadow: var(--shadow-soft);
 }
 
@@ -224,7 +224,7 @@ header h1 {
 .chart-block img {
     width: 100%;
     height: auto;
-    border-radius: 12px;
+    border-radius: 0;
     border: 1px solid var(--border-light);
     background: var(--surface-alt);
 }
@@ -239,7 +239,7 @@ header h1 {
     background: var(--muted-light);
     padding: 12px 16px;
     margin-top: 12px;
-    border-radius: 0 0 12px 12px;
+    border-radius: 0;
 }
 
 .chart-summary p {
@@ -271,7 +271,7 @@ header h1 {
     margin-top: 16px;
     background: var(--surface);
     border: 1px solid var(--border);
-    border-radius: 14px;
+    border-radius: 0;
     overflow: hidden;
     box-shadow: var(--shadow-soft);
 }


### PR DESCRIPTION
## Summary
- set the header, section cards, TOC entries, chart blocks, chart summaries, and tables in `static/css/report.css` to use square corners

## Testing
- pytest tests/test_export_report_rendering.py tests/test_aoi_daily_report.py tests/test_operator_report_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68d2c9520f9883258ed0c82f7afa55e1