### PR TITLE
Use absolute logo URLs in report exports

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2974,7 +2974,9 @@ def export_integrated_report():
     report_date = _get('report_date')
     period = _get('period')
     author = _get('author')
-    logo_url = _get('logo_url')
+    logo_url = _get('logo_url') or url_for(
+        'static', filename='images/company-logo.png', _external=True
+    )
     footer_left = _get('footer_left')
     report_id = _get('report_id')
     contact = _get('contact', 'tschwartz@4spectra.com')
@@ -3070,6 +3072,10 @@ def export_aoi_daily_report():
     show_cover = str(request.args.get('show_cover', 'false')).lower() not in {'0', 'false', 'no'}
     report_css = _load_report_css()
 
+    logo_url = request.args.get('logo_url') or url_for(
+        'static', filename='images/company-logo.png', _external=True
+    )
+
     html = render_template(
         'report/aoi_daily/index.html',
         day=day.isoformat(),
@@ -3078,6 +3084,7 @@ def export_aoi_daily_report():
         end=end,
         generated_at=generated_at,
         contact=contact,
+        logo_url=logo_url,
         report_css=report_css,
         **payload,
     )
@@ -3516,7 +3523,9 @@ def export_operator_report():
     report_date = _get('report_date')
     period = _get('period')
     author = _get('author')
-    logo_url = _get('logo_url') or url_for('static', filename='images/company-logo.png')
+    logo_url = _get('logo_url') or url_for(
+        'static', filename='images/company-logo.png', _external=True
+    )
     footer_left = _get('footer_left')
     report_id = _get('report_id')
     contact = _get('contact', 'tschwartz@4spectra.com')

--- a/templates/report/aoi_daily/cover.html
+++ b/templates/report/aoi_daily/cover.html
@@ -2,7 +2,9 @@
     <br>
     <header>
         <h1>
-            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="Company logo" class="company-logo-pdf"/>
+            {% endif %}
             {{ title or 'AOI Daily Report' }}
         </h1>
     </header>

--- a/templates/report/cover.html
+++ b/templates/report/cover.html
@@ -2,7 +2,9 @@
     <br>
     <header>
         <h1>
-            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="Company logo" class="company-logo-pdf"/>
+            {% endif %}
             {{ title or 'Operator Report' }}
         </h1>
     </header>

--- a/templates/report/integrated/cover.html
+++ b/templates/report/integrated/cover.html
@@ -2,7 +2,9 @@
     <br>
     <header>
         <h1>
-            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="Company logo" class="company-logo-pdf"/>
+            {% endif %}
             {{ title or 'AOI Integrated Report' }}
         </h1>
     </header>

--- a/templates/report/operator/cover.html
+++ b/templates/report/operator/cover.html
@@ -2,7 +2,9 @@
     <br>
     <header>
         <h1>
-            <img src="{{ logo_url or url_for('static', filename='images/company-logo.png') }}" alt="Company logo" class="company-logo-pdf"/>
+            {% if logo_url %}
+            <img src="{{ logo_url }}" alt="Company logo" class="company-logo-pdf"/>
+            {% endif %}
             {{ title or 'Operator Report' }}
         </h1>
     </header>

--- a/tests/test_aoi_daily_report.py
+++ b/tests/test_aoi_daily_report.py
@@ -85,6 +85,7 @@ def test_export_aoi_daily_report_cover_fields(app_instance, monkeypatch):
         )
         assert resp.status_code == 200
         html = resp.data.decode()
+        assert "http://localhost/static/images/company-logo.png" in html
         assert "<style>" in html
         assert "--font-body" in html
         assert "report_range:</b> 2024-06-01 - 2024-06-01" in html

--- a/tests/test_operator_report_routes.py
+++ b/tests/test_operator_report_routes.py
@@ -180,7 +180,7 @@ def test_operator_cover_page(app_instance, monkeypatch):
         assert resp.status_code == 200
         html = resp.data.decode()
         assert "cover-page" in html
-        assert "/static/images/company-logo.png" in html
+        assert "http://localhost/static/images/company-logo.png" in html
         assert "Alice" in html
 
         resp = client.get(


### PR DESCRIPTION
## Summary
- default integrated, operator, and AOI daily exports to an absolute static logo when none is provided
- update report cover templates to expect an absolute logo URL
- extend report export tests to verify the exported HTML embeds the fully-qualified logo URL

## Testing
- pytest tests/test_export_report_rendering.py tests/test_operator_report_routes.py tests/test_aoi_daily_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d2df2120f88325beaf8fa5c97fb331