### PR TITLE
Add bug report preview card and API summary

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -352,6 +352,13 @@ p {
   height: 140px !important;
 }
 
+.dashboard-card__info {
+  font-size: 0.85rem;
+  color: var(--ink-subtle);
+  margin: 0;
+  line-height: 1.4;
+}
+
 .dashboard-card:hover {
   border-color: var(--accent);
   box-shadow: var(--shadow-ambient);

--- a/templates/home.html
+++ b/templates/home.html
@@ -28,6 +28,16 @@
       <canvas id="assemblyForecastPreview"></canvas>
     </div>
   </a>
+  <a
+    class="dashboard-link"
+    href="{{ url_for('main.analysis_tracker_logs', tab='bug-reports') }}"
+  >
+    <div class="dashboard-card">
+      <h2>Bug Reports</h2>
+      <canvas id="bugReportsPreview"></canvas>
+      <p id="bugReportsInfo" class="dashboard-card__info">Loading bug report summary…</p>
+    </div>
+  </a>
 </section>
 {% if user_role == 'ADMIN' and code_errors %}
 <section class="admin-diagnostics">

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -131,12 +131,32 @@ def _forecast_preview_patch():
     }
 
 
+def _bug_preview_patch():
+    today = _current_day()
+    rows = [
+        {
+            "status": "open",
+            "created_at": f"{today.isoformat()}T08:15:00+00:00",
+        },
+        {
+            "status": "resolved",
+            "created_at": f"{today.isoformat()}T12:30:00+00:00",
+        },
+        {
+            "status": "closed",
+            "created_at": f"{(today - timedelta(days=1)).isoformat()}T09:00:00+00:00",
+        },
+    ]
+    return {"fetch_bug_reports": _make_fetch(rows)}
+
+
 PREVIEW_CASES = [
     ("/moat_preview", _moat_preview_patch),
     ("/aoi_preview", _aoi_preview_patch),
     ("/fi_preview", _fi_preview_patch),
     ("/daily_reports_preview", _daily_preview_patch),
     ("/forecast_preview", _forecast_preview_patch),
+    ("/bug_reports_preview", _bug_preview_patch),
 ]
 
 
@@ -161,6 +181,9 @@ def test_home_dashboard_previews_return_expected_fields(
     assert {"values", "yields"} & payload.keys()
     assert "start_date" in payload
     assert "end_date" in payload
+    if endpoint == "/bug_reports_preview":
+        assert "summary" in payload
+        assert payload["summary"]["total_reports"] == 3
 
 
 def test_home_admin_renders_diagnostics(app_instance, monkeypatch):


### PR DESCRIPTION
## Summary
- add a `/bug_reports_preview` endpoint that aggregates the past week of bug report statuses and returns summary metadata
- enhance the preview renderer to handle summary data, configure the new bug report card, and show the status text on the dashboard
- update the home dashboard markup/styles and extend preview tests to cover the bug report preview

## Testing
- PYTHONPATH=. pytest tests/test_preview_endpoints.py tests/test_home_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d321b897288325a3ac61171b251f4a