### PR TITLE
Add admin diagnostics summary to home dashboard

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -29,5 +29,38 @@
     </div>
   </a>
 </section>
+{% if user_role == 'ADMIN' and code_errors %}
+<section class="admin-diagnostics">
+  <h2>System Diagnostics</h2>
+  <p class="admin-diagnostics__lead">Spectra detected issues while preparing administrative data. Review the items below to restore service health.</p>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Source</th>
+        <th>Component</th>
+        <th>Status</th>
+        <th>Details</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in code_errors %}
+      <tr>
+        <td>{{ item.source or 'System' }}</td>
+        <td>{{ item.name }}</td>
+        <td>
+          <span class="status status-offline">{{ item.status or 'Unavailable' }}</span>
+        </td>
+        <td>
+          {{ item.message }}
+          {% if item.description %}
+          <br><small>{{ item.description }}</small>
+          {% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>
+{% endif %}
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- surface aggregated Supabase and feature-state issues when administrators load the home dashboard
- render a diagnostics table for admins under the preview grid so problems are easy to spot
- add coverage proving the diagnostics appear when Supabase reports an unavailable table

## Testing
- PYTHONPATH=. pytest tests/test_home_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d31b2122a08325868b0627f73469d9