### PR TITLE
Add DPM ingestion and analysis endpoints

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -450,6 +450,36 @@ def fetch_recent_moat(days: int = 7):
         return None, f"Failed to fetch recent MOAT data: {exc}"
 
 
+def fetch_moat_dpm():
+    """Retrieve MOAT DPM data from the database."""
+
+    supabase = _get_client()
+    try:
+        response = supabase.table("moat_dpm").select("*").execute()
+        data = _apply_report_date_offset(response.data)
+        return data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch MOAT DPM data: {exc}"
+
+
+def fetch_recent_moat_dpm(days: int = 7):
+    """Retrieve recent MOAT DPM data for the past ``days`` days."""
+
+    supabase = _get_client()
+    start_date = (datetime.utcnow() - timedelta(days=days)).date().isoformat()
+    try:
+        response = (
+            supabase.table("moat_dpm")
+            .select("*")
+            .gte("Report Date", start_date)
+            .execute()
+        )
+        data = _apply_report_date_offset(response.data)
+        return data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch recent MOAT DPM data: {exc}"
+
+
 def fetch_defect_catalog() -> tuple[list[dict[str, str]] | None, str | None]:
     """Return the list of known defects with identifiers and names."""
 
@@ -550,6 +580,28 @@ def insert_moat_bulk(rows: list[dict]):
         return None, f"Failed to insert MOAT data: {exc}"
 
 
+def insert_moat_dpm(data: dict):
+    """Insert a single MOAT DPM record."""
+
+    supabase = _get_client()
+    try:
+        response = supabase.table("moat_dpm").insert(data).execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to insert MOAT DPM data: {exc}"
+
+
+def insert_moat_dpm_bulk(rows: list[dict]):
+    """Insert multiple MOAT DPM records."""
+
+    supabase = _get_client()
+    try:
+        response = supabase.table("moat_dpm").insert(rows).execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to insert MOAT DPM data: {exc}"
+
+
 def fetch_saved_queries():
     """Retrieve saved chart queries for PPM analysis.
 
@@ -584,6 +636,25 @@ def fetch_saved_queries():
         return None, f"Failed to fetch saved queries: {exc}"
 
 
+def fetch_dpm_saved_queries():
+    """Retrieve saved chart queries for DPM analysis."""
+
+    supabase = _get_client()
+    try:
+        response = (
+            supabase.table("dpm_saved_queries")
+            .select(
+                "id,name,type,description,start_date,end_date,value_source,x_column,y_agg,"
+                "chart_type,line_color,params,created_at"
+            )
+            .order("created_at", desc=True)
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to fetch DPM saved queries: {exc}"
+
+
 def insert_saved_query(data: dict):
     """Insert a saved chart query definition into Supabase.
 
@@ -597,6 +668,17 @@ def insert_saved_query(data: dict):
         return response.data, None
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to save chart query: {exc}"
+
+
+def insert_dpm_saved_query(data: dict):
+    """Insert a saved DPM chart query definition into Supabase."""
+
+    supabase = _get_client()
+    try:
+        response = supabase.table("dpm_saved_queries").insert(data).execute()
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to save DPM chart query: {exc}"
 
 
 def update_saved_query(name: str, data: dict):
@@ -618,6 +700,22 @@ def update_saved_query(name: str, data: dict):
         return response.data, None
     except Exception as exc:  # pragma: no cover - network errors
         return None, f"Failed to update saved query: {exc}"
+
+
+def update_dpm_saved_query(name: str, data: dict):
+    """Update or upsert a saved DPM chart query definition by ``name``."""
+
+    supabase = _get_client()
+    try:
+        payload = {**data, "name": name}
+        response = (
+            supabase.table("dpm_saved_queries")
+            .upsert(payload, on_conflict="name")
+            .execute()
+        )
+        return response.data, None
+    except Exception as exc:  # pragma: no cover - network errors
+        return None, f"Failed to update DPM saved query: {exc}"
 
 
 def fetch_saved_aoi_queries():

