### PR TITLE
Refocus line report KPIs on window-level yield and defects

### DIFF
--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -21,7 +21,7 @@
   <header>
     <h3>Line-Level Performance Metrics</h3>
     <p class="section-subtitle">
-      Aggregate yield, false calls, and throughput across all assemblies inspected on each line.
+      Aggregate window yield, defect rates, and throughput across all assemblies inspected on each line.
     </p>
   </header>
   <div class="table-wrapper">
@@ -29,12 +29,15 @@
       <thead>
         <tr>
           <th>Line</th>
-          <th>Yield %</th>
+          <th>Window Yield %</th>
+          <th>Part Yield %</th>
           <th>Confirmed Defects</th>
           <th>False Calls / Board</th>
-          <th>PPM</th>
-          <th>DPM</th>
+          <th>False Call PPM</th>
+          <th>False Call DPM</th>
+          <th>Defect DPM</th>
           <th>Boards / Day</th>
+          <th>Total Windows</th>
           <th>Total Parts</th>
         </tr>
       </thead>

--- a/templates/report/line/assemblies.html
+++ b/templates/report/line/assemblies.html
@@ -7,20 +7,40 @@
       <thead>
         <tr>
           <th>Line</th>
-          <th>Yield %</th>
+          <th>Window Yield %</th>
           <th>False Calls / Board</th>
-          <th>PPM</th>
-          <th>DPM</th>
+          <th>False Call PPM</th>
+          <th>False Call DPM</th>
+          <th>Defect DPM</th>
         </tr>
       </thead>
       <tbody>
         {% for line, metrics in assembly.lines.items() %}
         <tr>
           <td>{{ line }}</td>
-          <td>{{ metrics.yield|default(0)|round(2) }}</td>
+          <td>{{ (metrics.windowYield if metrics.windowYield is not none else metrics.yield)|default(0)|round(2) }}</td>
           <td>{{ metrics.falseCallsPerBoard|default(0)|round(2) }}</td>
