### PR TITLE
Refactor report JS to use shared runner helper

### DIFF
--- a/static/js/aoi_daily_report.js
+++ b/static/js/aoi_daily_report.js
@@ -1,39 +1,39 @@
-import { downloadFile } from './utils.js';
+import { setupReportRunner } from './report_runner.js';
 
 document.addEventListener('DOMContentLoaded', () => {
-  const runBtn = document.getElementById('run-report');
-  const downloadBtn = document.getElementById('download-report');
-  const downloadControls = document.getElementById('download-controls');
   const previewBox = document.getElementById('preview-data');
 
-  if (downloadControls) downloadControls.style.display = 'none';
+  const collectParams = () => {
+    const date = document.getElementById('report-date')?.value || '';
+    const format = document.getElementById('file-format')?.value || 'pdf';
+    return { date, format };
+  };
 
-  runBtn?.addEventListener('click', () => {
-    const date = document.getElementById('report-date').value;
+  const validateParams = ({ date }) => {
     if (!date) {
-      alert('Please select a date.');
-      return;
+      return 'Please select a date.';
     }
-    const params = new URLSearchParams({ date });
-    fetch(`/api/reports/aoi_daily?${params.toString()}`)
-      .then((res) => res.json())
-      .then((data) => {
-        if (previewBox) previewBox.textContent = JSON.stringify(data, null, 2);
-        if (downloadControls) downloadControls.style.display = 'flex';
-      })
-      .catch(() => alert('Failed to run report.'));
-  });
+    return true;
+  };
 
-  downloadBtn?.addEventListener('click', async () => {
-    const fmt = document.getElementById('file-format').value;
-    const date = document.getElementById('report-date').value;
-    if (!date) {
-      alert('Please select a date.');
-      return;
-    }
-    const params = new URLSearchParams({ format: fmt, date, show_cover: 'true' });
-    await downloadFile(`/reports/aoi_daily/export?${params.toString()}`, {
-      buttonId: 'download-report',
-    });
+  setupReportRunner({
+    collectParams,
+    validateParams,
+    buildPreviewUrl: ({ date }) => {
+      const params = new URLSearchParams({ date });
+      return `/api/reports/aoi_daily?${params.toString()}`;
+    },
+    onPreviewSuccess: (data) => {
+      if (previewBox) previewBox.textContent = JSON.stringify(data, null, 2);
+    },
+    onPreviewError: () => alert('Failed to run report.'),
+    buildDownloadUrl: ({ date, format }) => {
+      const params = new URLSearchParams({
+        format: format || 'pdf',
+        date,
+        show_cover: 'true',
+      });
+      return `/reports/aoi_daily/export?${params.toString()}`;
+    },
   });
 });

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -1,20 +1,13 @@
-import { downloadFile } from './utils.js';
+import { setupReportRunner } from './report_runner.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const selectors = {
-    runBtn: 'run-report',
     previewContainer: 'preview',
     previewData: 'preview-data',
   };
-
-  const runBtn = document.getElementById(selectors.runBtn);
-  const downloadControls = document.getElementById('download-controls');
-  const downloadBtn = document.getElementById('download-report');
   const previewDetails = document.getElementById(selectors.previewContainer);
   const previewData = document.getElementById(selectors.previewData);
   let reportData = null;
-
-  if (downloadControls) downloadControls.style.display = 'none';
 
   function clearPreview() {
     if (previewData) {
@@ -25,46 +18,50 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  runBtn?.addEventListener('click', async () => {
-    const start = document.getElementById('start-date').value;
-    const end = document.getElementById('end-date').value;
+  const collectParams = () => {
+    const start = document.getElementById('start-date')?.value || '';
+    const end = document.getElementById('end-date')?.value || '';
+    const format = document.getElementById('file-format')?.value || 'pdf';
+    return { start, end, format };
+  };
+
+  const validateParams = ({ start, end }) => {
     if (!start || !end) {
-      alert('Please select a date range.');
-      return;
+      return 'Please select a date range.';
     }
+    return true;
+  };
 
-    clearPreview();
-
-    try {
-      const response = await fetch(`/api/reports/line?start_date=${start}&end_date=${end}`);
-      if (!response.ok) throw new Error('Failed to run report');
-      reportData = await response.json();
-
+  setupReportRunner({
+    collectParams,
+    validateParams,
+    beforePreview: () => {
+      clearPreview();
+    },
+    buildPreviewUrl: ({ start, end }) => {
+      const params = new URLSearchParams({ start_date: start, end_date: end });
+      return `/api/reports/line?${params.toString()}`;
+    },
+    onPreviewSuccess: (data) => {
+      reportData = data;
       if (previewData) {
         previewData.textContent = JSON.stringify(reportData, null, 2);
       }
       if (previewDetails) {
         previewDetails.open = true;
       }
-      if (downloadControls) downloadControls.style.display = 'flex';
-    } catch (err) {
-      console.error(err);
-      alert('Failed to run line report.');
-    }
-  });
-
-  downloadBtn?.addEventListener('click', async () => {
-    const fmtSelect = document.getElementById('file-format');
-    const selectedFormat = fmtSelect?.value;
-    const fmt = ['pdf', 'html'].includes(selectedFormat) ? selectedFormat : 'pdf';
-    const start = document.getElementById('start-date').value;
-    const end = document.getElementById('end-date').value;
-    const params = new URLSearchParams({ format: fmt });
-    if (start) params.append('start_date', start);
-    if (end) params.append('end_date', end);
-    await downloadFile(`/reports/line/export?${params.toString()}`, {
-      buttonId: 'download-report',
+    },
+    onPreviewError: () => alert('Failed to run line report.'),
+    buildDownloadUrl: ({ start, end, format }) => {
+      const selected = (format || '').toLowerCase();
+      const fmt = ['pdf', 'html'].includes(selected) ? selected : 'pdf';
+      const params = new URLSearchParams({ format: fmt });
+      if (start) params.append('start_date', start);
+      if (end) params.append('end_date', end);
+      return `/reports/line/export?${params.toString()}`;
+    },
+    downloadOptions: {
       spinnerId: 'download-spinner',
-    });
+    },
   });
 });

--- a/static/js/report_runner.js
+++ b/static/js/report_runner.js
@@ -1,0 +1,110 @@
+import { downloadFile } from './utils.js';
+
+function alertValidationResult(result) {
+  if (typeof result === 'string' && result) {
+    alert(result);
+  }
+}
+
+export function setupReportRunner({
+  runButtonId = 'run-report',
+  downloadButtonId = 'download-report',
+  downloadControlsId = 'download-controls',
+  collectParams = () => ({}),
+  validateParams,
+  beforePreview,
+  buildPreviewUrl,
+  fetchPreview = (url) => fetch(url),
+  onPreviewSuccess,
+  onPreviewError,
+  buildDownloadUrl,
+  downloadOptions = {},
+} = {}) {
+  const runBtn = document.getElementById(runButtonId);
+  const downloadBtn = document.getElementById(downloadButtonId);
+  const downloadControls = downloadControlsId
+    ? document.getElementById(downloadControlsId)
+    : null;
+
+  if (downloadControls) downloadControls.style.display = 'none';
+
+  async function handleRun(event) {
+    event?.preventDefault?.();
+    const params = collectParams();
+    const validationResult = validateParams
+      ? validateParams(params, { isDownload: false })
+      : true;
+    if (validationResult !== true) {
+      alertValidationResult(validationResult);
+      return;
+    }
+
+    beforePreview?.(params);
+
+    const previewUrl =
+      typeof buildPreviewUrl === 'function'
+        ? buildPreviewUrl(params)
+        : buildPreviewUrl;
+
+    if (!previewUrl) {
+      console.warn('setupReportRunner: preview URL was not provided.');
+      return;
+    }
+
+    try {
+      const response = await fetchPreview(previewUrl, params);
+      if (!response.ok) {
+        throw new Error(`Preview request failed with status ${response.status}`);
+      }
+      const data = await response.json();
+      if (onPreviewSuccess) {
+        await onPreviewSuccess(data, params);
+      }
+      if (downloadControls) downloadControls.style.display = 'flex';
+    } catch (err) {
+      console.error(err);
+      if (onPreviewError) {
+        onPreviewError(err, params);
+      } else {
+        alert('Failed to run report.');
+      }
+      if (downloadControls) downloadControls.style.display = 'none';
+    }
+  }
+
+  runBtn?.addEventListener('click', handleRun);
+
+  async function handleDownload(event) {
+    event?.preventDefault?.();
+    const params = collectParams();
+    const validationResult = validateParams
+      ? validateParams(params, { isDownload: true })
+      : true;
+    if (validationResult !== true) {
+      alertValidationResult(validationResult);
+      return;
+    }
+
+    const downloadUrl =
+      typeof buildDownloadUrl === 'function'
+        ? buildDownloadUrl(params)
+        : buildDownloadUrl;
+
+    if (!downloadUrl) {
+      console.warn('setupReportRunner: download URL was not provided.');
+      return;
+    }
+
+    await downloadFile(downloadUrl, {
+      buttonId: downloadButtonId,
+      ...downloadOptions,
+    });
+  }
+
+  downloadBtn?.addEventListener('click', handleDownload);
+
+  return {
+    run: handleRun,
+    download: handleDownload,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared report runner helper that handles preview validation, download state, and shared UI controls
- update the integrated, operator, AOI daily, and line report pages to use the helper while preserving their specific preview logic
- ensure download actions continue to disable the button/spinner and previews render after successful responses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da740d6f94832598baceb2373e40b4