### PR TITLE
Add explicit raw and true part yield metrics to line report

### DIFF
--- a/templates/report/line/assemblies.html
+++ b/templates/report/line/assemblies.html
@@ -8,6 +8,8 @@
         <tr>
           <th>Line</th>
           <th>Window Yield %</th>
+          <th>True Part Yield %</th>
+          <th>Raw Part Yield %</th>
           <th>False Calls / Board</th>
           <th>False Call PPM</th>
           <th>False Call DPM</th>
@@ -18,7 +20,27 @@
         {% for line, metrics in assembly.lines.items() %}
         <tr>
           <td>{{ line }}</td>
-          <td>{{ (metrics.windowYield if metrics.windowYield is not none else metrics.yield)|default(0)|round(2) }}</td>
+          <td>
+            {% if metrics.windowYield is not none %}
+              {{ metrics.windowYield|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
+            {% if metrics.truePartYield is not none %}
+              {{ metrics.truePartYield|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
+            {% if metrics.rawPartYield is not none %}
+              {{ metrics.rawPartYield|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
           <td>{{ metrics.falseCallsPerBoard|default(0)|round(2) }}</td>
           <td>
             {% if metrics.falseCallPpm is not none %}

--- a/templates/report/line/metrics.html
+++ b/templates/report/line/metrics.html
@@ -28,7 +28,8 @@
       <tr>
         <th>Line</th>
         <th>Window Yield %</th>
-        <th>Part Yield %</th>
+        <th>True Part Yield %</th>
+        <th>Raw Part Yield %</th>
         <th>Confirmed Defects</th>
         <th>False Calls / Board</th>
         <th>False Call PPM</th>
@@ -43,10 +44,23 @@
       {% for metric in lineMetrics %}
       <tr>
         <td>{{ metric.line }}</td>
-        <td>{{ (metric.windowYield if metric.windowYield is not none else metric.yield)|round(2) }}</td>
         <td>
-          {% if metric.partYield is not none %}
-            {{ metric.partYield|round(2) }}
+          {% if metric.windowYield is not none %}
+            {{ metric.windowYield|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
+        <td>
+          {% if metric.truePartYield is not none %}
+            {{ metric.truePartYield|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
+        <td>
+          {% if metric.rawPartYield is not none %}
+            {{ metric.rawPartYield|round(2) }}
           {% else %}
             --
           {% endif %}

--- a/templates/report/line/summary.html
+++ b/templates/report/line/summary.html
@@ -5,8 +5,21 @@
       <h3>Top Lines</h3>
       <ul>
         {% if benchmarking.bestYield %}
-        {% set best_yield = benchmarking.bestYield.windowYield if benchmarking.bestYield.windowYield is not none else benchmarking.bestYield.partYield if benchmarking.bestYield.partYield is not none else benchmarking.bestYield.yield %}
-        <li><strong>Best Window Yield:</strong> {{ benchmarking.bestYield.line }} ({{ best_yield|round(2) }}%)</li>
+        {% set best = benchmarking.bestYield %}
+        {% if best.windowYield is not none %}
+        {% set best_label = 'Window Yield' %}
+        {% set best_value = best.windowYield %}
+        {% elif best.truePartYield is not none %}
+        {% set best_label = 'True Part Yield' %}
+        {% set best_value = best.truePartYield %}
+        {% elif best.rawPartYield is not none %}
+        {% set best_label = 'Raw Part Yield' %}
+        {% set best_value = best.rawPartYield %}
+        {% else %}
+        {% set best_label = 'Yield' %}
+        {% set best_value = 0 %}
+        {% endif %}
+        <li><strong>Best {{ best_label }}:</strong> {{ best.line }} ({{ best_value|round(2) }}%)</li>
         {% endif %}
         {% if benchmarking.lowestFalseCalls %}
         <li><strong>Lowest False Calls:</strong> {{ benchmarking.lowestFalseCalls.line }} ({{ benchmarking.lowestFalseCalls.falseCallsPerBoard|round(2) }})</li>
@@ -19,7 +32,9 @@
     <article class="section-card">
       <h3>Company Averages</h3>
       <ul>
-        <li>Window Yield: {{ (companyAverages.windowYield if companyAverages.windowYield is not none else companyAverages.yield)|round(2) }}%</li>
+        <li>Window Yield: {{ (companyAverages.windowYield if companyAverages.windowYield is not none else 0)|round(2) }}%</li>
+        <li>True Part Yield: {{ (companyAverages.truePartYield if companyAverages.truePartYield is not none else 0)|round(2) }}%</li>
+        <li>Raw Part Yield: {{ (companyAverages.rawPartYield if companyAverages.rawPartYield is not none else 0)|round(2) }}%</li>
         <li>False Calls / Board: {{ companyAverages.falseCallsPerBoard|round(2) }}</li>
         <li>False Call PPM: {{ (companyAverages.falseCallPpm if companyAverages.falseCallPpm is not none else 0)|round(2) }}</li>
         <li>False Call DPM: {{ (companyAverages.falseCallDpm if companyAverages.falseCallDpm is not none else 0)|round(2) }}</li>


### PR DESCRIPTION
## Summary
- compute raw and true part yield metrics alongside window yield for line-level and trend payloads
- expose the new yield series in company averages, report templates, and Matplotlib charts
- update line report tests to expect the expanded payload and verify chart generation receives the new keys

## Testing
- pytest tests/test_line_report.py

------
https://chatgpt.com/codex/tasks/task_e_68da85adb3388325879069a08fd27f1f