### PR TITLE
Support ranged MOAT queries for line report

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -3447,10 +3447,10 @@ def _safe_ratio(num: float, den: float) -> float:
 
 
 def build_line_report_payload(start: date | None = None, end: date | None = None) -> dict:
-    ppm_rows, error = fetch_moat()
+    ppm_rows, error = fetch_moat(start_date=start, end_date=end)
     if error:
         abort(500, description=error)
-    dpm_rows, error = fetch_moat_dpm()
+    dpm_rows, error = fetch_moat_dpm(start_date=start, end_date=end)
     if error:
         abort(500, description=error)
 


### PR DESCRIPTION
## Summary
- add helpers to normalize dates and paginate Supabase MOAT queries with optional start and end filters
- pass requested date ranges to the line report data fetchers to avoid truncated exports
- extend line report tests to cover ranged exports across multiple months

## Testing
- `pytest tests/test_line_report.py`


------
https://chatgpt.com/codex/tasks/task_e_68da8d46923883259579082fd752cc82