### PR TITLE
Align line report templates with shared report styles

### DIFF
--- a/templates/report/line/assemblies.html
+++ b/templates/report/line/assemblies.html
@@ -1,9 +1,9 @@
 <section class="report-section">
   <h2>Assembly vs Line Comparisons</h2>
   {% for assembly in assemblyComparisons %}
-  <article class="report-card">
+  <article class="section-card">
     <h3>{{ assembly.assembly }}</h3>
-    <table class="report-table">
+    <table class="data-table">
       <thead>
         <tr>
           <th>Line</th>
@@ -52,9 +52,9 @@
       {% endif %}
     {% endfor %}
     {% if mixes %}
-    <div class="defect-mix-grid">
+    <div class="kpi-grid">
       {% for item in mixes %}
-      <div>
+      <div class="section-card">
         <h4>{{ item[0] }} Defect Mix</h4>
         <ul>
           {% for defect, share in (item[1].items()|sort(attribute=1, reverse=True))[:5] %}

--- a/templates/report/line/cover.html
+++ b/templates/report/line/cover.html
@@ -1,49 +1,53 @@
-<section class="report-cover">
-  <div class="cover-header">
-    <img src="{{ logo_url }}" alt="Logo" class="cover-logo" />
-    <div class="cover-meta">
-      <h1>{{ title or 'Line Report' }}</h1>
-      {% if subtitle %}<p class="cover-subtitle">{{ subtitle }}</p>{% endif %}
-    </div>
+<section class="report-section cover-page" id="cover">
+  <br />
+  <header>
+    <h1>
+      {% if logo_url %}
+      <img src="{{ logo_url }}" alt="Company logo" class="company-logo-pdf" />
+      {% endif %}
+      {{ title or 'Line Report' }}
+    </h1>
+  </header>
+  {% if subtitle %}
+  <p class="section-desc">{{ subtitle }}</p>
+  {% endif %}
+  <div class="report-details">
+    <p><strong>Report Date:</strong>&nbsp;{{ report_date or generated_at }}</p>
   </div>
-  <dl class="cover-details">
-    <div>
-      <dt>Report Date</dt>
-      <dd>{{ report_date or generated_at }}</dd>
-    </div>
-    <div>
-      <dt>Period</dt>
-      <dd>
-        {% if period %}
-          {{ period }}
-        {% elif start or end %}
-          {{ start or '—' }} to {{ end or '—' }}
-        {% else %}
-          Custom Range
-        {% endif %}
-      </dd>
-    </div>
-    {% if author %}
-    <div>
-      <dt>Prepared By</dt>
-      <dd>{{ author }}</dd>
-    </div>
-    {% endif %}
-    {% if contact %}
-    <div>
-      <dt>Contact</dt>
-      <dd>{{ contact }}</dd>
-    </div>
-    {% endif %}
-    {% if report_id %}
-    <div>
-      <dt>Report ID</dt>
-      <dd>{{ report_id }}</dd>
-    </div>
-    {% endif %}
-  </dl>
-  <footer class="cover-footer">
-    <span>{{ confidentiality }}</span>
-    {% if footer_left %}<span>{{ footer_left }}</span>{% endif %}
-  </footer>
+  <div class="report-details">
+    <p>
+      <strong>Period:</strong>&nbsp;
+      {% if period %}
+        {{ period }}
+      {% elif start or end %}
+        {{ start or '—' }} to {{ end or '—' }}
+      {% else %}
+        Custom Range
+      {% endif %}
+    </p>
+  </div>
+  {% if author %}
+  <div class="report-details">
+    <p><strong>Prepared By:</strong>&nbsp;{{ author }}</p>
+  </div>
+  {% endif %}
+  {% if contact %}
+  <div class="report-details">
+    <p><strong>Contact:</strong>&nbsp;{{ contact }}</p>
+  </div>
+  {% endif %}
+  {% if report_id %}
+  <div class="report-details">
+    <p><strong>Report ID:</strong>&nbsp;{{ report_id }}</p>
+  </div>
+  {% endif %}
+  {% if confidentiality or footer_left %}
+  <div class="report-details">
+    <p>
+      {% if confidentiality %}{{ confidentiality }}{% endif %}
+      {% if confidentiality and footer_left %}&nbsp;•&nbsp;{% endif %}
+      {% if footer_left %}{{ footer_left }}{% endif %}
+    </p>
+  </div>
+  {% endif %}
 </section>

--- a/templates/report/line/cross_line.html
+++ b/templates/report/line/cross_line.html
@@ -1,7 +1,7 @@
 <section class="report-section">
   <h2>Cross-Line Synchronization</h2>
-  <div class="two-column">
-    <div>
+  <div class="kpi-grid">
+    <div class="section-card">
       <h3>Yield Variance</h3>
       <ul>
         {% for entry in crossLine.yieldVariance[:5] %}
@@ -11,7 +11,7 @@
         {% endfor %}
       </ul>
     </div>
-    <div>
+    <div class="section-card">
       <h3>False Call Variance</h3>
       <ul>
         {% for entry in crossLine.falseCallVariance[:5] %}
