### PR TITLE
Allow linking feature states to UUID bug IDs

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -91,7 +91,7 @@ def upsert_feature_state(
     *,
     status: str,
     message: str | None = None,
-    bug_report_id: int | str | None = None,
+    bug_report_id: str | None = None,
 ) -> tuple[list[dict] | None, str | None]:
     """Create or update a feature state entry."""
 
@@ -104,14 +104,11 @@ def upsert_feature_state(
     if error:
         return None, error
 
-    bug_value: int | None
+    bug_value: str | None
     if bug_report_id in (None, ""):
         bug_value = None
     else:
-        try:
-            bug_value = int(bug_report_id)
-        except (TypeError, ValueError):
-            return None, "Bug report identifier must be a number"
+        bug_value = str(bug_report_id)
 
     payload = {
         "slug": slug,
@@ -133,17 +130,12 @@ def upsert_feature_state(
 
 
 def fetch_feature_states_for_bug(
-    bug_report_id: int | str,
+    bug_report_id: str,
 ) -> tuple[list[dict] | None, str | None]:
     """Return feature state records associated with ``bug_report_id``."""
 
     if bug_report_id in (None, ""):
         return [], None
-
-    try:
-        bug_value = int(bug_report_id)
-    except (TypeError, ValueError):
-        return [], "Invalid bug report identifier"
 
     supabase, error = _ensure_supabase_client()
     if error:
@@ -153,7 +145,7 @@ def fetch_feature_states_for_bug(
         response = (
             supabase.table("app_feature_states")
             .select("*")
-            .eq("bug_report_id", bug_value)
+            .eq("bug_report_id", str(bug_report_id))
             .execute()
         )
         return response.data or [], None

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -822,20 +822,18 @@ def _fetch_configured_users() -> tuple[list[dict], str | None]:
     return users, supabase_error
 
 
-def _normalize_bug_id(value: object) -> int | None:
-    try:
-        if value in (None, ""):
-            return None
-        return int(value)
-    except (TypeError, ValueError):
+def _normalize_bug_id(value: object) -> str | None:
+    if value in (None, ""):
         return None
+    text = str(value).strip()
+    return text or None
 
 
 def _build_feature_cards(
     bug_records: list[dict] | None,
-) -> tuple[list[dict[str, object]], dict[int, dict]]:
+) -> tuple[list[dict[str, object]], dict[str, dict]]:
     cards: list[dict[str, object]] = []
-    bug_lookup: dict[int, dict] = {}
+    bug_lookup: dict[str, dict] = {}
 
     for bug in bug_records or []:
         bug_id = _normalize_bug_id(bug.get("id"))
@@ -888,7 +886,7 @@ def _build_bug_options(bug_records: list[dict] | None) -> list[dict[str, object]
         key=lambda item: (
             0 if item["status"] == "on_hold" else 1,
             0 if item["status"] == "open" else 1,
-            item["id"],
+            str(item["id"]),
         )
     )
     return options
@@ -1086,7 +1084,7 @@ def admin_feature_action():
     bug_id = _normalize_bug_id(raw_bug_id)
 
     if raw_bug_id and bug_id is None:
-        flash('Enter a valid bug report number to link.', 'error')
+        flash('Enter a valid bug report identifier to link.', 'error')
         return redirect(url_for('main.admin_panel', tab='features'))
 
     definition = _feature_definition(slug)

--- a/migrations/20240730_create_app_feature_states.sql
+++ b/migrations/20240730_create_app_feature_states.sql
@@ -2,7 +2,7 @@ CREATE TABLE IF NOT EXISTS app_feature_states (
     slug text PRIMARY KEY,
     status text NOT NULL DEFAULT 'available',
     message text,
-    bug_report_id bigint REFERENCES bug_reports(id) ON DELETE SET NULL,
+    bug_report_id uuid REFERENCES bug_reports(id) ON DELETE SET NULL,
     updated_at timestamptz NOT NULL DEFAULT timezone('utc', now())
 );
 


### PR DESCRIPTION
## Summary
- change the app_feature_states migration to store bug_report_id values as UUIDs
- accept string bug identifiers throughout the feature state persistence layer
- keep admin feature forms and option builders working when bug IDs are UUID strings

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d315f0193c8325ab55a5abaafc40a5