### PR TITLE
Stop auto-expanding line report preview

### DIFF
--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -26,9 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function showSection(section) {
     if (section) section.hidden = false;
-    if (previewDetails && !previewDetails.open) {
-      previewDetails.open = true;
-    }
   }
 
   function hideSections() {


### PR DESCRIPTION
## Summary
- remove the logic that forced the line report preview <details> element to open when showing a section
- keep section visibility toggling intact without automatically expanding the preview container

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da6c42c7e483258cd1bd5c826cae25