### PR TITLE
Simplify report download controls and requests

### DIFF
--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -33,17 +33,11 @@ document.addEventListener('DOMContentLoaded', () => {
     const start = document.getElementById('start-date').value;
     const end = document.getElementById('end-date').value;
     const params = new URLSearchParams({ format: fmt });
-    const includeCover = document.getElementById('include-cover')?.checked;
-    params.append('show_cover', includeCover ? 'true' : 'false');
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
     await downloadFile(`/reports/integrated/export?${params.toString()}`, {
       buttonId: 'download-report',
     });
-  });
-
-  document.getElementById('email-report')?.addEventListener('click', () => {
-    alert('Email sent (placeholder).');
   });
 
   function setDesc(id, lines) {

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -4,8 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
   const runBtn = document.getElementById('run-line-report');
   const downloadControls = document.getElementById('download-controls');
   const downloadBtn = document.getElementById('download-report');
-  const includeCover = document.getElementById('include-cover');
-  const includeSummary = document.getElementById('include-summary');
   const previewDetails = document.getElementById('line-preview');
   let reportData = null;
   let yieldChart = null;
@@ -454,15 +452,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const params = new URLSearchParams({ format: fmt });
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
-    params.append('show_cover', includeCover?.checked ? 'true' : 'false');
-    params.append('show_summary', includeSummary?.checked ? 'true' : 'false');
     await downloadFile(`/reports/line/export?${params.toString()}`, {
       buttonId: 'download-report',
       spinnerId: 'download-spinner',
     });
-  });
-
-  document.getElementById('email-report')?.addEventListener('click', () => {
-    alert('Email sent (placeholder).');
   });
 });

--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -89,18 +89,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const end = document.getElementById('end-date').value;
     const operator = getDropdownValues('filter-operator').join(',');
     const params = new URLSearchParams({ format: fmt });
-    const includeCover = document.getElementById('include-cover')?.checked;
-    params.append('show_cover', includeCover ? 'true' : 'false');
     if (start) params.append('start_date', start);
     if (end) params.append('end_date', end);
     if (operator) params.append('operator', operator);
     await downloadFile(`/reports/operator/export?${params.toString()}`, {
       buttonId: 'download-report',
     });
-  });
-
-  document.getElementById('email-report')?.addEventListener('click', () => {
-    alert('Email sent (placeholder).');
   });
 
   function setDesc(id, lines) {

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -78,7 +78,7 @@
     </div>
   </details>
 
-<div class="field-row" id="download-controls">
+<div id="download-controls" class="field-row" style="display:none">
   <div class="field">
     <label for="file-format">Format</label>
     <select id="file-format">
@@ -86,14 +86,8 @@
       <option value="html">html</option>
     </select>
   </div>
-  <div class="field">
-    <label for="include-cover">Cover Page</label>
-    <input type="checkbox" id="include-cover" checked />
-  </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>
-  <button id="email-report">Email Report</button>
-  <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
 </div>
 {% endblock %}
 

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -102,7 +102,7 @@
   </div>
 </details>
 
-<div class="field-row" id="download-controls">
+<div id="download-controls" class="field-row" style="display:none">
   <div class="field">
     <label for="file-format">Format</label>
     <select id="file-format">
@@ -110,18 +110,8 @@
       <option value="html">html</option>
     </select>
   </div>
-  <div class="field">
-    <label for="include-cover">Cover Page</label>
-    <input type="checkbox" id="include-cover" checked />
-  </div>
-  <div class="field">
-    <label for="include-summary">Executive Summary</label>
-    <input type="checkbox" id="include-summary" checked />
-  </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>
-  <button id="email-report">Email Report</button>
-  <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
 </div>
 {% endblock %}
 

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -55,14 +55,8 @@
       <option value="html">html</option>
     </select>
   </div>
-  <div class="field">
-    <label for="include-cover">Cover Page</label>
-    <input type="checkbox" id="include-cover" checked />
-  </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>
-  <button id="email-report">Email Report</button>
-  <p class="pdf-host-warning">PDF generation requires a Linux or Windows host. macOS is not supported.</p>
 </div>
 {% endblock %}
 


### PR DESCRIPTION
## Summary
- simplify the download controls on the line, operator, and integrated report pages to match the AOI daily report
- trim front-end download logic to only send required filters and remove unused controls
- rely on backend defaults for optional flags after removing the related query parameters

## Testing
- `pytest tests/test_line_report.py::test_line_report_export_html_includes_charts tests/test_line_report.py::test_line_report_export_pdf_succeeds tests/test_operator_report_routes.py::test_export_operator_report tests/test_export_integrated_report_date_range.py::test_export_integrated_report_respects_date_range`
- `python operator_report_pdf_check.py (inline script)`

------
https://chatgpt.com/codex/tasks/task_e_68d9dbc1d05083258fc186da32c981e0