### PR TITLE
Restrict line report exports to PDF and HTML

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -4561,7 +4561,7 @@ def export_line_report():
         **charts,
     )
 
-    fmt = request.args.get('format')
+    fmt = request.args.get('format') or 'html'
     if fmt == 'pdf':
         try:
             pdf = render_html_to_pdf(html, base_url=request.url_root)
@@ -4581,7 +4581,7 @@ def export_line_report():
             download_name='report.html',
             as_attachment=True,
         )
-    return html
+    return jsonify({'message': 'Unsupported format. Choose pdf or html.'}), 400
 
 
 @main_bp.route('/api/reports/integrated', methods=['GET'])

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -433,7 +433,9 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   downloadBtn?.addEventListener('click', async () => {
-    const fmt = document.getElementById('file-format').value;
+    const fmtSelect = document.getElementById('file-format');
+    const selectedFormat = fmtSelect?.value;
+    const fmt = ['pdf', 'html'].includes(selectedFormat) ? selectedFormat : 'pdf';
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
     const params = new URLSearchParams({ format: fmt });

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -102,7 +102,6 @@
     <label for="file-format">Format</label>
     <select id="file-format">
       <option value="pdf">pdf</option>
-      <option value="xlsx">xlsx</option>
       <option value="html">html</option>
     </select>
   </div>

--- a/tests/test_line_report.py
+++ b/tests/test_line_report.py
@@ -156,3 +156,18 @@ def test_line_report_export_handles_pdf_error(app_instance, monkeypatch):
 
     assert resp.status_code == 503
     assert resp.get_json() == {"message": "Install Pango"}
+
+
+def test_line_report_export_rejects_unknown_format(app_instance, monkeypatch):
+    monkeypatch.setattr(routes, "build_line_report_payload", lambda start, end: {})
+    monkeypatch.setattr(routes, "_generate_line_report_charts", lambda payload: {})
+    monkeypatch.setattr(routes, "render_template", lambda template, **context: "<html></html>")
+
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        with client.session_transaction() as sess:
+            sess["username"] = "tester"
+        resp = client.get("/reports/line/export?format=xlsx")
+
+    assert resp.status_code == 400
+    assert resp.get_json() == {"message": "Unsupported format. Choose pdf or html."}


### PR DESCRIPTION
## Summary
- remove the XLSX option from the line report download controls and guard the client-side selection
- harden the line report export endpoint to only serve PDF or HTML responses
- cover the new validation with a regression test for unsupported formats

## Testing
- pytest tests/test_line_report.py

------
https://chatgpt.com/codex/tasks/task_e_68d9ac8d6a608325bde91f5cc1695771