-          <td>{{ metrics.ppm|default(0)|round(2) }}</td>
-          <td>{{ metrics.dpm|default(0)|round(2) }}</td>
+          <td>
+            {% if metrics.falseCallPpm is not none %}
+              {{ metrics.falseCallPpm|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
+            {% if metrics.falseCallDpm is not none %}
+              {{ metrics.falseCallDpm|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
+            {% if metrics.defectDpm is not none %}
+              {{ metrics.defectDpm|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/report/line/kpis.html
+++ b/templates/report/line/kpis.html
@@ -4,20 +4,22 @@
     <thead>
       <tr>
         <th>Line</th>
-        <th>Yield Δ vs Avg</th>
-        <th>False Call Δ</th>
-        <th>PPM Δ</th>
-        <th>DPM Δ</th>
+        <th>Window Yield Δ</th>
+        <th>False Call Δ (/board)</th>
+        <th>False Call PPM Δ</th>
+        <th>False Call DPM Δ</th>
+        <th>Defect DPM Δ</th>
       </tr>
     </thead>
     <tbody>
       {% for entry in benchmarking.lineVsCompany %}
       <tr>
         <td>{{ entry.line }}</td>
-        <td>{{ entry.yieldDelta|round(2) }}</td>
+        <td>{{ entry.windowYieldDelta|round(2) }}</td>
         <td>{{ entry.falseCallDelta|round(2) }}</td>
-        <td>{{ entry.ppmDelta|round(2) }}</td>
-        <td>{{ entry.dpmDelta|round(2) }}</td>
+        <td>{{ entry.falseCallPpmDelta|round(2) }}</td>
+        <td>{{ entry.falseCallDpmDelta|round(2) }}</td>
+        <td>{{ entry.defectDpmDelta|round(2) }}</td>
       </tr>
       {% endfor %}
     </tbody>

--- a/templates/report/line/metrics.html
+++ b/templates/report/line/metrics.html
@@ -16,12 +16,15 @@
     <thead>
       <tr>
         <th>Line</th>
-        <th>Yield %</th>
+        <th>Window Yield %</th>
+        <th>Part Yield %</th>
         <th>Confirmed Defects</th>
         <th>False Calls / Board</th>
-        <th>PPM</th>
-        <th>DPM</th>
+        <th>False Call PPM</th>
+        <th>False Call DPM</th>
+        <th>Defect DPM</th>
         <th>Boards / Day</th>
+        <th>Total Windows</th>
         <th>Total Parts</th>
       </tr>
     </thead>
@@ -29,12 +32,39 @@
       {% for metric in lineMetrics %}
       <tr>
         <td>{{ metric.line }}</td>
-        <td>{{ metric.yield|round(2) }}</td>
+        <td>{{ (metric.windowYield if metric.windowYield is not none else metric.yield)|round(2) }}</td>
+        <td>
+          {% if metric.partYield is not none %}
+            {{ metric.partYield|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
         <td>{{ metric.confirmedDefects|round(0) }}</td>
         <td>{{ metric.falseCallsPerBoard|round(2) }}</td>
-        <td>{{ metric.ppm|round(2) }}</td>
-        <td>{{ metric.dpm|round(2) }}</td>
+        <td>
+          {% if metric.falseCallPpm is not none %}
+            {{ metric.falseCallPpm|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
+        <td>
+          {% if metric.falseCallDpm is not none %}
+            {{ metric.falseCallDpm|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
+        <td>
+          {% if metric.defectDpm is not none %}
+            {{ metric.defectDpm|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
         <td>{{ metric.boardsPerDay|round(2) }}</td>
+        <td>{{ metric.totalWindows|round(0) }}</td>
         <td>{{ metric.totalParts|round(0) }}</td>
       </tr>
       {% endfor %}

--- a/templates/report/line/summary.html
+++ b/templates/report/line/summary.html
@@ -5,7 +5,8 @@
       <h3>Top Lines</h3>
       <ul>
         {% if benchmarking.bestYield %}
-        <li><strong>Best Yield:</strong> {{ benchmarking.bestYield.line }} ({{ benchmarking.bestYield.yield|round(2) }}%)</li>
+        {% set best_yield = benchmarking.bestYield.windowYield if benchmarking.bestYield.windowYield is not none else benchmarking.bestYield.partYield if benchmarking.bestYield.partYield is not none else benchmarking.bestYield.yield %}
+        <li><strong>Best Window Yield:</strong> {{ benchmarking.bestYield.line }} ({{ best_yield|round(2) }}%)</li>
         {% endif %}
         {% if benchmarking.lowestFalseCalls %}
         <li><strong>Lowest False Calls:</strong> {{ benchmarking.lowestFalseCalls.line }} ({{ benchmarking.lowestFalseCalls.falseCallsPerBoard|round(2) }})</li>
@@ -18,10 +19,11 @@
     <article>
       <h3>Company Averages</h3>
       <ul>
-        <li>Yield: {{ companyAverages.yield|round(2) }}%</li>
+        <li>Window Yield: {{ (companyAverages.windowYield if companyAverages.windowYield is not none else companyAverages.yield)|round(2) }}%</li>
         <li>False Calls / Board: {{ companyAverages.falseCallsPerBoard|round(2) }}</li>
-        <li>PPM: {{ companyAverages.ppm|round(2) }}</li>
-        <li>DPM: {{ companyAverages.dpm|round(2) }}</li>
+        <li>False Call PPM: {{ (companyAverages.falseCallPpm if companyAverages.falseCallPpm is not none else 0)|round(2) }}</li>
+        <li>False Call DPM: {{ (companyAverages.falseCallDpm if companyAverages.falseCallDpm is not none else 0)|round(2) }}</li>
+        <li>Defect DPM: {{ (companyAverages.defectDpm if companyAverages.defectDpm is not none else 0)|round(2) }}</li>
       </ul>
     </article>
     <article>
@@ -30,7 +32,7 @@
         {% set drift = (trendInsights.lineDrift or [])[:3] %}
         {% if drift %}
           {% for item in drift %}
-          <li>{{ item.line }} yield drifted {{ item.change|round(2) }} pts ({{ item.start|round(2) }}% → {{ item.end|round(2) }}%).</li>
+          <li>{{ item.line }} window yield drifted {{ item.change|round(2) }} pts ({{ item.start|round(2) }}% → {{ item.end|round(2) }}%).</li>
           {% endfor %}
         {% else %}
           <li>No significant yield drift detected across lines.</li>


### PR DESCRIPTION
## Summary
- pivoted line report aggregation to prioritize window-based yields, defect counts, and delta calculations while keeping part-level metrics as optional context
- refreshed the line report UI to surface window-yield, false-call DPM, and defect DPM KPIs and adjusted benchmarking copy accordingly
- expanded the line report tests to assert the new window-focused metrics and updated schema stubs

## Testing
- pytest tests/test_line_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d6b00401e8832588b7c50e831fc0d7