### PR TITLE
Enhance desktop report downloads and styling

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -741,6 +741,49 @@ p {
   resize: vertical;
 }
 
+.content select,
+.content .field-row select,
+.modal select {
+  appearance: none;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  background-color: var(--surface);
+  border: var(--border-thin) solid var(--border-muted);
+  border-radius: 10px;
+  padding: 11px 42px 11px 16px;
+  color: var(--ink);
+  font-size: 0.95rem;
+  line-height: 1.4;
+  min-height: 42px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45),
+    0 1px 2px rgba(17, 24, 39, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--border-strong) 50%),
+    linear-gradient(135deg, var(--border-strong) 50%, transparent 50%),
+    linear-gradient(to right, var(--border-muted), var(--border-muted));
+  background-position:
+    calc(100% - 22px) calc(50% - 4px),
+    calc(100% - 16px) calc(50% - 4px),
+    calc(100% - 2.8rem) 0.45rem;
+  background-size: 8px 8px, 8px 8px, 1px 70%;
+  background-repeat: no-repeat;
+}
+
+.content select:hover,
+.content .field-row select:hover,
+.modal select:hover {
+  border-color: var(--border-hover);
+}
+
+.content select:focus,
+.content .field-row select:focus,
+.modal select:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
 .full-width {
   grid-column: 1 / -1;
 }
@@ -751,16 +794,70 @@ p {
   flex-wrap: wrap;
 }
 
+.content button,
+.content input[type='button'],
+.content input[type='submit'],
+.modal button,
+.modal input[type='button'],
+.modal input[type='submit'] {
+  font-family: var(--font-base);
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: var(--border-thin) solid var(--border-muted);
+  background: linear-gradient(180deg, var(--surface), var(--muted-light));
+  color: var(--ink);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  cursor: pointer;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.75);
+  transition: transform 0.18s ease, box-shadow 0.18s ease,
+    border-color 0.18s ease, background-color 0.18s ease;
+}
+
+.content button:hover,
+.content button:focus,
+.content input[type='button']:hover,
+.content input[type='button']:focus,
+.content input[type='submit']:hover,
+.content input[type='submit']:focus,
+.modal button:hover,
+.modal button:focus,
+.modal input[type='button']:hover,
+.modal input[type='button']:focus,
+.modal input[type='submit']:hover,
+.modal input[type='submit']:focus {
+  border-color: var(--accent);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.12);
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.content button:disabled,
+.content input[type='button']:disabled,
+.content input[type='submit']:disabled,
+.modal button:disabled,
+.modal input[type='button']:disabled,
+.modal input[type='submit']:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
 button.primary,
 .primary {
   background: var(--accent);
   color: #fff;
   border: none;
-  padding: 12px 16px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  cursor: pointer;
-  transition: background 0.2s ease, transform 0.2s ease;
+  box-shadow: 0 12px 24px rgba(10, 155, 168, 0.35);
+  transition: background 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 button.primary:hover,
@@ -769,18 +866,16 @@ button.primary:focus,
 .primary:focus {
   background: var(--accent-strong);
   transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(11, 107, 116, 0.3);
 }
 
 button.ghost,
 .ghost {
   background: transparent;
   border: var(--border-thin) solid var(--border);
-  padding: 12px 16px;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--ink);
-  cursor: pointer;
-  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 button.ghost:hover,
@@ -790,6 +885,7 @@ button.ghost:focus,
   background: var(--muted);
   border-color: var(--accent);
   color: var(--accent-strong);
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
 }
 
 .data-table {
@@ -842,7 +938,7 @@ textarea,
 input,
 select,
 button {
-  border-radius: 0;
+  border-radius: 10px;
 }
 
 @media (max-width: 1100px) {

--- a/static/js/aoi_daily_report.js
+++ b/static/js/aoi_daily_report.js
@@ -1,4 +1,4 @@
-import { showSpinner, hideSpinner } from './utils.js';
+import { downloadFile } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-report');
@@ -24,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(() => alert('Failed to run report.'));
   });
 
-  downloadBtn?.addEventListener('click', () => {
+  downloadBtn?.addEventListener('click', async () => {
     const fmt = document.getElementById('file-format').value;
     const date = document.getElementById('report-date').value;
     if (!date) {
@@ -32,8 +32,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
     const params = new URLSearchParams({ format: fmt, date, show_cover: 'true' });
-    showSpinner('download-report');
-    window.location = `/reports/aoi_daily/export?${params.toString()}`;
-    setTimeout(() => hideSpinner('download-report'), 3000);
+    await downloadFile(`/reports/aoi_daily/export?${params.toString()}`, {
+      buttonId: 'download-report',
+    });
   });
 });

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,4 +1,4 @@
-import { showSpinner, hideSpinner } from './utils.js';
+import { downloadFile } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-report');
@@ -28,7 +28,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(() => alert('Failed to run report.'));
   });
 
