### PR TITLE
Fix duplicate rejection reason set declaration

### DIFF
--- a/static/js/employee.js
+++ b/static/js/employee.js
@@ -406,7 +406,6 @@ function setupAoiArea(container) {
   const rejectionRowTemplate = sheetForm ? sheetForm.querySelector('[data-rejection-row-template]') : null;
   const addRejectionRowButton = sheetForm ? sheetForm.querySelector('[data-action="add-rejection-row"]') : null;
   const rejectionHiddenInput = sheetForm ? sheetForm.querySelector('[data-rejection-json]') : null;
-  const rejectionReasonSelects = new Set();
   const operatorSignature = sheetForm ? sheetForm.querySelector('[data-operator-signature]') : null;
   const signatureControl = operatorSignature ? operatorSignature.querySelector('[data-action="operator-signature"]') : null;
   const signatureDisplay = operatorSignature ? operatorSignature.querySelector('[data-signature-display]') : null;


### PR DESCRIPTION
## Summary
- remove a duplicate declaration of the rejection reason select set in the employee portal script to prevent runtime syntax errors

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d49e58ea088325a26664f4c3493a2c