### PR TITLE
Track additional Supabase tables in admin overview

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -887,6 +887,9 @@ TRACKED_SUPABASE_TABLES = {
     "bug_reports": "In-app feedback collected to triage feature issues and bugs.",
     "defects": "Defect catalog entries referenced when analysing bug submissions.",
     "app_versions": "Release ledger aligning desktop and web deployments.",
+    "moat_dpm": "MOAT defect-per-million submissions that drive the DPM dashboards.",
+    "app_feature_states": "Feature flag states used to lock or reopen capabilities from bug triage.",
+    "part_result_table": "Part-level AOI results providing deeper context for line quality checks.",
 }
 
 

--- a/tests/test_admin_user_management.py
+++ b/tests/test_admin_user_management.py
@@ -166,8 +166,14 @@ def test_admin_overview_lists_tracked_tables(admin_app):
     context = templates[0][1]
     overview = context["overview"]
     table_names = [table_info["name"] for table_info in overview["tracked_tables"]]
-    assert "bug_reports" in table_names
-    assert "defects" in table_names
+    for expected in (
+        "bug_reports",
+        "defects",
+        "moat_dpm",
+        "app_feature_states",
+        "part_result_table",
+    ):
+        assert expected in table_names
 
 
 def test_admin_can_create_supabase_user(admin_app):


### PR DESCRIPTION
## Summary
- add admin console descriptions for the moat_dpm, app_feature_states, and part_result_table Supabase tables
- update the admin overview test to expect the expanded tracked table list

## Testing
- pytest tests/test_admin_user_management.py

------
https://chatgpt.com/codex/tasks/task_e_68dac89a36c88325aa218f896d07273e