-  downloadBtn?.addEventListener('click', () => {
+  downloadBtn?.addEventListener('click', async () => {
     const fmt = document.getElementById('file-format').value;
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
@@ -37,9 +37,9 @@ document.addEventListener('DOMContentLoaded', () => {
     params.append('show_cover', includeCover ? 'true' : 'false');
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
-    showSpinner('download-report');
-    window.location = `/reports/integrated/export?${params.toString()}`;
-    setTimeout(() => hideSpinner('download-report'), 3000);
+    await downloadFile(`/reports/integrated/export?${params.toString()}`, {
+      buttonId: 'download-report',
+    });
   });
 
   document.getElementById('email-report')?.addEventListener('click', () => {

--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -46,7 +46,7 @@ function getDropdownValues(className) {
     .filter((v) => v);
 }
 
-import { showSpinner, hideSpinner } from './utils.js';
+import { downloadFile } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-report');
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(() => alert('Failed to run report.'));
   });
 
-  downloadBtn?.addEventListener('click', () => {
+  downloadBtn?.addEventListener('click', async () => {
     const fmt = document.getElementById('file-format').value;
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
@@ -94,9 +94,9 @@ document.addEventListener('DOMContentLoaded', () => {
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
     if (operator) params.append('operator', operator);
-    showSpinner('download-report');
-    window.location = `/reports/operator/export?${params.toString()}`;
-    setTimeout(() => hideSpinner('download-report'), 3000);
+    await downloadFile(`/reports/operator/export?${params.toString()}`, {
+      buttonId: 'download-report',
+    });
   });
 
   document.getElementById('email-report')?.addEventListener('click', () => {

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -1,13 +1,71 @@
-export function showSpinner(btnId) {
-  const spinner = document.getElementById('download-spinner');
-  const btn = document.getElementById(btnId);
+export function showSpinner(btnId, spinnerId = 'download-spinner') {
+  const spinner = spinnerId ? document.getElementById(spinnerId) : null;
+  const btn = btnId ? document.getElementById(btnId) : null;
   if (spinner) spinner.hidden = false;
   if (btn) btn.disabled = true;
 }
 
-export function hideSpinner(btnId) {
-  const spinner = document.getElementById('download-spinner');
-  const btn = document.getElementById(btnId);
+export function hideSpinner(btnId, spinnerId = 'download-spinner') {
+  const spinner = spinnerId ? document.getElementById(spinnerId) : null;
+  const btn = btnId ? document.getElementById(btnId) : null;
   if (spinner) spinner.hidden = true;
   if (btn) btn.disabled = false;
+}
+
+function decodeFileName(disposition) {
+  if (!disposition) return null;
+  // RFC 5987 style: filename*=UTF-8''...
+  const encodedMatch = /filename\*=UTF-8''([^;]+)/i.exec(disposition);
+  if (encodedMatch && encodedMatch[1]) {
+    try {
+      return decodeURIComponent(encodedMatch[1]);
+    } catch (err) {
+      console.warn('Failed to decode RFC5987 filename', err);
+    }
+  }
+  const quotedMatch = /filename="?([^";]+)"?/i.exec(disposition);
+  if (quotedMatch && quotedMatch[1]) {
+    return quotedMatch[1];
+  }
+  return null;
+}
+
+export async function downloadFile(url, { buttonId, spinnerId = 'download-spinner', filename } = {}) {
+  showSpinner(buttonId, spinnerId);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      credentials: 'same-origin',
+    });
+    if (!response.ok) {
+      throw new Error(`Download failed with status ${response.status}`);
+    }
+    const blob = await response.blob();
+    let downloadName = filename;
+    if (!downloadName) {
+      downloadName = decodeFileName(response.headers.get('Content-Disposition'));
+    }
+    if (!downloadName) {
+      const parsed = new URL(url, window.location.origin);
+      const parts = parsed.pathname.split('/').filter(Boolean);
+      downloadName = parts.length ? parts[parts.length - 1] : 'download';
+    }
+    const blobUrl = window.URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = blobUrl;
+    anchor.download = downloadName;
+    anchor.rel = 'noopener';
+    anchor.style.display = 'none';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    window.URL.revokeObjectURL(blobUrl);
+    return true;
+  } catch (err) {
+    console.error('Download failed', err);
+    alert('Failed to download file. Please try again.');
+    return false;
+  } finally {
+    hideSpinner(buttonId, spinnerId);
+  }
 }


### PR DESCRIPTION
## Summary
- style application dropdowns and action buttons with rounded, elevated controls and refined focus states outside the navigation bar
- add a reusable download helper to fetch report exports as files and hook it up to integrated, operator, and AOI daily report buttons

## Testing
- PYTHONPATH=. pytest tests/test_export_integrated_report_date_range.py

------
https://chatgpt.com/codex/tasks/task_e_68d4a4fad73483258d1348e1da184cb3