### PR TITLE
Wrap line report previews in collapsible details

### DIFF
--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -6,6 +6,7 @@ document.addEventListener('DOMContentLoaded', () => {
   const downloadBtn = document.getElementById('download-report');
   const includeCover = document.getElementById('include-cover');
   const includeSummary = document.getElementById('include-summary');
+  const previewDetails = document.getElementById('line-preview');
   let reportData = null;
   let yieldChart = null;
   let falseCallChart = null;
@@ -27,6 +28,9 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showSection(section) {
     if (section) section.hidden = false;
+    if (previewDetails && !previewDetails.open) {
+      previewDetails.open = true;
+    }
   }
 
   function hideSections() {
@@ -415,6 +419,9 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     hideSections();
     clearCharts();
+    if (previewDetails) {
+      previewDetails.open = false;
+    }
     try {
       const response = await fetch(`/api/reports/line?start_date=${start}&end_date=${end}`);
       if (!response.ok) throw new Error('Failed to run report');

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -17,85 +17,90 @@
   </div>
 </div>
 
-<section class="section-card" id="line-metrics-section" hidden>
-  <header>
-    <h3>Line-Level Performance Metrics</h3>
-    <p class="section-subtitle">
-      Aggregate window yield, defect rates, and throughput across all assemblies inspected on each line.
-    </p>
-  </header>
-  <div class="table-wrapper">
-    <table class="data-table">
-      <thead>
-        <tr>
-          <th>Line</th>
-          <th>Window Yield %</th>
-          <th>Part Yield %</th>
-          <th>Confirmed Defects</th>
-          <th>Defects / Board</th>
-          <th>False Calls / Board</th>
-          <th>False Call DPM</th>
-          <th>Defect DPM</th>
-          <th>Boards / Day</th>
-          <th>Total Windows</th>
-          <th>Total Parts</th>
-        </tr>
-      </thead>
-      <tbody id="line-metrics-body"></tbody>
-    </table>
+<details id="line-preview" class="section-card">
+  <summary>Preview Charts</summary>
+  <div class="preview-content">
+    <section class="section-card" id="line-metrics-section" hidden>
+      <header>
+        <h3>Line-Level Performance Metrics</h3>
+        <p class="section-subtitle">
+          Aggregate window yield, defect rates, and throughput across all assemblies inspected on each line.
+        </p>
+      </header>
+      <div class="table-wrapper">
+        <table class="data-table">
+          <thead>
+            <tr>
+              <th>Line</th>
+              <th>Window Yield %</th>
+              <th>Part Yield %</th>
+              <th>Confirmed Defects</th>
+              <th>Defects / Board</th>
+              <th>False Calls / Board</th>
+              <th>False Call DPM</th>
+              <th>Defect DPM</th>
+              <th>Boards / Day</th>
+              <th>Total Windows</th>
+              <th>Total Parts</th>
+            </tr>
+          </thead>
+          <tbody id="line-metrics-body"></tbody>
+        </table>
+      </div>
+      <div class="chart-grid">
+        <div class="chart-block">
+          <canvas id="lineYieldChart"></canvas>
+        </div>
+        <div class="chart-block">
+          <canvas id="lineFalseCallChart"></canvas>
+        </div>
+        <div class="chart-block">
+          <canvas id="lineQualityChart"></canvas>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-card" id="assembly-comparison-section" hidden>
+      <header>
+        <h3>Assembly vs Line Comparisons</h3>
+        <p class="section-subtitle">
+          Compare how each line performs on the same assembly to pinpoint tuning or process opportunities.
+        </p>
+      </header>
+      <div id="assembly-comparisons"></div>
+    </section>
+
+    <section class="section-card" id="cross-line-section" hidden>
+      <header>
+        <h3>Cross-Line Synchronization</h3>
+        <p class="section-subtitle">
+          Measure consistency across lines and highlight where defect signatures diverge.</p>
+      </header>
+      <div id="cross-line-content"></div>
+    </section>
+
+    <section class="section-card" id="trend-section" hidden>
+      <header>
+        <h3>Trend Insights</h3>
+        <p class="section-subtitle">
+          Track yield drift, learning curves, and longitudinal performance by line.</p>
+      </header>
+      <div class="chart-block">
+        <canvas id="lineTrendChart"></canvas>
+      </div>
+      <div id="trend-insights"></div>
+    </section>
+
+    <section class="section-card" id="benchmarking-section" hidden>
+      <header>
+        <h3>Benchmarking KPIs</h3>
+        <p class="section-subtitle">
+          Quickly identify top-performing and at-risk lines relative to company targets.</p>
+      </header>
+      <div id="benchmarking-content"></div>
+    </section>
   </div>
-  <div class="chart-grid">
-    <div class="chart-block">
-      <canvas id="lineYieldChart"></canvas>
-    </div>
-    <div class="chart-block">
-      <canvas id="lineFalseCallChart"></canvas>
-    </div>
-    <div class="chart-block">
-      <canvas id="lineQualityChart"></canvas>
-    </div>
-  </div>
-</section>
-
-<section class="section-card" id="assembly-comparison-section" hidden>
-  <header>
-    <h3>Assembly vs Line Comparisons</h3>
-    <p class="section-subtitle">
-      Compare how each line performs on the same assembly to pinpoint tuning or process opportunities.
-    </p>
-  </header>
-  <div id="assembly-comparisons"></div>
-</section>
-
-<section class="section-card" id="cross-line-section" hidden>
-  <header>
-    <h3>Cross-Line Synchronization</h3>
-    <p class="section-subtitle">
-      Measure consistency across lines and highlight where defect signatures diverge.</p>
-  </header>
-  <div id="cross-line-content"></div>
-</section>
-
-<section class="section-card" id="trend-section" hidden>
-  <header>
-    <h3>Trend Insights</h3>
-    <p class="section-subtitle">
-      Track yield drift, learning curves, and longitudinal performance by line.</p>
-  </header>
-  <div class="chart-block">
-    <canvas id="lineTrendChart"></canvas>
-  </div>
-  <div id="trend-insights"></div>
-</section>
-
-<section class="section-card" id="benchmarking-section" hidden>
-  <header>
-    <h3>Benchmarking KPIs</h3>
-    <p class="section-subtitle">
-      Quickly identify top-performing and at-risk lines relative to company targets.</p>
-  </header>
-  <div id="benchmarking-content"></div>
-</section>
+</details>
 
 <div class="field-row" id="download-controls">
   <div class="field">


### PR DESCRIPTION
## Summary
- wrap the line report preview sections in a collapsible <details> container that matches the integrated report layout
- ensure the new preview container opens when report data loads and resets when rerunning the report

## Testing
- not run (UI change)

------
https://chatgpt.com/codex/tasks/task_e_68d9cf0c298883259a1f5d8a1cb8cc14