### PR TITLE
Add DPM analysis dashboard and preview integration

### DIFF
--- a/static/js/dpm.js
+++ b/static/js/dpm.js
@@ -1,11 +1,11 @@
 import { showSpinner, hideSpinner } from './utils.js';
 
-let ppmChartInstance = null;
-let ppmChartExpandedInstance = null;
+let dpmChartInstance = null;
+let dpmChartExpandedInstance = null;
 let currentData = { labels: [], values: [], datasets: [] };
 let savedQueriesCache = [];
 
-// Inferred columns/types from /moat
+// Inferred columns/types from /moat_dpm
 let allColumns = [];
 let columnTypes = {}; // { colName: 'temporal'|'numeric'|'categorical'|'boolean' }
 
@@ -139,13 +139,13 @@ function renderChart(targetId, labels, values, cfg) {
     ],
   };
 
-  if (targetId === 'ppmChart' && ppmChartInstance) ppmChartInstance.destroy();
-  if (targetId === 'ppmChartExpanded' && ppmChartExpandedInstance) ppmChartExpandedInstance.destroy();
+  if (targetId === 'dpmChart' && dpmChartInstance) dpmChartInstance.destroy();
+  if (targetId === 'dpmChartExpanded' && dpmChartExpandedInstance) dpmChartExpandedInstance.destroy();
 
   // eslint-disable-next-line no-undef
   const instance = new Chart(ctx, { type: cfg.type, data, options: buildOptions(cfg), plugins: [controlLinesPlugin] });
-  if (targetId === 'ppmChart') ppmChartInstance = instance;
-  if (targetId === 'ppmChartExpanded') ppmChartExpandedInstance = instance;
+  if (targetId === 'dpmChart') dpmChartInstance = instance;
+  if (targetId === 'dpmChartExpanded') dpmChartExpandedInstance = instance;
 }
 
 // Render multiple datasets (series) against shared labels
@@ -172,8 +172,8 @@ function renderChartMulti(targetId, labels, datasets, cfg) {
     borderWidth: 2,
   }));
 
-  if (targetId === 'ppmChart' && ppmChartInstance) ppmChartInstance.destroy();
-  if (targetId === 'ppmChartExpanded' && ppmChartExpandedInstance) ppmChartExpandedInstance.destroy();
+  if (targetId === 'dpmChart' && dpmChartInstance) dpmChartInstance.destroy();
+  if (targetId === 'dpmChartExpanded' && dpmChartExpandedInstance) dpmChartExpandedInstance.destroy();
 
   // eslint-disable-next-line no-undef
   const baseOpts = buildOptions(cfg);
@@ -183,8 +183,8 @@ function renderChartMulti(targetId, labels, datasets, cfg) {
     options: { ...baseOpts, plugins: { ...baseOpts.plugins, legend: { display: true } } },
     plugins: [controlLinesPlugin],
   });
