### PR TITLE
Limit report downloads to supported formats

### DIFF
--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -83,7 +83,6 @@
     <label for="file-format">Format</label>
     <select id="file-format">
       <option value="pdf">pdf</option>
-      <option value="xlsx">xlsx</option>
       <option value="html">html</option>
     </select>
   </div>

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -52,7 +52,6 @@
     <label for="file-format">Format</label>
     <select id="file-format">
       <option value="pdf">pdf</option>
-      <option value="xlsx">xlsx</option>
       <option value="html">html</option>
     </select>
   </div>


### PR DESCRIPTION
## Summary
- remove the xlsx option from the integrated and operator report download format pickers so only pdf and html remain
- align the available client-side formats with the export endpoints, which only support pdf and html

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9da311ee883258e29a543258136e3