### PR TITLE
Standardize line report preview element IDs

### DIFF
--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -1,11 +1,17 @@
 import { downloadFile } from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const runBtn = document.getElementById('run-line-report');
+  const selectors = {
+    runBtn: 'run-report',
+    previewContainer: 'preview',
+    previewData: 'preview-data',
+  };
+
+  const runBtn = document.getElementById(selectors.runBtn);
   const downloadControls = document.getElementById('download-controls');
   const downloadBtn = document.getElementById('download-report');
-  const previewDetails = document.getElementById('line-preview');
-  const previewData = document.getElementById('line-preview-data');
+  const previewDetails = document.getElementById(selectors.previewContainer);
+  const previewData = document.getElementById(selectors.previewData);
   let reportData = null;
 
   if (downloadControls) downloadControls.style.display = 'none';

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -13,14 +13,14 @@
       <label for="end-date">End Date</label>
       <input type="date" id="end-date" />
     </div>
-    <button type="button" id="run-line-report">Run</button>
+    <button type="button" id="run-report">Run</button>
   </div>
 </div>
 
-<details id="line-preview" class="section-card">
+<details id="preview" class="section-card">
   <summary>Preview Data</summary>
   <div class="preview-content">
-    <pre id="line-preview-data" class="json-preview"></pre>
+    <pre id="preview-data" class="json-preview"></pre>
   </div>
 </details>
 


### PR DESCRIPTION
## Summary
- align the line report template with shared run and preview element IDs used across report pages
- update the line report JavaScript to reference the standardized element IDs via a small selector map

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da72167358832580a6c7fb5d438a22