--- a/migrations/20240906_create_moat_dpm_tables.sql
+++ b/migrations/20240906_create_moat_dpm_tables.sql
@@ -1,0 +1,36 @@
+CREATE TABLE IF NOT EXISTS moat_dpm (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    "Model Name" text NOT NULL,
+    "Total Boards" numeric,
+    "Total Parts/Board" numeric,
+    "Total Parts" numeric,
+    "NG Parts" numeric,
+    "NG PPM" numeric,
+    "FalseCall Parts" numeric,
+    "FalseCall PPM" numeric,
+    "Report Date" date NOT NULL,
+    "Line" text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS moat_dpm_report_date_idx ON moat_dpm ("Report Date");
+CREATE INDEX IF NOT EXISTS moat_dpm_line_idx ON moat_dpm ("Line");
+
+CREATE TABLE IF NOT EXISTS dpm_saved_queries (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    name text UNIQUE NOT NULL,
+    type text NOT NULL,
+    description text,
+    start_date date,
+    end_date date,
+    value_source text,
+    x_column text,
+    y_agg text,
+    chart_type text,
+    line_color text,
+    params jsonb NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT timezone('utc', now())
+);
+
+CREATE INDEX IF NOT EXISTS dpm_saved_queries_created_at_idx
+    ON dpm_saved_queries (created_at DESC);

--- a/tests/test_upload_dpm_reports.py
+++ b/tests/test_upload_dpm_reports.py
@@ -1,0 +1,110 @@
+import os
+import io
+import pytest
+from openpyxl import Workbook
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def make_workbook():
+    wb = Workbook()
+    ws = wb.active
+    ws.cell(row=7, column=2, value="ModelX")
+    ws.cell(row=7, column=3, value=1)
+    ws.cell(row=7, column=4, value=1)
+    ws.cell(row=7, column=5, value=1)
+    ws.cell(row=7, column=6, value=1)
+    ws.cell(row=7, column=7, value=1)
+    ws.cell(row=7, column=8, value=1)
+    ws.cell(row=7, column=9, value=1)
+    ws.cell(row=8, column=2, value="Total")
+    buf = io.BytesIO()
+    wb.save(buf)
+    buf.seek(0)
+    return buf
+
+
+def test_upload_dpm_single_date(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = {}
+
+    def fake_insert(rows):
+        captured["rows"] = rows
+        return None, None
+
+    monkeypatch.setattr(routes, "insert_moat_dpm_bulk", fake_insert)
+    with app_instance.app_context():
+        data = {"file": (make_workbook(), "DPMReportControl 2024-07-01 L1.xlsx")}
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/dpm_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured["rows"][0]["Line"] == "L1"
+    assert captured["rows"][0]["Report Date"] == "2024-07-01"
+
+
+def test_upload_dpm_date_range(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = {}
+
+    def fake_insert(rows):
+        captured["rows"] = rows
+        return None, None
+
+    monkeypatch.setattr(routes, "insert_moat_dpm_bulk", fake_insert)
+    with app_instance.app_context():
+        data = {
+            "file": (make_workbook(), "DPMReportControl 2024-07-01 to 2024-07-02 L2.xlsx")
+        }
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post("/dpm_reports/upload", data=data, content_type="multipart/form-data")
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured["rows"][0]["Line"] == "L2"
+    assert captured["rows"][0]["Report Date"] == "2024-07-01"
+
+
+def test_upload_dpm_mixed_case_filename(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    captured = {}
+
+    def fake_insert(rows):
+        captured["rows"] = rows
+        return None, None
+
+    monkeypatch.setattr(routes, "insert_moat_dpm_bulk", fake_insert)
+    with app_instance.app_context():
+        data = {
+            "file": (
+                make_workbook(),
+                "dPmRePorTCoNtRoL 2024-07-01 To 2024-07-02 l3.XLSX",
+            )
+        }
+        with client.session_transaction() as sess:
+            sess["username"] = "ADMIN"
+        resp = client.post(
+            "/dpm_reports/upload",
+            data=data,
+            content_type="multipart/form-data",
+        )
+    assert resp.status_code == 201
+    assert resp.get_json()["inserted"] == 1
+    assert captured["rows"][0]["Line"] == "l3"
+    assert captured["rows"][0]["Report Date"] == "2024-07-01"


### PR DESCRIPTION
## Summary
- add a migration defining Supabase tables for MOAT DPM data and saved queries
- extend the database helper module with DPM fetch/insert utilities
- expose DPM upload and analysis endpoints plus tests for the new upload route

## Testing
- PYTHONPATH=. pytest tests/test_upload_dpm_reports.py

------
https://chatgpt.com/codex/tasks/task_e_68d67c0448548325ae572e104a84ade3