### PR TITLE
Allow administrators to upload analysis data

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -2502,7 +2502,11 @@ def forecast_preview():
 def ppm_analysis():
     if 'username' not in session:
         return redirect(url_for('auth.login'))
-    return render_template('ppm_analysis.html', username=session.get('username'))
+    return render_template(
+        'ppm_analysis.html',
+        username=session.get('username'),
+        user_role=(session.get('role') or '').upper(),
+    )
 
 
 @main_bp.route('/analysis/ppm/data', methods=['GET'])
@@ -5010,7 +5014,11 @@ def analysis_tracker_logs():
 def aoi_daily_reports():
     if 'username' not in session:
         return redirect(url_for('auth.login'))
-    return render_template('aoi_daily_reports.html', username=session.get('username'))
+    return render_template(
+        'aoi_daily_reports.html',
+        username=session.get('username'),
+        user_role=(session.get('role') or '').upper(),
+    )
 
 
 def _daily_data(fetch_func):
@@ -5231,7 +5239,11 @@ def aoi_daily_data():
 def fi_daily_reports():
     if 'username' not in session:
         return redirect(url_for('auth.login'))
-    return render_template('fi_daily_reports.html', username=session.get('username'))
+    return render_template(
+        'fi_daily_reports.html',
+        username=session.get('username'),
+        user_role=(session.get('role') or '').upper(),
+    )
 
 
 @main_bp.route('/analysis/fi/data', methods=['GET'])

--- a/templates/aoi_daily_reports.html
+++ b/templates/aoi_daily_reports.html
@@ -8,7 +8,7 @@
     <div class="analysis-left section-card">
       <div class="tab-bar">
         <div class="tab active" data-target="builder-tab">Chart Builder</div>
-        {% if username == 'ADMIN' %}
+        {% if user_role == 'ADMIN' %}
         <div class="tab" data-target="upload-tab">Upload</div>
         {% endif %}
       </div>
@@ -75,7 +75,7 @@
         </div>
       </div>
 
-      {% if username == 'ADMIN' %}
+      {% if user_role == 'ADMIN' %}
       <div id="upload-tab" class="tab-content" style="display:none;">
         <form id="upload-form">
           <div class="field-row">

--- a/templates/fi_daily_reports.html
+++ b/templates/fi_daily_reports.html
@@ -8,7 +8,7 @@
     <div class="analysis-left section-card">
       <div class="tab-bar">
         <div class="tab active" data-target="builder-tab">Chart Builder</div>
-        {% if username == 'ADMIN' %}
+        {% if user_role == 'ADMIN' %}
         <div class="tab" data-target="upload-tab">Upload</div>
         {% endif %}
       </div>
@@ -75,7 +75,7 @@
         </div>
       </div>
 
-      {% if username == 'ADMIN' %}
+      {% if user_role == 'ADMIN' %}
       <div id="upload-tab" class="tab-content" style="display:none;">
         <form id="upload-form">
           <div class="field-row">

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -8,7 +8,7 @@
     <div class="analysis-left section-card">
       <div class="tab-bar">
         <div class="tab active" data-target="builder-tab">Chart Builder</div>
-        {% if username == 'ADMIN' %}
+        {% if user_role == 'ADMIN' %}
         <div class="tab" data-target="upload-tab">Upload</div>
         {% endif %}
       </div>
@@ -160,7 +160,7 @@
         <button type="button" id="run-chart">Run</button>
       </div>
     </div> <!-- end builder-tab -->
-    {% if username == 'ADMIN' %}
+    {% if user_role == 'ADMIN' %}
     <div id="upload-tab" class="tab-content" style="display:none;">
       <form id="upload-form">
         <div class="field-row">


### PR DESCRIPTION
## Summary
- ensure analysis upload tabs render for any user with the ADMIN role label
- pass the current session role to the AOI, FI, and PPM analysis templates so the upload tab can be shown for administrators

## Testing
- pytest tests/test_home_dashboard.py *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68d67322b8b48325b60afdb73e830ee1