### PR TITLE
Add per-board defect metrics to line report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3610,6 +3610,8 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
         )
 
         fc_per_board = _safe_ratio(fc_parts, boards)
+        windows_per_board = _safe_ratio(windows, boards) if boards else None
+        defects_per_board = _safe_ratio(ng_windows, boards) if boards else None
         false_call_ppm = (
             _safe_ratio(fc_parts, parts) * 1_000_000
             if parts
@@ -3637,6 +3639,8 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
             'totalParts': parts,
             'totalBoards': boards,
             'totalWindows': windows,
+            'ngParts': ng_parts,
+            'ngWindows': ng_windows,
             'falseCalls': fc_parts,
             'confirmedDefects': confirmed_parts,
             'windowConfirmedDefects': window_confirmed,
@@ -3644,6 +3648,8 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
             'rawPartYield': raw_part_yield,
             'truePartYield': true_part_yield,
             'falseCallsPerBoard': fc_per_board,
+            'windowsPerBoard': windows_per_board,
+            'defectsPerBoard': defects_per_board,
             'falseCallPpm': false_call_ppm,
             'falseCallDpm': false_call_dpm,
             'defectDpm': defect_dpm,
@@ -3782,6 +3788,8 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
                     else None
                 )
             )
+            windows_per_board = _safe_ratio(windows, boards) if boards else None
+            defects_per_board = _safe_ratio(ng_windows, boards) if boards else None
             entries.append(
                 {
                     'date': dt.isoformat(),
@@ -3794,6 +3802,14 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
                     'defectDpm': defect_dpm,
                     'confirmedDefects': confirmed_parts,
                     'windowConfirmedDefects': window_confirmed,
+                    'boards': boards,
+                    'parts': parts,
+                    'ngParts': ng_parts,
+                    'falseCalls': fc_parts,
+                    'windows': windows,
+                    'ngWindows': ng_windows,
+                    'windowsPerBoard': windows_per_board,
+                    'defectsPerBoard': defects_per_board,
                 }
             )
         return {'line': line, 'entries': entries}
@@ -3916,6 +3932,14 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
                 'defectMix': defect_mix,
                 'confirmedDefects': confirmed_parts,
                 'windowConfirmedDefects': window_confirmed,
+                'parts': parts,
+                'boards': boards,
+                'windows': windows,
+                'ngParts': ng_parts,
+                'ngWindows': ng_windows,
+                'falseCalls': fc_parts,
+                'windowsPerBoard': _safe_ratio(windows, boards) if boards else None,
+                'defectsPerBoard': _safe_ratio(ng_windows, boards) if boards else None,
             }
         if len(lines_info) >= 2:
             assembly_comparisons.append({'assembly': assembly, 'lines': lines_info})
@@ -4078,6 +4102,18 @@ def build_line_report_payload(start: date | None = None, end: date | None = None
             'falseCallPpm': company_false_call_ppm,
             'falseCallDpm': company_false_call_dpm,
             'defectDpm': company_dpm,
+            'ngParts': overall['ng_parts'],
+            'ngWindows': overall['ng_windows'],
+            'windowsPerBoard': (
+                _safe_ratio(overall['total_windows'], overall['total_boards'])
+                if overall['total_boards']
+                else None
+            ),
+            'defectsPerBoard': (
+                _safe_ratio(overall['ng_windows'], overall['total_boards'])
+                if overall['total_boards']
+                else None
+            ),
         },
     }
 

--- a/templates/report/line/assemblies.html
+++ b/templates/report/line/assemblies.html
@@ -11,9 +11,13 @@
           <th>True Part Yield %</th>
           <th>Raw Part Yield %</th>
           <th>False Calls / Board</th>
+          <th>Windows / Board</th>
+          <th>Defects / Board</th>
           <th>False Call PPM</th>
           <th>False Call DPM</th>
           <th>Defect DPM</th>
+          <th>NG Parts</th>
+          <th>NG Windows</th>
         </tr>
       </thead>
       <tbody>
@@ -43,6 +47,20 @@
           </td>
           <td>{{ metrics.falseCallsPerBoard|default(0)|round(2) }}</td>
           <td>
+            {% if metrics.windowsPerBoard is not none %}
+              {{ metrics.windowsPerBoard|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
+            {% if metrics.defectsPerBoard is not none %}
+              {{ metrics.defectsPerBoard|round(2) }}
+            {% else %}
+              --
+            {% endif %}
+          </td>
+          <td>
             {% if metrics.falseCallPpm is not none %}
               {{ metrics.falseCallPpm|round(2) }}
             {% else %}
@@ -63,6 +81,8 @@
               --
             {% endif %}
           </td>
+          <td>{{ metrics.ngParts|round(0) }}</td>
+          <td>{{ metrics.ngWindows|round(0) }}</td>
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/report/line/metrics.html
+++ b/templates/report/line/metrics.html
@@ -31,7 +31,11 @@
         <th>True Part Yield %</th>
         <th>Raw Part Yield %</th>
         <th>Confirmed Defects</th>
+        <th>NG Parts</th>
+        <th>NG Windows</th>
         <th>False Calls / Board</th>
+        <th>Windows / Board</th>
+        <th>Defects / Board</th>
         <th>False Call PPM</th>
         <th>False Call DPM</th>
         <th>Defect DPM</th>
@@ -66,7 +70,23 @@
           {% endif %}
         </td>
         <td>{{ metric.confirmedDefects|round(0) }}</td>
+        <td>{{ metric.ngParts|round(0) }}</td>
+        <td>{{ metric.ngWindows|round(0) }}</td>
         <td>{{ metric.falseCallsPerBoard|round(2) }}</td>
+        <td>
+          {% if metric.windowsPerBoard is not none %}
+            {{ metric.windowsPerBoard|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
+        <td>
+          {% if metric.defectsPerBoard is not none %}
+            {{ metric.defectsPerBoard|round(2) }}
+          {% else %}
+            --
+          {% endif %}
+        </td>
         <td>
           {% if metric.falseCallPpm is not none %}
             {{ metric.falseCallPpm|round(2) }}

--- a/templates/report/line/summary.html
+++ b/templates/report/line/summary.html
@@ -39,6 +39,10 @@
         <li>False Call PPM: {{ (companyAverages.falseCallPpm if companyAverages.falseCallPpm is not none else 0)|round(2) }}</li>
         <li>False Call DPM: {{ (companyAverages.falseCallDpm if companyAverages.falseCallDpm is not none else 0)|round(2) }}</li>
         <li>Defect DPM: {{ (companyAverages.defectDpm if companyAverages.defectDpm is not none else 0)|round(2) }}</li>
+        <li>NG Parts: {{ companyAverages.ngParts|round(0) }}</li>
+        <li>NG Windows: {{ companyAverages.ngWindows|round(0) }}</li>
+        <li>Windows / Board: {{ (companyAverages.windowsPerBoard if companyAverages.windowsPerBoard is not none else 0)|round(2) }}</li>
+        <li>Defects / Board: {{ (companyAverages.defectsPerBoard if companyAverages.defectsPerBoard is not none else 0)|round(2) }}</li>
       </ul>
     </article>
     <article class="section-card">


### PR DESCRIPTION
## Summary
- extend the line metrics payload with NG counts and per-board window/defect ratios
- propagate the additional metrics through line trends, assembly comparisons, and company averages
- update report templates and tests to surface and validate the expanded data

## Testing
- pytest tests/test_line_report.py

------
https://chatgpt.com/codex/tasks/task_e_68da8a63c7e083259bd4b407de4495dd