### PR TITLE
Update tracker preview summary to focus on average duration

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2366,11 +2366,7 @@ def tracker_preview():
     end_display = _tracker_format_timestamp(last_end, local_zone)
 
     if total_sessions:
-        summary_text = (
-            f"{start_display or 'N/A'} to {end_display or 'N/A'} | "
-            f"{total_sessions} sessions | {total_events} events | "
-            f"Avg session {average_duration_label}"
-        )
+        summary_text = f"Average Time: {average_duration_label}"
     else:
         summary_text = "No recent tracking sessions recorded."
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -480,20 +480,30 @@ document.addEventListener('DOMContentLoaded', () => {
     infoId: 'trackerAnalyticsInfo',
     summaryFormatter(data) {
       if (!data) return '';
-      const start = data.start_display || data.start_time || data.start_date || 'N/A';
-      const end = data.end_display || data.end_time || data.end_date || 'N/A';
-      const sessions = Number(data.total_sessions || 0);
-      const events = Number(data.total_events || 0);
-      const navigation = Number(data.total_navigation_events || 0);
-      const backtracks = Number(data.total_backtracking_events || 0);
-      const avg = (data.average_duration_label || '').trim() || '--';
-      return [
-        `${start} to ${end}`,
-        `${sessions} sessions`,
-        `${events} events`,
-        `Nav ${navigation} / Backtracks ${backtracks}`,
-        `Avg ${avg}`,
-      ].join(' | ');
+
+      const trimmedAvg = (data.average_duration_label || '').trim();
+      if (trimmedAvg) {
+        return `Average Time: ${trimmedAvg}`;
+      }
+
+      const seconds = Number(data.average_duration_seconds);
+      if (Number.isFinite(seconds)) {
+        const totalSeconds = Math.max(0, seconds);
+        const hours = Math.floor(totalSeconds / 3600);
+        const minutes = Math.floor((totalSeconds % 3600) / 60);
+        const secs = Math.round(totalSeconds % 60);
+        const parts = [];
+        if (hours) {
+          parts.push(`${hours}h`);
+        }
+        if (minutes) {
+          parts.push(`${minutes}m`);
+        }
+        parts.push(`${secs}s`);
+        return `Average Time: ${parts.join(' ')}`;
+      }
+
+      return 'Average Time: --';
     },
     emptyMessage: 'No recent tracker activity.',
     valueFormatter(value) {

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -268,7 +268,10 @@ def test_home_dashboard_previews_return_expected_fields(
         assert payload["total_sessions"] == 2
         assert payload["total_navigation_events"] == 3
         assert payload["total_backtracking_events"] == 1
-        assert payload["summary_text"]
+        assert (
+            payload["summary_text"]
+            == f"Average Time: {payload['average_duration_label']}"
+        )
 
 
 def test_home_admin_renders_diagnostics(app_instance, monkeypatch):

--- a/tests/test_preview_endpoints.py
+++ b/tests/test_preview_endpoints.py
@@ -269,7 +269,7 @@ def test_tracker_preview_returns_summary(app_instance, monkeypatch):
         assert data['total_backtracking_events'] == 1
         assert data['average_duration_seconds'] is not None
         assert data['average_duration_label']
-        assert data['summary_text']
+        assert data['summary_text'] == f"Average Time: {data['average_duration_label']}"
         assert ('start_time' in data and data['start_time']) or (
             'start_date' in data and data['start_date']
         )


### PR DESCRIPTION
## Summary
- simplify the tracker preview summary so it only reports the formatted average session duration on both the server response and client display
- ensure the front-end gracefully falls back when no duration label is available
- align preview endpoint tests with the new summary format

## Testing
- PYTHONPATH=. pytest tests/test_preview_endpoints.py tests/test_home_dashboard.py


------
https://chatgpt.com/codex/tasks/task_e_68d3346ab6048325b694dd4d5d1a4140