### PR TITLE
Keep line report downloads available after preview errors

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1183,6 +1183,11 @@ button {
   align-items: center;
 }
 
+.json-preview.preview-message {
+  white-space: pre-wrap;
+  color: var(--danger);
+}
+
 .spinner {
   width: 16px;
   height: 16px;

--- a/static/js/line_report.js
+++ b/static/js/line_report.js
@@ -17,9 +17,19 @@ document.addEventListener('DOMContentLoaded', () => {
   function clearPreview() {
     if (previewData) {
       previewData.textContent = '';
+      previewData.classList.remove('preview-message');
     }
     if (previewDetails) {
       previewDetails.open = false;
+    }
+  }
+
+  function showPreviewMessage(message) {
+    if (!previewData) return;
+    previewData.textContent = message;
+    previewData.classList.add('preview-message');
+    if (previewDetails) {
+      previewDetails.open = true;
     }
   }
 
@@ -52,12 +62,21 @@ document.addEventListener('DOMContentLoaded', () => {
       reportData = data;
       if (previewData) {
         previewData.textContent = JSON.stringify(reportData, null, 2);
+        previewData.classList.remove('preview-message');
       }
       if (previewDetails) {
         previewDetails.open = true;
       }
     },
-    onPreviewError: () => alert('Failed to run line report.'),
+    onPreviewError: (err) => {
+      reportData = null;
+      const reason = err?.message
+        ? `\nDetails: ${err.message}`
+        : '';
+      showPreviewMessage(
+        `We couldn't generate a preview for the selected dates, but you can still download the report.${reason}`,
+      );
+    },
     buildDownloadUrl: ({ start, end, format }) => {
       const selected = (format || '').toLowerCase();
       const preferred = getPreferredReportFormat();
@@ -70,5 +89,6 @@ document.addEventListener('DOMContentLoaded', () => {
     downloadOptions: {
       spinnerId: 'download-spinner',
     },
+    showDownloadControlsOnValidation: true,
   });
 });

--- a/static/js/report_runner.js
+++ b/static/js/report_runner.js
@@ -19,6 +19,7 @@ export function setupReportRunner({
   onPreviewError,
   buildDownloadUrl,
   downloadOptions = {},
+  showDownloadControlsOnValidation = false,
 } = {}) {
   const runBtn = document.getElementById(runButtonId);
   const downloadBtn = document.getElementById(downloadButtonId);
@@ -39,6 +40,10 @@ export function setupReportRunner({
       return;
     }
 
+    if (downloadControls && showDownloadControlsOnValidation) {
+      downloadControls.style.display = 'flex';
+    }
+
     beforePreview?.(params);
 
     const previewUrl =
@@ -48,6 +53,9 @@ export function setupReportRunner({
 
     if (!previewUrl) {
       console.warn('setupReportRunner: preview URL was not provided.');
+      if (downloadControls && !showDownloadControlsOnValidation) {
+        downloadControls.style.display = 'none';
+      }
       return;
     }
 
@@ -68,7 +76,9 @@ export function setupReportRunner({
       } else {
         alert('Failed to run report.');
       }
-      if (downloadControls) downloadControls.style.display = 'none';
+      if (downloadControls && !showDownloadControlsOnValidation) {
+        downloadControls.style.display = 'none';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- add an optional setupReportRunner flag so validated parameters can reveal download controls even when previews fail or are skipped
- update the line report workflow to use the new flag, surface inline messaging on preview failures, and keep the download action available once dates are validated
- style the JSON preview area so fallback messages are readable when preview data is unavailable

## Testing
- Manual verification: launched the Flask dev server, navigated to the line report, selected a >7 day range, and confirmed the inline warning plus visible download controls even when the Supabase-backed preview endpoint returned 500 due to missing credentials

------
https://chatgpt.com/codex/tasks/task_e_68da7b81122c8325beb88fb5e15c5af3