### PR TITLE
Prevent non-finite values in line report metrics

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -265,10 +265,30 @@ def _coerce_number(value, *, default=0.0):
     if not text:
         return default
 
+    lowered = text.lower()
+    invalid_tokens = {
+        'nan',
+        '+nan',
+        '-nan',
+        'inf',
+        '+inf',
+        '-inf',
+        'infinity',
+        '+infinity',
+        '-infinity',
+    }
+    if lowered in invalid_tokens:
+        return default
+
     try:
-        return float(text)
+        number = float(text)
     except (TypeError, ValueError):
         return default
+
+    if math.isnan(number) or math.isinf(number):
+        return default
+
+    return number
 
 
 def _aoi_passed(row):


### PR DESCRIPTION
## Summary
- sanitize numeric coercion to reject string representations of NaN and Infinity
- add a regression test ensuring the line report API returns finite metrics when fed non-finite tokens

## Testing
- pytest tests/test_line_report.py


------
https://chatgpt.com/codex/tasks/task_e_68daded337208325824e06dc5b1fe637