### PR TITLE
Update PDF generation warnings to be platform-neutral

### DIFF
--- a/templates/dpm_analysis.html
+++ b/templates/dpm_analysis.html
@@ -197,7 +197,7 @@
         <span class="spinner" id="download-spinner" hidden></span>
         <button type="button" id="copy-image">Copy Image</button>
       </div>
-      <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
+      <p class="pdf-host-warning">PDF generation availability depends on your host configuration.</p>
       <div class="preview-card" style="height: 300px;">
         <canvas id="dpmChart"></canvas>
       </div>

--- a/templates/ppm_analysis.html
+++ b/templates/ppm_analysis.html
@@ -197,7 +197,7 @@
         <span class="spinner" id="download-spinner" hidden></span>
         <button type="button" id="copy-image">Copy Image</button>
       </div>
-      <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
+      <p class="pdf-host-warning">PDF generation availability depends on your host configuration.</p>
       <div class="preview-card" style="height: 300px;">
         <canvas id="ppmChart"></canvas>
       </div>


### PR DESCRIPTION
## Summary
- replace the PDF generation warning in the PPM and DPM analysis templates with host-agnostic messaging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9b427aa988325b22a97077f058cd2