### PR TITLE
Add admin employee preview toggle and layout sync

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -706,6 +706,8 @@ def admin_employee_portal():
         username=username,
         user_role=role,
         areas=EMPLOYEE_AREA_OPTIONS,
+        employee_preview_active=True,
+        employee_preview_return_url=request.args.get('return') or url_for('main.home'),
     )
 
 

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1763,6 +1763,77 @@ body.employee-layout .content {
   gap: 12px;
 }
 
+.bug-chat-container.has-preview-toggle {
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 16px;
+}
+
+.bug-chat-preview-control {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.employee-preview-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--surface);
+}
+
+.employee-preview-toggle input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.employee-preview-track {
+  position: relative;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: var(--border-muted);
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.employee-preview-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 20px;
+  height: 20px;
+  border-radius: 999px;
+  background: var(--surface);
+  box-shadow: var(--shadow-ambient);
+  transition: transform 0.2s ease;
+}
+
+.employee-preview-toggle input:checked + .employee-preview-track {
+  background: var(--accent);
+}
+
+.employee-preview-toggle input:checked + .employee-preview-track .employee-preview-thumb {
+  transform: translateX(20px);
+}
+
+.employee-preview-toggle input:focus-visible + .employee-preview-track {
+  outline: 3px solid rgba(13, 155, 168, 0.45);
+  outline-offset: 2px;
+}
+
+.employee-preview-text {
+  color: var(--ink);
+}
+
 .bug-chat-trigger {
   display: inline-flex;
   align-items: center;
@@ -2018,5 +2089,11 @@ body.employee-layout .content {
 
   .bug-chat-row {
     flex-direction: column;
+  }
+
+  .bug-chat-container.has-preview-toggle {
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 10px;
   }
 }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -683,6 +683,38 @@ document.addEventListener('DOMContentLoaded', () => {
     const authGuard = chatContainer.querySelector('.bug-chat-auth-guard');
     const submitButton = chatContainer.querySelector('.bug-chat-submit');
     const resetButton = chatContainer.querySelector('.bug-chat-reset');
+    const previewToggle = chatContainer.querySelector('[data-admin-employee-toggle]');
+    const previewLabel = chatContainer.querySelector('[data-preview-toggle-label]');
+
+    if (previewToggle) {
+      const role = (chatContainer.dataset.userRole || '').toUpperCase();
+      if (role === 'ADMIN') {
+        const syncPreviewLabel = () => {
+          if (!previewLabel) return;
+          const stateText = previewToggle.checked
+            ? 'Employee portal preview on'
+            : 'Employee portal preview off';
+          previewLabel.textContent = stateText;
+        };
+
+        const initialState = (previewToggle.dataset.previewActive || '').toLowerCase();
+        if (initialState) {
+          previewToggle.checked = initialState === 'true';
+        }
+
+        syncPreviewLabel();
+
+        previewToggle.addEventListener('change', () => {
+          syncPreviewLabel();
+          const targetUrl = previewToggle.checked
+            ? previewToggle.dataset.employeeUrl
+            : previewToggle.dataset.adminUrl;
+          if (targetUrl) {
+            window.location.href = targetUrl;
+          }
+        });
+      }
+    }
 
     if (panel) {
       panel.setAttribute('aria-hidden', 'true');

--- a/templates/base.html
+++ b/templates/base.html
@@ -7,7 +7,9 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
   {% block extra_head %}{% endblock %}
 </head>
-<body class="{% if user_role == 'EMPLOYEE' %}employee-layout{% endif %}">
+{% set employee_preview_active = employee_preview_active|default(false) %}
+{% set employee_preview_return_url = employee_preview_return_url|default(request.args.get('return') or request.url) %}
+<body class="{% if user_role == 'EMPLOYEE' or employee_preview_active %}employee-layout{% endif %}">
   {% macro feature_nav_link(label, href, slug) -%}
     {% set feature = (feature_states.get(slug) if feature_states else {}) %}
     {% set status = feature.get('status', 'available') %}
@@ -29,7 +31,7 @@
       {% endif %}
     </a>
   {%- endmacro %}
-  {% if user_role != 'EMPLOYEE' %}
+  {% if user_role != 'EMPLOYEE' and not employee_preview_active %}
   <header class="app-header">
     <nav class="navbar" role="navigation" aria-label="Primary">
       <div class="nav-left">
@@ -112,10 +114,11 @@
 
   <div
     id="bug-chat-container"
-    class="bug-chat-container"
+    class="bug-chat-container{% if user_role == 'ADMIN' %} has-preview-toggle{% endif %}"
     data-endpoint="{{ url_for('main.submit_bug_report') }}"
     data-signed-in="{{ 'true' if user_id else 'false' }}"
     data-username="{{ username or '' }}"
+    data-user-role="{{ user_role or '' }}"
   >
     <button
       type="button"
@@ -128,12 +131,24 @@
       <span class="trigger-icon" aria-hidden="true">&#9993;</span>
     </button>
     {% if user_role == 'ADMIN' %}
-    <a
-      class="bug-chat-admin-link"
-      href="{{ url_for('main.admin_employee_portal') }}"
-    >
-      Employee portal preview
-    </a>
+    <div class="bug-chat-preview-control">
+      <label class="employee-preview-toggle">
+        <input
+          type="checkbox"
+          data-admin-employee-toggle
+          data-admin-url="{{ employee_preview_return_url }}"
+          data-employee-url="{{ url_for('main.admin_employee_portal', return=request.path) }}"
+          data-preview-active="{{ 'true' if employee_preview_active else 'false' }}"
+          {% if employee_preview_active %}checked{% endif %}
+        />
+        <span class="employee-preview-track" aria-hidden="true">
+          <span class="employee-preview-thumb"></span>
+        </span>
+        <span class="employee-preview-text" data-preview-toggle-label>
+          Employee portal preview
+        </span>
+      </label>
+    </div>
     {% endif %}
 
     <section

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -321,7 +321,7 @@ def test_admin_employee_portal_requires_admin_role(app_instance):
     assert response.status_code == 403
 
 
-def test_admin_employee_portal_link_visible_for_admin(app_instance, monkeypatch):
+def test_admin_preview_toggle_visible_for_admin(app_instance, monkeypatch):
     client = app_instance.test_client()
 
     with app_instance.app_context():
@@ -342,7 +342,8 @@ def test_admin_employee_portal_link_visible_for_admin(app_instance, monkeypatch)
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert "/admin/employee-portal" in html
+    assert 'data-admin-employee-toggle' in html
+    assert 'data-employee-url="/admin/employee-portal' in html
 
 
 def test_employee_portal_link_hidden_for_non_admin(app_instance):
@@ -353,4 +354,19 @@ def test_employee_portal_link_hidden_for_non_admin(app_instance):
 
     assert response.status_code == 200
     html = response.get_data(as_text=True)
-    assert "/admin/employee-portal" not in html
+    assert 'data-admin-employee-toggle' not in html
+
+
+def test_admin_employee_portal_preview_uses_employee_layout(app_instance):
+    client = app_instance.test_client()
+
+    _login(client, role="ADMIN")
+    response = client.get("/admin/employee-portal?return=/home")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert '<body class="employee-layout"' in html
+    assert '<header class="app-header"' not in html
+    assert 'data-admin-employee-toggle' in html
+    assert 'data-admin-url="/home"' in html
+    assert 'data-preview-active="true"' in html


### PR DESCRIPTION
## Summary
- replace the bug report admin preview link with an employee preview toggle and ensure the base layout respects preview mode
- style the bug chat footer for the new toggle and add JS to drive the preview redirect and labels
- pass preview context from the employee portal route and extend home dashboard tests for the toggle visibility and layout

## Testing
- PYTHONPATH=. pytest tests/test_home_dashboard.py


------
https://chatgpt.com/codex/tasks/task_e_68d33133b2d48325921348084b280b9d