### PR TITLE
Filter assembly comparisons to multi-line assemblies

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3856,7 +3856,8 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
                 'defectDpm': defect_dpm,
                 'defectMix': defect_mix,
             }
-        assembly_comparisons.append({'assembly': assembly, 'lines': lines_info})
+        if len(lines_info) >= 2:
+            assembly_comparisons.append({'assembly': assembly, 'lines': lines_info})
 
     yield_variance = []
     false_call_variance = []

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -186,6 +186,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const container = document.getElementById('assembly-comparisons');
     if (!container) return;
     container.innerHTML = '';
+    if (!comparisons.length) {
+      container.innerHTML = '<p class="empty-state">No multi-line assemblies available for comparison.</p>';
+      showSection(sections.assembly);
+      return;
+    }
+
     comparisons.forEach((item) => {
       const details = document.createElement('details');
       details.className = 'comparison-block';


### PR DESCRIPTION
## Summary
- avoid returning assembly comparison data when an assembly only has a single line in the selected range
- show an empty-state message in the line report UI when no assembly comparisons are available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9cffa00088325a2205cb18c530eef