### PR TITLE
Add line performance report

### DIFF
--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -1,0 +1,431 @@
+import { downloadFile } from './utils.js';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const runBtn = document.getElementById('run-line-report');
+  const downloadControls = document.getElementById('download-controls');
+  const downloadBtn = document.getElementById('download-report');
+  const includeCover = document.getElementById('include-cover');
+  const includeSummary = document.getElementById('include-summary');
+  let reportData = null;
+  let yieldChart = null;
+  let falseCallChart = null;
+  let ppmChart = null;
+  let trendChart = null;
+
+  if (downloadControls) downloadControls.style.display = 'none';
+
+  const numberFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 0 });
+  const decimalFormatter = new Intl.NumberFormat('en-US', { maximumFractionDigits: 2 });
+
+  const sections = {
+    metrics: document.getElementById('line-metrics-section'),
+    assembly: document.getElementById('assembly-comparison-section'),
+    crossLine: document.getElementById('cross-line-section'),
+    trend: document.getElementById('trend-section'),
+    benchmarking: document.getElementById('benchmarking-section'),
+  };
+
+  function showSection(section) {
+    if (section) section.hidden = false;
+  }
+
+  function hideSections() {
+    Object.values(sections).forEach((section) => {
+      if (section) {
+        section.hidden = true;
+        const tables = section.querySelectorAll('tbody');
+        tables.forEach((tbody) => {
+          tbody.innerHTML = '';
+        });
+        const containers = section.querySelectorAll('[data-clear-on-run]');
+        containers.forEach((el) => {
+          el.innerHTML = '';
+        });
+      }
+    });
+  }
+
+  function fmtPercent(value) {
+    if (value === null || value === undefined) return '--';
+    return `${decimalFormatter.format(value)}%`;
+  }
+
+  function fmtNumber(value, fractionDigits = 2) {
+    if (value === null || value === undefined) return '--';
+    const formatter = fractionDigits === 0
+      ? numberFormatter
+      : new Intl.NumberFormat('en-US', { maximumFractionDigits: fractionDigits });
+    return formatter.format(value);
+  }
+
+  function clearCharts() {
+    yieldChart?.destroy();
+    falseCallChart?.destroy();
+    ppmChart?.destroy();
+    trendChart?.destroy();
+  }
+
+  function renderLineMetrics(metrics) {
+    const tbody = document.getElementById('line-metrics-body');
+    if (!tbody) return;
+    tbody.innerHTML = '';
+    metrics.forEach((metric) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = `
+        <td>${metric.line}</td>
+        <td>${fmtPercent(metric.yield)}</td>
+        <td>${fmtNumber(metric.confirmedDefects)}</td>
+        <td>${fmtNumber(metric.falseCallsPerBoard)}</td>
+        <td>${fmtNumber(metric.ppm)}</td>
+        <td>${fmtNumber(metric.dpm)}</td>
+        <td>${fmtNumber(metric.boardsPerDay)}</td>
+        <td>${fmtNumber(metric.totalParts)}</td>
+      `;
+      tbody.appendChild(tr);
+    });
+    showSection(sections.metrics);
+  }
+
+  function renderLineCharts(metrics) {
+    const yieldCtx = document.getElementById('lineYieldChart')?.getContext('2d');
+    const falseCallCtx = document.getElementById('lineFalseCallChart')?.getContext('2d');
+    const ppmCtx = document.getElementById('linePpmChart')?.getContext('2d');
+    clearCharts();
+    if (yieldCtx) {
+      yieldChart = new Chart(yieldCtx, {
+        type: 'bar',
+        data: {
+          labels: metrics.map((m) => m.line),
+          datasets: [
+            {
+              label: 'Yield %',
+              data: metrics.map((m) => m.yield),
+              backgroundColor: '#0ea5e9',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          plugins: { legend: { display: false } },
+          scales: { y: { title: { display: true, text: 'Yield %' } } },
+        },
+      });
+    }
+    if (falseCallCtx) {
+      falseCallChart = new Chart(falseCallCtx, {
+        type: 'bar',
+        data: {
+          labels: metrics.map((m) => m.line),
+          datasets: [
+            {
+              label: 'False Calls / Board',
+              data: metrics.map((m) => m.falseCallsPerBoard),
+              backgroundColor: '#f97316',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          plugins: { legend: { display: false } },
+          scales: { y: { title: { display: true, text: 'False Calls / Board' } } },
+        },
+      });
+    }
+    if (ppmCtx) {
+      ppmChart = new Chart(ppmCtx, {
+        type: 'bar',
+        data: {
+          labels: metrics.map((m) => m.line),
+          datasets: [
+            {
+              label: 'PPM',
+              data: metrics.map((m) => m.ppm),
+              backgroundColor: '#1d4ed8',
+            },
+            {
+              label: 'DPM',
+              data: metrics.map((m) => m.dpm),
+              backgroundColor: '#059669',
+            },
+          ],
+        },
+        options: {
+          responsive: true,
+          scales: {
+            y: {
+              title: { display: true, text: 'Parts per Million' },
+            },
+          },
+        },
+      });
+    }
+  }
+
+  function renderAssemblyComparisons(comparisons) {
+    const container = document.getElementById('assembly-comparisons');
+    if (!container) return;
+    container.innerHTML = '';
+    comparisons.forEach((item) => {
+      const details = document.createElement('details');
+      details.className = 'comparison-block';
+      const summary = document.createElement('summary');
+      summary.textContent = item.assembly;
+      details.appendChild(summary);
+
+      const table = document.createElement('table');
+      table.className = 'data-table';
+      table.innerHTML = `
+        <thead>
+          <tr>
+            <th>Line</th>
+            <th>Yield %</th>
+            <th>False Calls / Board</th>
+            <th>PPM</th>
+            <th>DPM</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      `;
+      const tbody = table.querySelector('tbody');
+      Object.entries(item.lines).forEach(([line, metrics]) => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${line}</td>
+          <td>${fmtPercent(metrics.yield)}</td>
+          <td>${fmtNumber(metrics.falseCallsPerBoard)}</td>
+          <td>${fmtNumber(metrics.ppm)}</td>
+          <td>${fmtNumber(metrics.dpm)}</td>
+        `;
+        tbody.appendChild(row);
+      });
+      details.appendChild(table);
+
+      const defectMixWrap = document.createElement('div');
+      defectMixWrap.className = 'defect-mix';
+      Object.entries(item.lines).forEach(([line, metrics]) => {
+        const mix = metrics.defectMix || {};
+        const entries = Object.entries(mix);
+        if (!entries.length) return;
+        const block = document.createElement('div');
+        block.className = 'defect-mix-card';
+        const list = entries
+          .sort((a, b) => b[1] - a[1])
+          .slice(0, 5)
+          .map(([defect, share]) => `<li>${defect}: ${fmtPercent(share * 100)}</li>`) // share already 0-1? we convert to percentage.
+          .join('');
+        block.innerHTML = `
+          <h4>${line} Defect Mix</h4>
+          <ul>${list || '<li>No defect data</li>'}</ul>
+        `;
+        defectMixWrap.appendChild(block);
+      });
+      if (defectMixWrap.children.length) {
+        details.appendChild(defectMixWrap);
+      }
+
+      container.appendChild(details);
+    });
+    if (comparisons.length) showSection(sections.assembly);
+  }
+
+  function renderCrossLine(data) {
+    const container = document.getElementById('cross-line-content');
+    if (!container) return;
+    container.innerHTML = '';
+
+    const varianceBlock = document.createElement('div');
+    varianceBlock.className = 'variance-grid';
+    const yieldList = (data.yieldVariance || []).slice(0, 5)
+      .map((item) => `<li>${item.assembly}: σ = ${fmtNumber(item.stddev)}</li>`)
+      .join('') || '<li>No multi-line assemblies</li>';
+    const fcList = (data.falseCallVariance || []).slice(0, 5)
+      .map((item) => `<li>${item.assembly}: σ = ${fmtNumber(item.stddev)}</li>`)
+      .join('') || '<li>No multi-line assemblies</li>';
+    varianceBlock.innerHTML = `
+      <div>
+        <h4>Yield Variance (Top)</h4>
+        <ul>${yieldList}</ul>
+      </div>
+      <div>
+        <h4>False Call Variance (Top)</h4>
+        <ul>${fcList}</ul>
+      </div>
+    `;
+    container.appendChild(varianceBlock);
+
+    const similarity = data.defectSimilarity || [];
+    if (similarity.length) {
+      const simWrapper = document.createElement('div');
+      simWrapper.className = 'similarity-grid';
+      similarity.slice(0, 5).forEach((entry) => {
+        const card = document.createElement('div');
+        card.className = 'similarity-card';
+        const pairs = entry.pairs
+          .map((pair) => `${pair.lines.join(' vs ')} → ${fmtNumber(pair.similarity * 100)}%`)
+          .join('<br>');
+        card.innerHTML = `<h4>${entry.assembly}</h4><p>${pairs}</p>`;
+        simWrapper.appendChild(card);
+      });
+      container.appendChild(simWrapper);
+    }
+
+    if (container.children.length) showSection(sections.crossLine);
+  }
+
+  function renderTrends(lineTrends, insights) {
+    const trendCtx = document.getElementById('lineTrendChart')?.getContext('2d');
+    const labels = lineTrends.length ? lineTrends[0].entries.map((entry) => entry.date) : [];
+    const datasets = lineTrends.map((trend) => ({
+      label: trend.line,
+      data: trend.entries.map((entry) => entry.yield ?? null),
+      spanGaps: true,
+      tension: 0.15,
+    }));
+    if (trendCtx && datasets.length) {
+      trendChart = new Chart(trendCtx, {
+        type: 'line',
+        data: { labels, datasets },
+        options: {
+          responsive: true,
+          plugins: { legend: { position: 'bottom' } },
+          scales: {
+            y: { title: { display: true, text: 'Yield %' } },
+          },
+        },
+      });
+    }
+
+    const container = document.getElementById('trend-insights');
+    if (!container) return;
+    container.innerHTML = '';
+    container.setAttribute('data-clear-on-run', '');
+
+    const drift = insights.lineDrift || [];
+    if (drift.length) {
+      const list = document.createElement('ul');
+      list.className = 'insight-list';
+      drift.slice(0, 5).forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = `${item.line}: ${fmtPercent(item.start)} → ${fmtPercent(item.end)} (Δ ${fmtPercent(item.change)})`;
+        list.appendChild(li);
+      });
+      container.appendChild(Object.assign(document.createElement('h4'), { textContent: 'Line Yield Drift' }));
+      container.appendChild(list);
+    }
+
+    const learning = insights.assemblyLearning || [];
+    if (learning.length) {
+      const list = document.createElement('ul');
+      list.className = 'insight-list';
+      learning.slice(0, 5).forEach((item) => {
+        const li = document.createElement('li');
+        li.textContent = `${item.assembly} on ${item.line}: ${fmtPercent(item.start[1])} → ${fmtPercent(item.end[1])}`;
+        list.appendChild(li);
+      });
+      container.appendChild(Object.assign(document.createElement('h4'), { textContent: 'Assembly Learning Curves' }));
+      container.appendChild(list);
+    }
+
+    if (container.children.length) showSection(sections.trend);
+  }
+
+  function renderBenchmarking(benchmarking, averages) {
+    const container = document.getElementById('benchmarking-content');
+    if (!container) return;
+    container.innerHTML = '';
+    container.setAttribute('data-clear-on-run', '');
+
+    const kpiList = document.createElement('ul');
+    kpiList.className = 'insight-list';
+    if (benchmarking.bestYield) {
+      kpiList.innerHTML += `<li>Best Yield: ${benchmarking.bestYield.line} (${fmtPercent(benchmarking.bestYield.yield)})</li>`;
+    }
+    if (benchmarking.lowestFalseCalls) {
+      kpiList.innerHTML += `<li>Lowest False Calls / Board: ${benchmarking.lowestFalseCalls.line} (${fmtNumber(benchmarking.lowestFalseCalls.falseCallsPerBoard)})</li>`;
+    }
+    if (benchmarking.mostConsistent) {
+      kpiList.innerHTML += `<li>Most Consistent: ${benchmarking.mostConsistent.line} (σ ${fmtNumber(benchmarking.mostConsistent.stddev)})</li>`;
+    }
+    container.appendChild(kpiList);
+
+    const table = document.createElement('table');
+    table.className = 'data-table';
+    table.innerHTML = `
+      <thead>
+        <tr>
+          <th>Line</th>
+          <th>Yield Δ vs Avg</th>
+          <th>False Call Δ</th>
+          <th>PPM Δ</th>
+          <th>DPM Δ</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    `;
+    const tbody = table.querySelector('tbody');
+    (benchmarking.lineVsCompany || []).forEach((entry) => {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${entry.line}</td>
+        <td>${fmtNumber(entry.yieldDelta)}</td>
+        <td>${fmtNumber(entry.falseCallDelta)}</td>
+        <td>${fmtNumber(entry.ppmDelta)}</td>
+        <td>${fmtNumber(entry.dpmDelta)}</td>
+      `;
+      tbody.appendChild(row);
+    });
+    container.appendChild(table);
+
+    const avg = document.createElement('p');
+    avg.className = 'kpi-summary';
+    avg.textContent = `Company averages — Yield: ${fmtPercent(averages.yield)}, False Calls / Board: ${fmtNumber(averages.falseCallsPerBoard)}, PPM: ${fmtNumber(averages.ppm)}, DPM: ${fmtNumber(averages.dpm)}`;
+    container.appendChild(avg);
+
+    showSection(sections.benchmarking);
+  }
+
+  runBtn?.addEventListener('click', async () => {
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    if (!start || !end) {
+      alert('Please select a date range.');
+      return;
+    }
+    hideSections();
+    clearCharts();
+    try {
+      const response = await fetch(`/api/reports/line?start_date=${start}&end_date=${end}`);
+      if (!response.ok) throw new Error('Failed to run report');
+      reportData = await response.json();
+      renderLineMetrics(reportData.lineMetrics || []);
+      renderLineCharts(reportData.lineMetrics || []);
+      renderAssemblyComparisons(reportData.assemblyComparisons || []);
+      renderCrossLine(reportData.crossLine || {});
+      renderTrends(reportData.lineTrends || [], reportData.trendInsights || {});
+      renderBenchmarking(reportData.benchmarking || {}, reportData.companyAverages || {});
+      if (downloadControls) downloadControls.style.display = 'flex';
+    } catch (err) {
+      console.error(err);
+      alert('Failed to run line report.');
+    }
+  });
+
+  downloadBtn?.addEventListener('click', async () => {
+    const fmt = document.getElementById('file-format').value;
+    const start = document.getElementById('start-date').value;
+    const end = document.getElementById('end-date').value;
+    const params = new URLSearchParams({ format: fmt });
+    if (start) params.append('start_date', start);
+    if (end) params.append('end_date', end);
+    params.append('show_cover', includeCover?.checked ? 'true' : 'false');
+    params.append('show_summary', includeSummary?.checked ? 'true' : 'false');
+    await downloadFile(`/reports/line/export?${params.toString()}`, {
+      buttonId: 'download-report',
+      spinnerId: 'download-spinner',
+    });
+  });
+
+  document.getElementById('email-report')?.addEventListener('click', () => {
+    alert('Email sent (placeholder).');
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -79,6 +79,7 @@
             <div class="dropdown" role="menu">
               {{ feature_nav_link('AOI Integrated Report', url_for('main.integrated_report'), 'reports_integrated') }}
               {{ feature_nav_link('Operator Report', url_for('main.operator_report'), 'reports_operator') }}
+              {{ feature_nav_link('Line Report', url_for('main.line_report'), 'reports_line') }}
               {{ feature_nav_link('AOI Daily Report', url_for('main.aoi_daily_report_page'), 'reports_aoi_daily') }}
             </div>
           </li>

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -1,0 +1,124 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Line Report</h2>
+
+<div class="section-card">
+  <div class="field-row">
+    <div class="field">
+      <label for="start-date">Start Date</label>
+      <input type="date" id="start-date" />
+    </div>
+    <div class="field">
+      <label for="end-date">End Date</label>
+      <input type="date" id="end-date" />
+    </div>
+    <button type="button" id="run-line-report">Run</button>
+  </div>
+</div>
+
+<section class="section-card" id="line-metrics-section" hidden>
+  <header>
+    <h3>Line-Level Performance Metrics</h3>
+    <p class="section-subtitle">
+      Aggregate yield, false calls, and throughput across all assemblies inspected on each line.
+    </p>
+  </header>
+  <div class="table-wrapper">
+    <table class="data-table">
+      <thead>
+        <tr>
+          <th>Line</th>
+          <th>Yield %</th>
+          <th>Confirmed Defects</th>
+          <th>False Calls / Board</th>
+          <th>PPM</th>
+          <th>DPM</th>
+          <th>Boards / Day</th>
+          <th>Total Parts</th>
+        </tr>
+      </thead>
+      <tbody id="line-metrics-body"></tbody>
+    </table>
+  </div>
+  <div class="chart-grid">
+    <div class="chart-block">
+      <canvas id="lineYieldChart"></canvas>
+    </div>
+    <div class="chart-block">
+      <canvas id="lineFalseCallChart"></canvas>
+    </div>
+    <div class="chart-block">
+      <canvas id="linePpmChart"></canvas>
+    </div>
+  </div>
+</section>
+
+<section class="section-card" id="assembly-comparison-section" hidden>
+  <header>
+    <h3>Assembly vs Line Comparisons</h3>
+    <p class="section-subtitle">
+      Compare how each line performs on the same assembly to pinpoint tuning or process opportunities.
+    </p>
+  </header>
+  <div id="assembly-comparisons"></div>
+</section>
+
+<section class="section-card" id="cross-line-section" hidden>
+  <header>
+    <h3>Cross-Line Synchronization</h3>
+    <p class="section-subtitle">
+      Measure consistency across lines and highlight where defect signatures diverge.</p>
+  </header>
+  <div id="cross-line-content"></div>
+</section>
+
+<section class="section-card" id="trend-section" hidden>
+  <header>
+    <h3>Trend Insights</h3>
+    <p class="section-subtitle">
+      Track yield drift, learning curves, and longitudinal performance by line.</p>
+  </header>
+  <div class="chart-block">
+    <canvas id="lineTrendChart"></canvas>
+  </div>
+  <div id="trend-insights"></div>
+</section>
+
+<section class="section-card" id="benchmarking-section" hidden>
+  <header>
+    <h3>Benchmarking KPIs</h3>
+    <p class="section-subtitle">
+      Quickly identify top-performing and at-risk lines relative to company targets.</p>
+  </header>
+  <div id="benchmarking-content"></div>
+</section>
+
+<div class="field-row" id="download-controls">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="xlsx">xlsx</option>
+      <option value="html">html</option>
+    </select>
+  </div>
+  <div class="field">
+    <label for="include-cover">Cover Page</label>
+    <input type="checkbox" id="include-cover" checked />
+  </div>
+  <div class="field">
+    <label for="include-summary">Executive Summary</label>
+    <input type="checkbox" id="include-summary" checked />
+  </div>
+  <button id="download-report">Download</button>
+  <span class="spinner" id="download-spinner" hidden></span>
+  <button id="email-report">Email Report</button>
+  <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script type="module" src="{{ url_for('static', filename='js/line_report.js') }}"></script>
+{% endblock %}

--- a/templates/report/line/assemblies.html
+++ b/templates/report/line/assemblies.html
@@ -1,0 +1,50 @@
+<section class="report-section">
+  <h2>Assembly vs Line Comparisons</h2>
+  {% for assembly in assemblyComparisons %}
+  <article class="report-card">
+    <h3>{{ assembly.assembly }}</h3>
+    <table class="report-table">
+      <thead>
+        <tr>
+          <th>Line</th>
+          <th>Yield %</th>
+          <th>False Calls / Board</th>
+          <th>PPM</th>
+          <th>DPM</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for line, metrics in assembly.lines.items() %}
+        <tr>
+          <td>{{ line }}</td>
+          <td>{{ metrics.yield|default(0)|round(2) }}</td>
+          <td>{{ metrics.falseCallsPerBoard|default(0)|round(2) }}</td>
+          <td>{{ metrics.ppm|default(0)|round(2) }}</td>
+          <td>{{ metrics.dpm|default(0)|round(2) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% set mixes = [] %}
+    {% for line, metrics in assembly.lines.items() %}
+      {% if metrics.defectMix %}
+        {% set mixes = mixes + [(line, metrics.defectMix)] %}
+      {% endif %}
+    {% endfor %}
+    {% if mixes %}
+    <div class="defect-mix-grid">
+      {% for item in mixes %}
+      <div>
+        <h4>{{ item[0] }} Defect Mix</h4>
+        <ul>
+          {% for defect, share in item[1].items()|sort(attribute=1, reverse=True)[:5] %}
+          <li>{{ defect }} — {{ (share * 100)|round(2) }}%</li>
+          {% endfor %}
+        </ul>
+      </div>
+      {% endfor %}
+    </div>
+    {% endif %}
+  </article>
+  {% endfor %}
+</section>

--- a/templates/report/line/cover.html
+++ b/templates/report/line/cover.html
@@ -1,0 +1,49 @@
+<section class="report-cover">
+  <div class="cover-header">
+    <img src="{{ logo_url }}" alt="Logo" class="cover-logo" />
+    <div class="cover-meta">
+      <h1>{{ title or 'Line Report' }}</h1>
+      {% if subtitle %}<p class="cover-subtitle">{{ subtitle }}</p>{% endif %}
+    </div>
+  </div>
+  <dl class="cover-details">
+    <div>
+      <dt>Report Date</dt>
+      <dd>{{ report_date or generated_at }}</dd>
+    </div>
+    <div>
+      <dt>Period</dt>
+      <dd>
+        {% if period %}
+          {{ period }}
+        {% elif start or end %}
+          {{ start or '—' }} to {{ end or '—' }}
+        {% else %}
+          Custom Range
+        {% endif %}
+      </dd>
+    </div>
+    {% if author %}
+    <div>
+      <dt>Prepared By</dt>
+      <dd>{{ author }}</dd>
+    </div>
+    {% endif %}
+    {% if contact %}
+    <div>
+      <dt>Contact</dt>
+      <dd>{{ contact }}</dd>
+    </div>
+    {% endif %}
+    {% if report_id %}
+    <div>
+      <dt>Report ID</dt>
+      <dd>{{ report_id }}</dd>
+    </div>
+    {% endif %}
+  </dl>
+  <footer class="cover-footer">
+    <span>{{ confidentiality }}</span>
+    {% if footer_left %}<span>{{ footer_left }}</span>{% endif %}
+  </footer>
+</section>

--- a/templates/report/line/cross_line.html
+++ b/templates/report/line/cross_line.html
@@ -1,0 +1,39 @@
+<section class="report-section">
+  <h2>Cross-Line Synchronization</h2>
+  <div class="two-column">
+    <div>
+      <h3>Yield Variance</h3>
+      <ul>
+        {% for entry in crossLine.yieldVariance[:5] %}
+        <li>{{ entry.assembly }} — σ {{ entry.stddev|round(2) }}</li>
+        {% else %}
+        <li>No multi-line assemblies available.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div>
+      <h3>False Call Variance</h3>
+      <ul>
+        {% for entry in crossLine.falseCallVariance[:5] %}
+        <li>{{ entry.assembly }} — σ {{ entry.stddev|round(2) }}</li>
+        {% else %}
+        <li>No multi-line assemblies available.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+  {% if crossLine.defectSimilarity %}
+  <div class="report-grid">
+    {% for entry in crossLine.defectSimilarity[:4] %}
+    <article>
+      <h3>{{ entry.assembly }}</h3>
+      <ul>
+        {% for pair in entry.pairs[:3] %}
+        <li>{{ pair.lines[0] }} vs {{ pair.lines[1] }} — {{ (pair.similarity * 100)|round(2) }}% similarity</li>
+        {% endfor %}
+      </ul>
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>

--- a/templates/report/line/index.html
+++ b/templates/report/line/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>{{ title or 'Line Report' }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}">
+  <style>{{ report_css|safe }}</style>
+</head>
+<body>
+  <main class="report-page">
+    {% if show_cover %}
+      {% include 'report/line/cover.html' %}
+    {% endif %}
+    {% if show_summary %}
+      {% include 'report/line/summary.html' %}
+    {% endif %}
+    {% include 'report/line/metrics.html' %}
+    {% include 'report/line/assemblies.html' %}
+    {% include 'report/line/cross_line.html' %}
+    {% include 'report/line/trends.html' %}
+    {% include 'report/line/kpis.html' %}
+  </main>
+</body>
+</html>

--- a/templates/report/line/kpis.html
+++ b/templates/report/line/kpis.html
@@ -1,0 +1,25 @@
+<section class="report-section">
+  <h2>Benchmarking KPIs</h2>
+  <table class="report-table">
+    <thead>
+      <tr>
+        <th>Line</th>
+        <th>Yield Δ vs Avg</th>
+        <th>False Call Δ</th>
+        <th>PPM Δ</th>
+        <th>DPM Δ</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for entry in benchmarking.lineVsCompany %}
+      <tr>
+        <td>{{ entry.line }}</td>
+        <td>{{ entry.yieldDelta|round(2) }}</td>
+        <td>{{ entry.falseCallDelta|round(2) }}</td>
+        <td>{{ entry.ppmDelta|round(2) }}</td>
+        <td>{{ entry.dpmDelta|round(2) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>

--- a/templates/report/line/metrics.html
+++ b/templates/report/line/metrics.html
@@ -1,0 +1,43 @@
+<section class="report-section">
+  <h2>Line-Level Performance</h2>
+  <figure class="report-figure">
+    <img src="{{ lineYieldImg }}" alt="Yield by Line" />
+    <figcaption>Yield performance across AOI lines.</figcaption>
+  </figure>
+  <figure class="report-figure">
+    <img src="{{ lineFalseCallImg }}" alt="False Calls by Line" />
+    <figcaption>False-call rate per board.</figcaption>
+  </figure>
+  <figure class="report-figure">
+    <img src="{{ linePpmImg }}" alt="PPM vs DPM" />
+    <figcaption>Comparison of false-call PPM and confirmed-defect DPM.</figcaption>
+  </figure>
+  <table class="report-table">
+    <thead>
+      <tr>
+        <th>Line</th>
+        <th>Yield %</th>
+        <th>Confirmed Defects</th>
+        <th>False Calls / Board</th>
+        <th>PPM</th>
+        <th>DPM</th>
+        <th>Boards / Day</th>
+        <th>Total Parts</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for metric in lineMetrics %}
+      <tr>
+        <td>{{ metric.line }}</td>
+        <td>{{ metric.yield|round(2) }}</td>
+        <td>{{ metric.confirmedDefects|round(0) }}</td>
+        <td>{{ metric.falseCallsPerBoard|round(2) }}</td>
+        <td>{{ metric.ppm|round(2) }}</td>
+        <td>{{ metric.dpm|round(2) }}</td>
+        <td>{{ metric.boardsPerDay|round(2) }}</td>
+        <td>{{ metric.totalParts|round(0) }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>

--- a/templates/report/line/summary.html
+++ b/templates/report/line/summary.html
@@ -1,0 +1,41 @@
+<section class="report-section">
+  <h2>Executive Summary</h2>
+  <div class="summary-grid">
+    <article>
+      <h3>Top Lines</h3>
+      <ul>
+        {% if benchmarking.bestYield %}
+        <li><strong>Best Yield:</strong> {{ benchmarking.bestYield.line }} ({{ benchmarking.bestYield.yield|round(2) }}%)</li>
+        {% endif %}
+        {% if benchmarking.lowestFalseCalls %}
+        <li><strong>Lowest False Calls:</strong> {{ benchmarking.lowestFalseCalls.line }} ({{ benchmarking.lowestFalseCalls.falseCallsPerBoard|round(2) }})</li>
+        {% endif %}
+        {% if benchmarking.mostConsistent %}
+        <li><strong>Most Consistent:</strong> {{ benchmarking.mostConsistent.line }} (σ {{ benchmarking.mostConsistent.stddev|round(2) }})</li>
+        {% endif %}
+      </ul>
+    </article>
+    <article>
+      <h3>Company Averages</h3>
+      <ul>
+        <li>Yield: {{ companyAverages.yield|round(2) }}%</li>
+        <li>False Calls / Board: {{ companyAverages.falseCallsPerBoard|round(2) }}</li>
+        <li>PPM: {{ companyAverages.ppm|round(2) }}</li>
+        <li>DPM: {{ companyAverages.dpm|round(2) }}</li>
+      </ul>
+    </article>
+    <article>
+      <h3>Key Insights</h3>
+      <ul>
+        {% set drift = (trendInsights.lineDrift or [])[:3] %}
+        {% if drift %}
+          {% for item in drift %}
+          <li>{{ item.line }} yield drifted {{ item.change|round(2) }} pts ({{ item.start|round(2) }}% → {{ item.end|round(2) }}%).</li>
+          {% endfor %}
+        {% else %}
+          <li>No significant yield drift detected across lines.</li>
+        {% endif %}
+      </ul>
+    </article>
+  </div>
+</section>

--- a/templates/report/line/trends.html
+++ b/templates/report/line/trends.html
@@ -1,0 +1,29 @@
+<section class="report-section">
+  <h2>Trend Insights</h2>
+  <figure class="report-figure">
+    <img src="{{ lineTrendImg }}" alt="Yield Trend by Line" />
+    <figcaption>Yield performance by line across the selected period.</figcaption>
+  </figure>
+  <div class="two-column">
+    <div>
+      <h3>Line Drift</h3>
+      <ul>
+        {% for item in trendInsights.lineDrift[:6] %}
+        <li>{{ item.line }}: {{ item.start|round(2) }}% → {{ item.end|round(2) }}% (Δ {{ item.change|round(2) }})</li>
+        {% else %}
+        <li>No significant drift detected.</li>
+        {% endfor %}
+      </ul>
+    </div>
+    <div>
+      <h3>Assembly Learning Curves</h3>
+      <ul>
+        {% for item in trendInsights.assemblyLearning[:6] %}
+        <li>{{ item.assembly }} on {{ item.line }}: {{ item.start[1]|round(2) }}% → {{ item.end[1]|round(2) }}% (Δ {{ item.change|round(2) }})</li>
+        {% else %}
+        <li>No repeated assembly runs detected.</li>
+        {% endfor %}
+      </ul>
+    </div>
+  </div>
+</section>

--- a/tests/test_line_report.py
+++ b/tests/test_line_report.py
@@ -1,0 +1,142 @@
+import os
+import sys
+import pytest
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module
+from app import create_app
+from app.main import routes
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    app = create_app()
+    return app
+
+
+def test_line_report_api_returns_expected_metrics(app_instance, monkeypatch):
+    ppm_rows = [
+        {
+            "Report Date": "2024-07-01",
+            "Line": "L1",
+            "Model Name": "AsmA",
+            "Total Parts": 100,
+            "Total Boards": 10,
+            "FalseCall Parts": 5,
+            "NG Parts": 15,
+        },
+        {
+            "Report Date": "2024-07-01",
+            "Line": "L2",
+            "Model Name": "AsmA",
+            "Total Parts": 80,
+            "Total Boards": 8,
+            "FalseCall Parts": 2,
+            "NG Parts": 6,
+        },
+        {
+            "Report Date": "2024-07-02",
+            "Line": "L1",
+            "Model Name": "AsmB",
+            "Total Parts": 120,
+            "Total Boards": 12,
+            "FalseCall Parts": 3,
+            "NG Parts": 8,
+        },
+    ]
+    dpm_rows = [
+        {
+            "Report Date": "2024-07-01",
+            "Line": "L1",
+            "Model Name": "AsmA",
+            "Total Windows": 200,
+            "NG Windows": 10,
+            "FalseCall Windows": 4,
+            "DPM": 50000,
+            "FC DPM": 20000,
+        },
+        {
+            "Report Date": "2024-07-02",
+            "Line": "L1",
+            "Model Name": "AsmB",
+            "Total Windows": 120,
+            "NG Windows": 6,
+            "FalseCall Windows": 3,
+            "DPM": 50000,
+            "FC DPM": 25000,
+        },
+        {
+            "Report Date": "2024-07-01",
+            "Line": "L2",
+            "Model Name": "AsmA",
+            "Total Windows": 80,
+            "NG Windows": 5,
+            "FalseCall Windows": 1,
+            "DPM": 62500,
+            "FC DPM": 12500,
+        },
+    ]
+
+    monkeypatch.setattr(routes, "fetch_moat", lambda: (ppm_rows, None))
+    monkeypatch.setattr(routes, "fetch_moat_dpm", lambda: (dpm_rows, None))
+
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        response = client.get(
+            "/api/reports/line?start_date=2024-07-01&end_date=2024-07-05"
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["lineMetrics"]
+    metrics = {item["line"]: item for item in payload["lineMetrics"]}
+    assert pytest.approx(metrics["L1"]["yield"], rel=1e-3) == 93.18
+    assert pytest.approx(metrics["L1"]["falseCallsPerBoard"], rel=1e-3) == 0.3636
+    assert pytest.approx(metrics["L1"]["ppm"], rel=1e-4) == 36363.6363
+    assert pytest.approx(metrics["L1"]["dpm"], rel=1e-4) == 50000.0
+    assert pytest.approx(metrics["L1"]["boardsPerDay"], rel=1e-3) == 11.0
+
+    assert payload["assemblyComparisons"]
+    asmA = next(item for item in payload["assemblyComparisons"] if item["assembly"] == "AsmA")
+    assert asmA["lines"]["L2"]["yield"] == pytest.approx(95.0)
+    assert payload["benchmarking"]["bestYield"]["line"] == "L2"
+
+
+def test_line_report_export_handles_pdf_error(app_instance, monkeypatch):
+    monkeypatch.setattr(routes, "build_line_report_payload", lambda start, end: {
+        "lineMetrics": [],
+        "assemblyComparisons": [],
+        "crossLine": {},
+        "lineTrends": [],
+        "trendInsights": {},
+        "benchmarking": {"lineVsCompany": []},
+        "companyAverages": {"yield": 0, "falseCallsPerBoard": 0, "ppm": 0, "dpm": 0},
+    })
+    monkeypatch.setattr(routes, "_generate_line_report_charts", lambda payload: {})
+    monkeypatch.setattr(routes, "render_template", lambda template, **context: "<html></html>")
+
+    def _raise_pdf_error(*args, **kwargs):
+        from app.main.pdf_utils import PdfGenerationError
+
+        raise PdfGenerationError("Install Pango")
+
+    monkeypatch.setattr(routes, "render_html_to_pdf", _raise_pdf_error)
+
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/reports/line/export?format=pdf")
+
+    assert resp.status_code == 503
+    assert resp.get_json() == {"message": "Install Pango"}


### PR DESCRIPTION
## Summary
- register a new Line Report feature flag and navigation entry
- aggregate PPM and DPM data into comprehensive line-level analytics with API and export routes
- add front-end UI, charts, and printable templates for the Line Report plus supporting tests

## Testing
- pytest tests/test_line_report.py tests/test_report_exports.py

------
https://chatgpt.com/codex/tasks/task_e_68d6a5b946948325a28c617cf2eaa610