@@ -23,9 +23,9 @@
     </div>
   </div>
   {% if crossLine.defectSimilarity %}
-  <div class="report-grid">
+  <div class="kpi-grid">
     {% for entry in crossLine.defectSimilarity[:4] %}
-    <article>
+    <article class="section-card">
       <h3>{{ entry.assembly }}</h3>
       <ul>
         {% for pair in entry.pairs[:3] %}

--- a/templates/report/line/kpis.html
+++ b/templates/report/line/kpis.html
@@ -1,6 +1,6 @@
 <section class="report-section">
   <h2>Benchmarking KPIs</h2>
-  <table class="report-table">
+  <table class="data-table">
     <thead>
       <tr>
         <th>Line</th>

--- a/templates/report/line/metrics.html
+++ b/templates/report/line/metrics.html
@@ -1,18 +1,29 @@
 <section class="report-section">
   <h2>Line-Level Performance</h2>
-  <figure class="report-figure">
-    <img src="{{ lineYieldImg }}" alt="Yield by Line" />
-    <figcaption>Yield performance across AOI lines.</figcaption>
-  </figure>
-  <figure class="report-figure">
-    <img src="{{ lineFalseCallImg }}" alt="False Calls by Line" />
-    <figcaption>False-call rate per board.</figcaption>
-  </figure>
-  <figure class="report-figure">
-    <img src="{{ linePpmImg }}" alt="PPM vs DPM" />
-    <figcaption>Comparison of false-call PPM and confirmed-defect DPM.</figcaption>
-  </figure>
-  <table class="report-table">
+  <div class="chart-grid">
+    <div class="chart-block">
+      <h3>Yield by Line</h3>
+      <img src="{{ lineYieldImg }}" alt="Yield by Line" />
+      <div class="chart-summary">
+        <p>Yield performance across AOI lines.</p>
+      </div>
+    </div>
+    <div class="chart-block">
+      <h3>False Calls by Line</h3>
+      <img src="{{ lineFalseCallImg }}" alt="False Calls by Line" />
+      <div class="chart-summary">
+        <p>False-call rate per board.</p>
+      </div>
+    </div>
+    <div class="chart-block">
+      <h3>PPM vs DPM</h3>
+      <img src="{{ linePpmImg }}" alt="PPM vs DPM" />
+      <div class="chart-summary">
+        <p>Comparison of false-call PPM and confirmed-defect DPM.</p>
+      </div>
+    </div>
+  </div>
+  <table class="data-table">
     <thead>
       <tr>
         <th>Line</th>

--- a/templates/report/line/summary.html
+++ b/templates/report/line/summary.html
@@ -1,7 +1,7 @@
 <section class="report-section">
   <h2>Executive Summary</h2>
-  <div class="summary-grid">
-    <article>
+  <div class="kpi-grid">
+    <article class="section-card">
       <h3>Top Lines</h3>
       <ul>
         {% if benchmarking.bestYield %}
@@ -16,7 +16,7 @@
         {% endif %}
       </ul>
     </article>
-    <article>
+    <article class="section-card">
       <h3>Company Averages</h3>
       <ul>
         <li>Window Yield: {{ (companyAverages.windowYield if companyAverages.windowYield is not none else companyAverages.yield)|round(2) }}%</li>
@@ -26,7 +26,7 @@
         <li>Defect DPM: {{ (companyAverages.defectDpm if companyAverages.defectDpm is not none else 0)|round(2) }}</li>
       </ul>
     </article>
-    <article>
+    <article class="section-card">
       <h3>Key Insights</h3>
       <ul>
         {% set drift = (trendInsights.lineDrift or [])[:3] %}

--- a/templates/report/line/trends.html
+++ b/templates/report/line/trends.html
@@ -1,11 +1,14 @@
 <section class="report-section">
   <h2>Trend Insights</h2>
-  <figure class="report-figure">
+  <div class="chart-block">
+    <h3>Yield Trend by Line</h3>
     <img src="{{ lineTrendImg }}" alt="Yield Trend by Line" />
-    <figcaption>Yield performance by line across the selected period.</figcaption>
-  </figure>
-  <div class="two-column">
-    <div>
+    <div class="chart-summary">
+      <p>Yield performance by line across the selected period.</p>
+    </div>
+  </div>
+  <div class="kpi-grid">
+    <div class="section-card">
       <h3>Line Drift</h3>
       <ul>
         {% for item in trendInsights.lineDrift[:6] %}
@@ -15,7 +18,7 @@
         {% endfor %}
       </ul>
     </div>
-    <div>
+    <div class="section-card">
       <h3>Assembly Learning Curves</h3>
       <ul>
         {% for item in trendInsights.assemblyLearning[:6] %}


### PR DESCRIPTION
## Summary
- update the line report cover to use the shared cover-page markup and detail formatting
- replace legacy wrappers in line report sections with shared section-card, chart-block, and data-table primitives
- align multi-column layouts with the shared KPI and chart grid utilities for consistency with other reports

## Testing
- pytest tests/test_line_report.py::test_line_report_export_html_includes_charts

------
https://chatgpt.com/codex/tasks/task_e_68da81989e84832595a679c56be5a9e4