### PR TITLE
Default report downloads to HTML on non-Linux clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ Daily report PDFs:
 Once the packages are present, `pip install -r requirements.txt` will install
 WeasyPrint and the Flask endpoints will be able to stream PDF responses.
 
+The web UI now detects the browser platform and defaults report downloads to
+HTML when the client is not running on Linux. On those systems the PDF option is
+disabled with an explanatory note so users understand the limitation. Linux
+installations that satisfy the native dependencies keep PDF selected by default
+and can continue exporting PDF reports without any extra steps.
+
 If your Linux distribution installs WeasyPrint libraries in non-standard
 locations, set the `WEASYPRINT_NATIVE_LIB_PATHS` environment variable to include
 paths that contain the required `.so` files.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1171,6 +1171,11 @@ button {
 .field { display: flex; flex-direction: column; }
 .field label { font-size: 12px; }
 .field input, .field select { padding: 6px; }
+.field-note {
+  margin-top: 4px;
+  font-size: 0.8rem;
+  color: var(--ink-subtle);
+}
 
 #download-controls {
   display: none;

--- a/static/js/aoi_daily_report.js
+++ b/static/js/aoi_daily_report.js
@@ -1,11 +1,18 @@
 import { setupReportRunner } from './report_runner.js';
+import {
+  configureReportFormatSelector,
+  getPreferredReportFormat,
+} from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const previewBox = document.getElementById('preview-data');
 
+  configureReportFormatSelector({ noteId: 'file-format-note' });
+
   const collectParams = () => {
     const date = document.getElementById('report-date')?.value || '';
-    const format = document.getElementById('file-format')?.value || 'pdf';
+    const format =
+      document.getElementById('file-format')?.value || getPreferredReportFormat();
     return { date, format };
   };
 
@@ -29,7 +36,7 @@ document.addEventListener('DOMContentLoaded', () => {
     onPreviewError: () => alert('Failed to run report.'),
     buildDownloadUrl: ({ date, format }) => {
       const params = new URLSearchParams({
-        format: format || 'pdf',
+        format: format || getPreferredReportFormat(),
         date,
         show_cover: 'true',
       });

--- a/static/js/integrated_report.js
+++ b/static/js/integrated_report.js
@@ -1,8 +1,14 @@
 import { setupReportRunner } from './report_runner.js';
+import {
+  configureReportFormatSelector,
+  getPreferredReportFormat,
+} from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   let reportData = null;
   let yieldChart, operatorChart, modelChart, fcVsNgChart, fcNgRatioChart;
+
+  configureReportFormatSelector({ noteId: 'file-format-note' });
 
   const collectParams = () => {
     const startInput = document.getElementById('start-date');
@@ -11,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
     return {
       start: startInput?.value || '',
       end: endInput?.value || '',
-      format: formatSelect?.value || 'pdf',
+      format: formatSelect?.value || getPreferredReportFormat(),
     };
   };
 
@@ -37,7 +43,9 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     onPreviewError: () => alert('Failed to run report.'),
     buildDownloadUrl: ({ start, end, format }) => {
-      const params = new URLSearchParams({ format: format || 'pdf' });
+      const params = new URLSearchParams({
+        format: format || getPreferredReportFormat(),
+      });
       if (start) params.append('start_date', start);
       if (end) params.append('end_date', end);
       return `/reports/integrated/export?${params.toString()}`;

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -1,10 +1,15 @@
 import { setupReportRunner } from './report_runner.js';
+import {
+  configureReportFormatSelector,
+  getPreferredReportFormat,
+} from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const selectors = {
     previewContainer: 'preview',
     previewData: 'preview-data',
   };
+  configureReportFormatSelector({ noteId: 'file-format-note' });
   const previewDetails = document.getElementById(selectors.previewContainer);
   const previewData = document.getElementById(selectors.previewData);
   let reportData = null;
@@ -21,7 +26,8 @@ document.addEventListener('DOMContentLoaded', () => {
   const collectParams = () => {
     const start = document.getElementById('start-date')?.value || '';
     const end = document.getElementById('end-date')?.value || '';
-    const format = document.getElementById('file-format')?.value || 'pdf';
+    const format =
+      document.getElementById('file-format')?.value || getPreferredReportFormat();
     return { start, end, format };
   };
 
@@ -54,7 +60,8 @@ document.addEventListener('DOMContentLoaded', () => {
     onPreviewError: () => alert('Failed to run line report.'),
     buildDownloadUrl: ({ start, end, format }) => {
       const selected = (format || '').toLowerCase();
-      const fmt = ['pdf', 'html'].includes(selected) ? selected : 'pdf';
+      const preferred = getPreferredReportFormat();
+      const fmt = ['pdf', 'html'].includes(selected) ? selected : preferred;
       const params = new URLSearchParams({ format: fmt });
       if (start) params.append('start_date', start);
       if (end) params.append('end_date', end);

--- a/static/js/operator_report.js
+++ b/static/js/operator_report.js
@@ -47,9 +47,15 @@ function getDropdownValues(className) {
 }
 
 import { setupReportRunner } from './report_runner.js';
+import {
+  configureReportFormatSelector,
+  getPreferredReportFormat,
+} from './utils.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   let dailyChart = null;
+
+  configureReportFormatSelector({ noteId: 'file-format-note' });
 
   fetch('/aoi_reports')
     .then((r) => r.json())
@@ -63,7 +69,8 @@ document.addEventListener('DOMContentLoaded', () => {
     const start = document.getElementById('start-date')?.value || '';
     const end = document.getElementById('end-date')?.value || '';
     const operator = getDropdownValues('filter-operator').join(',');
-    const format = document.getElementById('file-format')?.value || 'pdf';
+    const format =
+      document.getElementById('file-format')?.value || getPreferredReportFormat();
     return { start, end, operator, format };
   };
 
@@ -87,7 +94,9 @@ document.addEventListener('DOMContentLoaded', () => {
     },
     onPreviewError: () => alert('Failed to run report.'),
     buildDownloadUrl: ({ start, end, operator, format }) => {
-      const params = new URLSearchParams({ format: format || 'pdf' });
+      const params = new URLSearchParams({
+        format: format || getPreferredReportFormat(),
+      });
       if (start) params.append('start_date', start);
       if (end) params.append('end_date', end);
       if (operator) params.append('operator', operator);

--- a/static/js/utils.js
+++ b/static/js/utils.js
@@ -12,6 +12,59 @@ export function hideSpinner(btnId, spinnerId = 'download-spinner') {
   if (btn) btn.disabled = false;
 }
 
+export function isLikelyLinuxClient() {
+  if (typeof navigator === 'undefined') {
+    return true;
+  }
+
+  const platform = navigator?.platform || '';
+  const userAgent = navigator?.userAgent || '';
+  const combined = `${platform} ${userAgent}`.toLowerCase();
+
+  return combined.includes('linux');
+}
+
+export function getPreferredReportFormat() {
+  return isLikelyLinuxClient() ? 'pdf' : 'html';
+}
+
+export function configureReportFormatSelector({
+  selectId = 'file-format',
+  noteId,
+  disablePdf = true,
+} = {}) {
+  const select = selectId ? document.getElementById(selectId) : null;
+  if (!select) return;
+
+  const noteEl = noteId ? document.getElementById(noteId) : null;
+  const pdfOption = select.querySelector('option[value="pdf"]');
+  const htmlOption = select.querySelector('option[value="html"]');
+  const linuxClient = isLikelyLinuxClient();
+
+  const message =
+    'PDF exports are only available on Linux hosts configured with the required PDF dependencies.';
+
+  if (linuxClient) {
+    if (pdfOption) pdfOption.disabled = false;
+    if (pdfOption) select.value = pdfOption.value;
+    if (noteEl) noteEl.hidden = true;
+    if (!noteEl) select.removeAttribute('title');
+    return;
+  }
+
+  if (htmlOption) select.value = htmlOption.value;
+  if (pdfOption && disablePdf) {
+    pdfOption.disabled = true;
+  }
+
+  if (noteEl) {
+    noteEl.textContent = message;
+    noteEl.hidden = false;
+  } else {
+    select.title = message;
+  }
+}
+
 function decodeFileName(disposition) {
   if (!disposition) return null;
   // RFC 5987 style: filename*=UTF-8''...

--- a/templates/aoi_daily_report.html
+++ b/templates/aoi_daily_report.html
@@ -25,6 +25,10 @@
       <option value="pdf">pdf</option>
       <option value="html">html</option>
     </select>
+    <p class="field-note" id="file-format-note" hidden>
+      PDF downloads are available on Linux hosts that have the required PDF
+      dependencies installed.
+    </p>
   </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>

--- a/templates/integrated_report.html
+++ b/templates/integrated_report.html
@@ -85,6 +85,10 @@
       <option value="pdf">pdf</option>
       <option value="html">html</option>
     </select>
+    <p class="field-note" id="file-format-note" hidden>
+      PDF downloads are available on Linux hosts that have the required PDF
+      dependencies installed.
+    </p>
   </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>

--- a/templates/line_report.html
+++ b/templates/line_report.html
@@ -31,6 +31,10 @@
       <option value="pdf">pdf</option>
       <option value="html">html</option>
     </select>
+    <p class="field-note" id="file-format-note" hidden>
+      PDF downloads are available on Linux hosts that have the required PDF
+      dependencies installed.
+    </p>
   </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>

--- a/templates/operator_report.html
+++ b/templates/operator_report.html
@@ -54,6 +54,10 @@
       <option value="pdf">pdf</option>
       <option value="html">html</option>
     </select>
+    <p class="field-note" id="file-format-note" hidden>
+      PDF downloads are available on Linux hosts that have the required PDF
+      dependencies installed.
+    </p>
   </div>
   <button id="download-report">Download</button>
   <span class="spinner" id="download-spinner" hidden></span>


### PR DESCRIPTION
## Summary
- detect the client platform at runtime and default report downloads to HTML when not on Linux, disabling PDF when unavailable
- update report templates with inline notices and styling to surface the Linux-only PDF requirement
- document the behavior so users know PDF exports remain available on properly configured Linux instances

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da7538c4b0832581aad1aed2e000ef