-  if (targetId === 'ppmChart') ppmChartInstance = instance;
-  if (targetId === 'ppmChartExpanded') ppmChartExpandedInstance = instance;
+  if (targetId === 'dpmChart') dpmChartInstance = instance;
+  if (targetId === 'dpmChartExpanded') dpmChartExpandedInstance = instance;
 }
 
 function fillTable(labels, values) {
@@ -202,7 +202,7 @@ function fillTable(labels, values) {
 }
 
 function updateInfo(labels, values) {
-  const info = document.getElementById('ppm-info');
+  const info = document.getElementById('dpm-info');
   const avg = values.length ? (values.reduce((a, b) => a + b, 0) / values.length).toFixed(4) : '0';
   info.textContent = `${labels[0] || ''} to ${labels[labels.length - 1] || ''} | Avg: ${avg}`;
 }
@@ -213,8 +213,8 @@ function expandModal(show) {
   if (show) {
     document.getElementById('modal-title').textContent = document.getElementById('chart-title').value || 'Chart Detail';
     const cfg = collectChartConfig();
-    if (ppmChartExpandedInstance) ppmChartExpandedInstance.destroy();
-    const expandedCanvas = document.getElementById('ppmChartExpanded');
+    if (dpmChartExpandedInstance) dpmChartExpandedInstance.destroy();
+    const expandedCanvas = document.getElementById('dpmChartExpanded');
     const box = expandedCanvas.parentElement;
     const rect = box.getBoundingClientRect();
     if (rect.width && rect.height) {
@@ -226,7 +226,7 @@ function expandModal(show) {
     const opts = { ...meta.options };
     if (opts.scales && opts.scales.x && opts.scales.x.ticks) opts.scales.x.ticks.display = true;
     // eslint-disable-next-line no-undef
-    ppmChartExpandedInstance = new Chart(ctx, { type: meta.type, data: { labels: meta.labels, datasets: meta.datasets }, options: opts, plugins: (activePreset?.kind==='line-control' ? [controlLinesPlugin] : []) });
+    dpmChartExpandedInstance = new Chart(ctx, { type: meta.type, data: { labels: meta.labels, datasets: meta.datasets }, options: opts, plugins: (activePreset?.kind==='line-control' ? [controlLinesPlugin] : []) });
     const vals = meta.datasets[0] && Array.isArray(meta.datasets[0].data) ? meta.datasets[0].data : currentData.values;
     fillTable(meta.labels || currentData.labels, vals);
   }
@@ -330,7 +330,7 @@ function filterSavedList() {
 }
 
 function loadSavedQueries() {
-  fetch('/analysis/ppm/saved')
+  fetch('/analysis/dpm/saved')
     .then((res) => res.json())
     .then((rows) => {
       const server = Array.isArray(rows)
@@ -377,7 +377,7 @@ function runChart() {
   runner
     .then((result) => {
       const cfg = collectChartConfig();
-      const canvasEl = document.getElementById('ppmChart');
+      const canvasEl = document.getElementById('dpmChart');
 
       if (hasCustom) {
         const labels = result.labels || [];
@@ -389,9 +389,9 @@ function runChart() {
         const width = Math.max(container.clientWidth, labels.length * minPerLabel);
         canvasEl.style.width = width + 'px';
         if (datasets.length > 1) {
-          renderChartMulti('ppmChart', labels, datasets, chartCfg);
+          renderChartMulti('dpmChart', labels, datasets, chartCfg);
         } else {
-          renderChart('ppmChart', labels, datasets[0]?.data || [], chartCfg);
+          renderChart('dpmChart', labels, datasets[0]?.data || [], chartCfg);
         }
         currentData = { labels, values: datasets[0]?.data || [], datasets, metaLookup: result.metaLookup };
         window.currentChartMeta = { labels, datasets, type: chartType, options: buildOptions(chartCfg), metaLookup: result.metaLookup };
@@ -446,16 +446,16 @@ function runChart() {
         const container = canvasEl.parentElement; const minPerLabel = 120; const width = Math.max(container.clientWidth, labels.length * minPerLabel); canvasEl.style.width = width + 'px';
       }
 
-      if (ppmChartInstance) ppmChartInstance.destroy();
+      if (dpmChartInstance) dpmChartInstance.destroy();
       // eslint-disable-next-line no-undef
-      ppmChartInstance = new Chart(ctx, { type: chartType, data: { labels, datasets }, options, plugins: (result.kind==='line-control' ? [controlLinesPlugin] : []) });
+      dpmChartInstance = new Chart(ctx, { type: chartType, data: { labels, datasets }, options, plugins: (result.kind==='line-control' ? [controlLinesPlugin] : []) });
       currentData = { labels, values: datasets[0]?.data || [], datasets, metaLookup: result.metaLookup };
       window.currentChartMeta = { labels, datasets, type: chartType, options, metaLookup: result.metaLookup };
       updateInfo(labels, datasets[0]?.data || []);
       if (title) document.getElementById('modal-title').textContent = title;
       document.getElementById('chart-description-result').textContent = description;
     })
-    .catch(() => { document.getElementById('ppm-info').textContent = 'Failed to build chart.'; });
+    .catch(() => { document.getElementById('dpm-info').textContent = 'Failed to build chart.'; });
 }
 
 // Flexible builder: group by arbitrary X, optional series, aggregation choice
@@ -469,9 +469,9 @@ async function runChartFlexible() {
   const xBin = document.getElementById('x-binning').value || 'none';
   const xSort = document.getElementById('x-cat-sort').value || 'alpha-asc';
 
-  const rows = await fetch('/moat').then((r) => r.json());
+  const rows = await fetch('/moat_dpm').then((r) => r.json());
   if (!rows || !rows.length) return { labels: [], datasets: [], firstValues: [], metaLookup: {} };
-  const cols = window.__ppm_cols__ || resolveColumns(rows);
+  const cols = window.__dpm_cols__ || resolveColumns(rows);
 
   // Value per row
   const valueFn = (row) => {
@@ -650,7 +650,7 @@ function uniqueSorted(arr) {
 }
 
 function initFiltersUI() {
-  fetch('/moat')
+  fetch('/moat_dpm')
     .then((r) => r.json())
     .then((rows) => {
       if (!Array.isArray(rows) || rows.length === 0) return;
@@ -692,7 +692,7 @@ function initFiltersUI() {
         addBtn.addEventListener('click', () => { linesWrap.appendChild(mkSelect()); });
       }
       // Store for later filtering
-      window.__ppm_cols__ = cols;
+      window.__dpm_cols__ = cols;
       // Populate Sort-By selector
       const sortSel = document.getElementById('sort-column');
       if (sortSel) {
@@ -721,9 +721,9 @@ function readFilters() {
 }
 
 async function runPresetChart() {
-  const rows = await fetch('/moat').then((r)=>r.json());
+  const rows = await fetch('/moat_dpm').then((r)=>r.json());
   if (!activePreset) setPreset('avg_fc_per_board');
-  const cols = window.__ppm_cols__ || resolveColumns(rows);
+  const cols = window.__dpm_cols__ || resolveColumns(rows);
   const f = readFilters();
   const kind = activePreset.kind || 'line-control';
   // filter rows
@@ -1079,7 +1079,7 @@ function updateXTypeUI() {
   };
 
   if (!columnTypes[xCol]) {
-    fetch('/moat')
+    fetch('/moat_dpm')
       .then((res) => res.json())
       .then((rows) => {
         const { cols, types } = inferTypes(rows);
@@ -1094,7 +1094,7 @@ function updateXTypeUI() {
 }
 
 function initColumnsUI() {
-  fetch('/moat')
+  fetch('/moat_dpm')
     .then((res) => res.json())
     .then((rows) => {
       const { cols, types } = inferTypes(rows);
@@ -1145,7 +1145,7 @@ function saveQuery() {
     line_color: cfg.line_color,
   };
   const method = existing ? 'PUT' : 'POST';
-  fetch('/analysis/ppm/saved', { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
+  fetch('/analysis/dpm/saved', { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) })
     .then((res) => { if (!res.ok) throw new Error('save failed'); return res.json(); })
     .then((rows) => {
       document.getElementById('save-name').value='';
@@ -1158,7 +1158,7 @@ function saveQuery() {
 }
 
 async function copyChartImage() {
-  const canvas = document.getElementById('ppmChart');
+  const canvas = document.getElementById('dpmChart');
   if (!navigator.clipboard || !navigator.clipboard.write) {
     alert('Clipboard API not supported in this browser.');
     return;
@@ -1173,7 +1173,7 @@ async function copyChartImage() {
 }
 
 function downloadExpandedChart() {
-  const canvas = document.getElementById('ppmChartExpanded');
+  const canvas = document.getElementById('dpmChartExpanded');
   if (!canvas) return;
   const link = document.createElement('a');
   const title = document.getElementById('chart-title').value || 'chart';
@@ -1301,7 +1301,7 @@ document.addEventListener('DOMContentLoaded', () => {
       const fd = new FormData();
       fd.append('file', fileInput.files[0]);
       try {
-        const res = await fetch('/ppm_reports/upload', { method: 'POST', body: fd });
+        const res = await fetch('/dpm_reports/upload', { method: 'POST', body: fd });
         if (!res.ok) {
           const text = await res.text();
           throw new Error(text || 'Upload failed');

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -423,6 +423,11 @@ function renderTablePreview({
 document.addEventListener('DOMContentLoaded', () => {
   const previewConfigs = [
     {
+      endpoint: '/moat_preview?source=dpm',
+      canvasId: 'dpmAnalysisPreview',
+      onClickHref: '/analysis/dpm?preset=avg_false_calls_per_assembly',
+    },
+    {
       endpoint: '/moat_preview',
       canvasId: 'ppmAnalysisPreview',
       onClickHref: '/analysis/ppm?preset=avg_false_calls_per_assembly',

--- a/templates/base.html
+++ b/templates/base.html
@@ -50,6 +50,7 @@
             <a href="#">Analysis <span class="arrow">&#9662;</span></a>
             <div class="dropdown" role="menu">
               {{ feature_nav_link('PPM Analysis', url_for('main.ppm_analysis'), 'analysis_ppm') }}
+              {{ feature_nav_link('DPM Analysis', url_for('main.dpm_analysis'), 'analysis_dpm') }}
               {{ feature_nav_link('AOI & FI Analysis', url_for('main.aoi_grades_page'), 'analysis_aoi_grades') }}
               {{ feature_nav_link('AOI Daily Reports', url_for('main.aoi_daily_reports'), 'analysis_aoi_daily') }}
               {{ feature_nav_link('FI Daily Reports', url_for('main.fi_daily_reports'), 'analysis_fi_daily') }}

--- a/templates/dpm_analysis.html
+++ b/templates/dpm_analysis.html
@@ -1,0 +1,238 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>DPM Analysis</h2>
+
+  <div class="analysis-grid">
+    <!-- Left: Builder / Upload Tabs -->
+    <div class="analysis-left section-card">
+      <div class="tab-bar">
+        <div class="tab active" data-target="builder-tab">Chart Builder</div>
+        {% if user_role == 'ADMIN' %}
+        <div class="tab" data-target="upload-tab">Upload</div>
+        {% endif %}
+      </div>
+
+      <div id="builder-tab" class="tab-content" style="display:block;">
+      <div class="section-title">Chart Builder</div>
+      <div class="field-row">
+        <div class="field">
+          <label for="chart-title">Chart Title</label>
+          <input id="chart-title" placeholder="Chart title" />
+        </div>
+        <div class="field">
+          <label for="chart-type">Chart Type</label>
+          <select id="chart-type">
+            <option value="line">Line</option>
+            <option value="bar">Bar</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="field">
+          <label for="chart-description">Chart Description</label>
+          <textarea id="chart-description" placeholder="Describe this chart"></textarea>
+        </div>
+      </div>
+
+    <div class="section-title" style="margin-top:10px;">Data Range</div>
+    <div class="field-row">
+      <div class="field">
+        <label for="start-date">Start Date</label>
+        <input type="date" id="start-date" />
+        <small>or token e.g. today-5d</small>
+      </div>
+      <div class="field">
+        <label for="end-date">End Date</label>
+        <input type="date" id="end-date" />
+        <small>or token e.g. today-1d</small>
+      </div>
+    </div>
+
+      <div class="section-title" style="margin-top:10px;">Filters</div>
+      <div class="field-row">
+        <div class="field" style="min-width:180px;">
+          <label for="filter-model-contains">Model Name contains</label>
+          <input id="filter-model-contains" placeholder="e.g. TH or SMT" />
+        </div>
+        <div class="field">
+          <label>Quick Tokens</label>
+          <div>
+            <label><input type="checkbox" id="filter-has-th" /> TH</label>
+            <label style="margin-left:8px;"><input type="checkbox" id="filter-has-smt" /> SMT</label>
+          </div>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="field" id="wrap-assembly" style="min-width:180px;">
+          <label for="filter-assembly">Assembly</label>
+          <select id="filter-assembly"></select>
+        </div>
+        <div class="field" id="wrap-rev" style="min-width:160px;">
+          <label for="filter-rev">Revision</label>
+          <select id="filter-rev" disabled></select>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="field" style="min-width:180px;">
+          <label>Line</label>
+          <div id="filter-lines"></div>
+          <button type="button" id="add-line">Add another line</button>
+        </div>
+        <div class="field" style="min-width:200px;">
+          <label for="filter-min-boards">Min Total Boards (per Model)</label>
+          <input type="number" id="filter-min-boards" value="7" min="0" />
+          <small>Exclude models with fewer boards</small>
+        </div>
+      </div>
+
+      <div class="field-row">
+        <div class="field" style="min-width:200px;">
+          <label for="sort-column">Sort By</label>
+          <select id="sort-column">
+            <option value="">(None)</option>
+            <option value="__y__">Y Value</option>
+          </select>
+        </div>
+        <div class="field" style="min-width:140px;">
+          <label for="sort-dir">Direction</label>
+          <select id="sort-dir">
+            <option value="asc">Ascending</option>
+            <option value="desc" selected>Descending</option>
+          </select>
+        </div>
+      </div>
+
+    <div class="section-title" style="margin-top:10px;">Appearance</div>
+    <div class="field-row">
+      <div class="field">
+        <label for="line-color">Line/Bar Color</label>
+        <input type="color" id="line-color" value="#000000" />
+      </div>
+      <div class="field">
+        <label for="point-style">Point Style</label>
+        <select id="point-style">
+          <option value="circle">Circle</option>
+          <option value="rect">Square</option>
+          <option value="triangle">Triangle</option>
+          <option value="cross">Cross</option>
+          <option value="star">Star</option>
+        </select>
+      </div>
+      <div class="field">
+        <label for="point-radius">Point Radius</label>
+        <input type="number" id="point-radius" value="3" min="0" max="12" />
+      </div>
+      <div class="field">
+        <label for="line-tension">Line Tension</label>
+        <input type="number" id="line-tension" value="0" min="0" max="0.5" step="0.1" />
+      </div>
+    </div>
+
+    <div class="section-title" style="margin-top:10px;">Axes</div>
+    <div class="field-row">
+      <div class="field">
+        <label for="x-title">X Axis Title</label>
+        <input id="x-title" placeholder="X Axis Title" />
+      </div>
+      <div class="field">
+        <label for="y-title">Y Axis Title</label>
+        <input id="y-title" placeholder="Y Axis Title" />
+      </div>
+      <div class="field">
+        <label for="show-tooltips">Tooltips</label>
+        <select id="show-tooltips">
+          <option value="yes" selected>Show</option>
+          <option value="no">Hide</option>
+        </select>
+      </div>
+    </div>
+
+      <div class="field-row" style="margin-top:12px;">
+        <div class="field" style="flex:1;">
+          <label for="save-name">Save As</label>
+          <input id="save-name" placeholder="Chart name" />
+        </div>
+        <button type="button" id="save-chart">Save</button>
+        <button type="button" id="run-chart">Run</button>
+      </div>
+    </div> <!-- end builder-tab -->
+    {% if user_role == 'ADMIN' %}
+    <div id="upload-tab" class="tab-content" style="display:none;">
+      <form id="upload-form">
+        <div class="field-row">
+          <div class="field" style="flex:1;">
+            <label for="upload-xlsx">XLSX File</label>
+            <input type="file" id="upload-xlsx" accept=".xlsx" />
+          </div>
+        </div>
+        <button type="submit" id="upload-button">Upload</button>
+      </form>
+    </div>
+    {% endif %}
+    </div>
+
+  <!-- Top Right: Saved Queries + Search -->
+  <div class="analysis-top-right section-card">
+    <div class="section-title">Saved Charts</div>
+    <div class="field-row" style="margin-bottom:8px;">
+      <div class="field" style="flex:1;">
+        <label for="saved-search">Search</label>
+        <input id="saved-search" placeholder="Filter saved charts" />
+      </div>
+    </div>
+    <ul id="saved-list" style="margin:0;padding-left:16px;"></ul>
+    <small>Select a preset to load its metric.</small>
+  </div>
+
+  <!-- Bottom Right: Results -->
+    <div class="analysis-bottom-right section-card">
+      <div class="section-title">Results: <span id="result-chart-name"></span></div>
+      <div class="field-row" style="margin-bottom:6px;">
+        <button type="button" id="expand-chart">Expand</button>
+        <button type="button" id="download-pdf">Download PDF</button>
+        <span class="spinner" id="download-spinner" hidden></span>
+        <button type="button" id="copy-image">Copy Image</button>
+      </div>
+      <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
+      <div class="preview-card" style="height: 300px;">
+        <canvas id="dpmChart"></canvas>
+      </div>
+      <div id="dpm-info" class="preview-info" style="margin-top:4px;"></div>
+      <div id="chart-description-result" class="preview-info" style="margin-top:4px;"></div>
+      <small>Control limits shown: mean (blue), UCL/LCL (red/green).</small>
+    </div>
+  </div>
+
+<!-- Modal for Expanded View + Data Table -->
+<div id="chart-modal" class="modal-overlay">
+  <div class="modal">
+    <div class="modal-header">
+      <div id="modal-title">Chart Detail</div>
+      <button id="modal-close" class="modal-close">Close</button>
+    </div>
+    <div class="modal-chart-box">
+      <canvas id="dpmChartExpanded"></canvas>
+    </div>
+    <div class="field-row" style="margin-top:10px;">
+      <button type="button" id="modal-download-chart">Download Chart</button>
+      <button type="button" id="modal-download-csv">Download CSV</button>
+      </div>
+    <div style="margin-top:10px;" class="section-title">Data</div>
+    <table class="data-table">
+      <thead><tr><th>Date</th><th>Value</th></tr></thead>
+      <tbody id="data-tbody"></tbody>
+    </table>
+  </div>
+  </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf@2.5.1/dist/jspdf.umd.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/jspdf-autotable@3.5.28/dist/jspdf.plugin.autotable.min.js"></script>
+<script type="module" src="{{ url_for('static', filename='js/dpm.js') }}"></script>
+{% endblock %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,6 +4,12 @@
 <h1>Previews</h1>
 <h3><i>(click to see further insight)</i></h3>
 <section class="dashboard-grid">
+  <a class="dashboard-link" href="{{ url_for('main.dpm_analysis') }}">
+    <div class="dashboard-card">
+      <h2>DPM Analysis</h2>
+      <canvas id="dpmAnalysisPreview"></canvas>
+    </div>
+  </a>
   <a class="dashboard-link" href="{{ url_for('main.ppm_analysis') }}">
     <div class="dashboard-card">
       <h2>PPM Analysis</h2>

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -86,7 +86,11 @@ def _moat_preview_patch():
             "Report Date": (today - timedelta(days=1)).isoformat(),
         },
     ]
-    return {"fetch_recent_moat": _make_fetch(rows)}
+    fetcher = _make_fetch(rows)
+    return {
+        "fetch_recent_moat": fetcher,
+        "fetch_recent_moat_dpm": fetcher,
+    }
 
 
 def _aoi_preview_patch():
@@ -231,6 +235,7 @@ def _tracker_preview_patch():
 
 PREVIEW_CASES = [
     ("/moat_preview", _moat_preview_patch),
+    ("/moat_preview?source=dpm", _moat_preview_patch),
     ("/aoi_preview", _aoi_preview_patch),
     ("/fi_preview", _fi_preview_patch),
     ("/daily_reports_preview", _daily_preview_patch),


### PR DESCRIPTION
## Summary
- register the DPM analysis feature and expose /moat_dpm along with an updated preview endpoint
- add navigation, home dashboard, template, and client script for the DPM analysis experience
- adjust saved-chart preset handling and extend dashboard preview tests for the new source

## Testing
- PYTHONPATH=. pytest tests/test_preview_endpoints.py::test_moat_preview_returns_summary
- PYTHONPATH=. pytest tests/test_home_dashboard.py::test_home_dashboard_previews_return_expected_fields


------
https://chatgpt.com/codex/tasks/task_e_68d67fea42108325bf7dcbb554df78b6