### PR TITLE
Auto-fill AOI program and load defect dropdown

### DIFF
--- a/templates/employee_home.html
+++ b/templates/employee_home.html
@@ -180,7 +180,9 @@
                       <input type="text" data-rejection-ref placeholder="e.g. R15" autocomplete="off">
                     </td>
                     <td data-label="Rejection Reason">
-                      <input type="text" data-rejection-reason placeholder="e.g. Bent lead" autocomplete="off">
+                      <select data-rejection-reason>
+                        <option value="" disabled selected>Loading defects...</option>
+                      </select>
                     </td>
                     <td data-label="Quantity">
                       <input type="number" data-rejection-quantity min="1" step="1" placeholder="0">


### PR DESCRIPTION
## Summary
- automatically set the Program input when an employee chooses the SMT or TH inspection data sheet and keep it read-only
- fetch the defect catalog for employees and populate the rejection reason selector with id and name details
- keep rejection detail serialization in sync with the selected defect metadata

## Testing
- pytest tests/test_employee_aoi_defects.py

------
https://chatgpt.com/codex/tasks/task_e_68d49a9375908325af7cc85643334e5c