### PR TITLE
Remove bug report summary from home dashboard preview

### DIFF
--- a/static/js/main.js
+++ b/static/js/main.js
@@ -451,7 +451,6 @@ document.addEventListener('DOMContentLoaded', () => {
   renderTablePreview({
     endpoint: '/bug_reports_preview',
     tableId: 'bugReportsPreviewTable',
-    infoId: 'bugReportsInfo',
     summaryFormatter(data) {
       if (!data || !data.summary) return '';
       const { summary } = data;

--- a/templates/home.html
+++ b/templates/home.html
@@ -47,7 +47,6 @@
           </tr>
         </tbody>
       </table>
-      <p id="bugReportsInfo" class="dashboard-card__info">Loading bug report summary…</p>
     </div>
   </a>
   <a


### PR DESCRIPTION
## Summary
- remove the bug report summary paragraph from the home dashboard card so it no longer reserves space for the text
- stop providing an info element id when rendering the bug report preview table so no summary text is generated

## Testing
- PYTHONPATH=. pytest tests/test_home_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d33583b9648325a2843ce753b95cae