### PR TITLE
Add part-level report analytics and interfaces

### DIFF
--- a/static/css/report.css
+++ b/static/css/report.css
@@ -339,6 +339,38 @@ pre,
     gap: 18px;
 }
 
+.metric-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 14px;
+    margin-top: 12px;
+}
+
+.metric {
+    background: var(--surface-elevated);
+    border: 1px solid var(--border-light);
+    padding: 12px;
+}
+
+.metric-label {
+    font-size: 11px;
+    color: var(--ink-soft);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.metric-value {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--accent-strong);
+}
+
+.two-column {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 18px;
+}
+
 .kpi-grid .section-card {
     margin: 0;
     padding: 16px;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2187,6 +2187,76 @@ body.employee-layout .content {
   font-weight: 600;
 }
 
+.metric-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-top: 12px;
+}
+
+.metric {
+  background: #f5f7fa;
+  border-radius: 8px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.metric-label {
+  font-size: 0.85rem;
+  color: #4b5563;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #0d9ba8;
+}
+
+.chart-grid {
+  display: grid;
+  gap: 20px;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  margin-top: 16px;
+}
+
+.chart-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  min-height: 320px;
+}
+
+.chart-card canvas {
+  width: 100%;
+  flex: 1;
+}
+
+.chart-card .data-table {
+  margin-top: auto;
+}
+
+.json-preview {
+  background: #0f172a;
+  color: #e2e8f0;
+  padding: 16px;
+  border-radius: 8px;
+  overflow: auto;
+  max-height: 320px;
+  font-family: 'Source Code Pro', monospace;
+}
+
+.preview-message {
+  font-style: italic;
+}
+
 @media (max-width: 600px) {
   .bug-chat-container {
     right: 16px;

--- a/static/js/part_report.js
+++ b/static/js/part_report.js
@@ -1,0 +1,192 @@
+import { setupReportRunner } from './report_runner.js';
+import {
+  configureReportFormatSelector,
+  getPreferredReportFormat,
+} from './utils.js';
+
+let defectChart = null;
+let falseCallChart = null;
+
+function formatPercent(value) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function resetCharts() {
+  defectChart?.destroy();
+  falseCallChart?.destroy();
+  defectChart = null;
+  falseCallChart = null;
+}
+
+function updateMetric(id, value, formatter = (v) => v) {
+  const el = document.getElementById(id);
+  if (el) {
+    el.textContent = formatter(value);
+  }
+}
+
+function renderDistributionTable(tableId, rows = []) {
+  const table = document.getElementById(tableId);
+  if (!table) return;
+  const tbody = table.querySelector('tbody');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  rows.slice(0, 10).forEach((row) => {
+    const tr = document.createElement('tr');
+    const labelCell = document.createElement('td');
+    labelCell.textContent = row.label || 'Unknown';
+    const countCell = document.createElement('td');
+    countCell.textContent = row.count?.toLocaleString() || '0';
+    const shareCell = document.createElement('td');
+    shareCell.textContent = formatPercent(row.share || 0);
+    tr.append(labelCell, countCell, shareCell);
+    tbody.appendChild(tr);
+  });
+}
+
+function renderBarChart(canvasId, rows = [], label) {
+  const canvas = document.getElementById(canvasId);
+  if (!canvas || !window.Chart) return null;
+  const labels = rows.slice(0, 10).map((row) => row.label || 'Unknown');
+  const values = rows.slice(0, 10).map((row) => row.count || 0);
+  if (!labels.length) {
+    return null;
+  }
+  const chart = new Chart(canvas.getContext('2d'), {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [
+        {
+          label,
+          data: values,
+          backgroundColor: '#0d9ba8',
+        },
+      ],
+    },
+    options: {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        x: {
+          ticks: {
+            autoSkip: true,
+            maxRotation: 0,
+          },
+        },
+        y: {
+          beginAtZero: true,
+          ticks: {
+            precision: 0,
+          },
+        },
+      },
+      plugins: {
+        legend: {
+          display: false,
+        },
+      },
+    },
+  });
+  return chart;
+}
+
+function populatePreview(data) {
+  const highlight = document.getElementById('part-report-highlight');
+  if (highlight) {
+    const insights = data?.insights?.highlights || [];
+    highlight.textContent = insights[0] || '';
+  }
+
+  updateMetric('metric-total-records', data?.meta?.totalRecords || 0, (v) =>
+    (v || 0).toLocaleString(),
+  );
+  updateMetric('metric-false-calls', data?.meta?.totalFalseCalls || 0, (v) =>
+    (v || 0).toLocaleString(),
+  );
+  updateMetric(
+    'metric-defects-per-board',
+    data?.yieldReliability?.defectsPerBoard || 0,
+    (v) => v.toFixed(2),
+  );
+  updateMetric('metric-unique-parts', data?.meta?.uniquePartNumbers || 0, (v) =>
+    (v || 0).toLocaleString(),
+  );
+
+  const defectRows = data?.defectDistributions?.byDefectCode || [];
+  renderDistributionTable('defectCodeTable', defectRows);
+  const falseCallRows = data?.falseCallPatterns?.byPartNumber || [];
+  renderDistributionTable('falseCallTable', falseCallRows);
+
+  resetCharts();
+  defectChart = renderBarChart('defectCodeChart', defectRows, 'Defects');
+  falseCallChart = renderBarChart('falseCallChart', falseCallRows, 'False Calls');
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const previewDetails = document.getElementById('preview');
+  const previewData = document.getElementById('preview-data');
+  configureReportFormatSelector({ noteId: 'file-format-note' });
+
+  function showPreviewMessage(message) {
+    if (!previewData) return;
+    previewData.textContent = message;
+    previewData.classList.add('preview-message');
+    if (previewDetails) previewDetails.open = true;
+  }
+
+  setupReportRunner({
+    collectParams: () => {
+      const start = document.getElementById('start-date')?.value || '';
+      const end = document.getElementById('end-date')?.value || '';
+      const format =
+        document.getElementById('file-format')?.value || getPreferredReportFormat();
+      return { start, end, format };
+    },
+    validateParams: ({ start, end }) => {
+      if (!start || !end) {
+        return 'Please select a date range.';
+      }
+      return true;
+    },
+    beforePreview: () => {
+      resetCharts();
+      if (previewData) {
+        previewData.textContent = '';
+        previewData.classList.remove('preview-message');
+      }
+      if (previewDetails) previewDetails.open = false;
+    },
+    buildPreviewUrl: ({ start, end }) => {
+      const params = new URLSearchParams({ start_date: start, end_date: end });
+      return `/api/reports/part?${params.toString()}`;
+    },
+    onPreviewSuccess: (data) => {
+      if (previewData) {
+        previewData.textContent = JSON.stringify(data, null, 2);
+        previewData.classList.remove('preview-message');
+      }
+      if (previewDetails) previewDetails.open = true;
+      populatePreview(data);
+    },
+    onPreviewError: (err) => {
+      const reason = err?.message ? `\nDetails: ${err.message}` : '';
+      showPreviewMessage(
+        `We couldn't generate a preview for the selected dates, but you can still download the report.${reason}`,
+      );
+    },
+    buildDownloadUrl: ({ start, end, format }) => {
+      const selected = (format || '').toLowerCase();
+      const preferred = getPreferredReportFormat();
+      const fmt = ['pdf', 'html'].includes(selected) ? selected : preferred;
+      const params = new URLSearchParams({ format: fmt });
+      if (start) params.append('start_date', start);
+      if (end) params.append('end_date', end);
+      return `/reports/part/export?${params.toString()}`;
+    },
+    downloadOptions: {
+      spinnerId: 'download-spinner',
+    },
+    showDownloadControlsOnValidation: true,
+  });
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,7 @@
               {{ feature_nav_link('AOI Integrated Report', url_for('main.integrated_report'), 'reports_integrated') }}
               {{ feature_nav_link('Operator Report', url_for('main.operator_report'), 'reports_operator') }}
               {{ feature_nav_link('Line Report', url_for('main.line_report'), 'reports_line') }}
+              {{ feature_nav_link('Part Report', url_for('main.part_report'), 'reports_part') }}
               {{ feature_nav_link('AOI Daily Report', url_for('main.aoi_daily_report_page'), 'reports_aoi_daily') }}
             </div>
           </li>

--- a/templates/part_report.html
+++ b/templates/part_report.html
@@ -1,0 +1,103 @@
+{% extends 'base.html' %}
+
+{% block content %}
+<h2>Part Report</h2>
+
+<div class="section-card">
+  <div class="field-row">
+    <div class="field">
+      <label for="start-date">Start Date</label>
+      <input type="date" id="start-date" />
+    </div>
+    <div class="field">
+      <label for="end-date">End Date</label>
+      <input type="date" id="end-date" />
+    </div>
+    <button type="button" id="run-report">Run</button>
+  </div>
+</div>
+
+<section id="summary-section" class="section-card">
+  <h3>Snapshot</h3>
+  <div class="metric-grid" id="part-summary-metrics">
+    <div class="metric">
+      <span class="metric-label">Total Findings</span>
+      <span class="metric-value" id="metric-total-records">0</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">False Calls</span>
+      <span class="metric-value" id="metric-false-calls">0</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">Defects / Board</span>
+      <span class="metric-value" id="metric-defects-per-board">0</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">Unique Parts</span>
+      <span class="metric-value" id="metric-unique-parts">0</span>
+    </div>
+  </div>
+  <p id="part-report-highlight"></p>
+</section>
+
+<details id="defect-preview" class="section-card">
+  <summary>Defect Distributions</summary>
+  <div class="chart-grid">
+    <div class="chart-card">
+      <h4>By Defect Code</h4>
+      <canvas id="defectCodeChart" height="220"></canvas>
+      <table id="defectCodeTable" class="data-table">
+        <thead>
+          <tr>
+            <th>Defect</th>
+            <th>Count</th>
+            <th>Share</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+    <div class="chart-card">
+      <h4>False Call Hotspots</h4>
+      <canvas id="falseCallChart" height="220"></canvas>
+      <table id="falseCallTable" class="data-table">
+        <thead>
+          <tr>
+            <th>Grouping</th>
+            <th>False Calls</th>
+            <th>Share</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
+  </div>
+</details>
+
+<details id="preview" class="section-card">
+  <summary>Payload Preview</summary>
+  <div class="preview-content">
+    <pre id="preview-data" class="json-preview"></pre>
+  </div>
+</details>
+
+<div id="download-controls" class="field-row" style="display:none">
+  <div class="field">
+    <label for="file-format">Format</label>
+    <select id="file-format">
+      <option value="pdf">pdf</option>
+      <option value="html">html</option>
+    </select>
+    <p class="field-note" id="file-format-note" hidden>
+      PDF downloads are available on Linux hosts that have the required PDF dependencies installed.
+    </p>
+  </div>
+  <button id="download-report">Download</button>
+  <span class="spinner" id="download-spinner" hidden></span>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script type="module" src="{{ url_for('static', filename='js/part_report.js') }}"></script>
+{% endblock %}

--- a/templates/report/part/advanced_analysis.html
+++ b/templates/report/part/advanced_analysis.html
@@ -1,0 +1,54 @@
+<section class="section-card">
+  <h2>Advanced Analysis</h2>
+  <div class="two-column">
+    <div>
+      <h3>Spatial Metrics</h3>
+      <ul>
+        <li>Offset μX: {{ spatialMetrics.offsets.meanX|round(3) }}</li>
+        <li>Offset μY: {{ spatialMetrics.offsets.meanY|round(3) }}</li>
+        <li>Rotation σ: {{ spatialMetrics.rotation.stdev|round(3) }}</li>
+        <li>Height σ: {{ spatialMetrics.height.stdev|round(3) }}</li>
+      </ul>
+      <h3>False Call Hotspots</h3>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Family</th>
+            <th>False Calls</th>
+            <th>Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in (falseCallPatterns.byFamily or [])[:6] %}
+          <tr>
+            <td>{{ row.label }}</td>
+            <td>{{ row.count }}</td>
+            <td>{{ (row.share * 100)|round(1) }}%</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+    <div>
+      <h3>Operator &amp; Process Linkages</h3>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Operator</th>
+            <th>Findings</th>
+            <th>FC Rate</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in (operatorLinkages.byOperator or [])[:6] %}
+          <tr>
+            <td>{{ row.operator }}</td>
+            <td>{{ row.total }}</td>
+            <td>{{ (row.falseCallRate * 100)|round(1) }}%</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>

--- a/templates/report/part/business_value.html
+++ b/templates/report/part/business_value.html
@@ -1,0 +1,34 @@
+<section class="section-card">
+  <h2>Business Value</h2>
+  <p>
+    Recommended focus areas informed by operator confirmations, spatial consistency,
+    and false-call density.
+  </p>
+  <ul>
+    {% for item in insights.businessValue or [] %}
+    <li>{{ item }}</li>
+    {% endfor %}
+    {% if (insights.businessValue or [])|length == 0 %}
+    <li>Stabilise inspection program recipes and maintain current review cadence.</li>
+    {% endif %}
+  </ul>
+  <h3>Critical Part Pareto</h3>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Part</th>
+        <th>Count</th>
+        <th>Share</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in (yieldReliability.criticalPartsPareto or [])[:10] %}
+      <tr>
+        <td>{{ row.label }}</td>
+        <td>{{ row.count }}</td>
+        <td>{{ (row.share * 100)|round(1) }}%</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</section>

--- a/templates/report/part/calculations.html
+++ b/templates/report/part/calculations.html
@@ -1,0 +1,29 @@
+<section class="section-card">
+  <h2>Calculations &amp; Trendlines</h2>
+  <p>
+    The chart below highlights longitudinal performance with false-call tracking.
+  </p>
+  <table class="data-table">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Findings</th>
+        <th>False Calls</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in (timeSeries.daily or [])[:12] %}
+      <tr>
+        <td>{{ row.date }}</td>
+        <td>{{ row.defects }}</td>
+        <td>{{ row.falseCalls }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  <p>
+    Defects per board: {{ yieldReliability.defectsPerBoard|round(3) }} • False calls per board:
+    {{ yieldReliability.falseCallsPerBoard|round(3) }} • Density μ:
+    {{ yieldReliability.densityMean|round(3) }}
+  </p>
+</section>

--- a/templates/report/part/index.html
+++ b/templates/report/part/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>{{ title or 'Part Report' }}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/report.css') }}" />
+  <style>{{ report_css|safe }}</style>
+</head>
+<body>
+  <main class="report-page">
+    {% if show_cover %}
+      {% include 'report/line/cover.html' %}
+    {% endif %}
+    {% if show_overview %}
+      {% include 'report/part/overview.html' %}
+    {% endif %}
+    {% if show_insights %}
+      {% include 'report/part/insights_metrics.html' %}
+    {% endif %}
+    {% if show_advanced %}
+      {% include 'report/part/advanced_analysis.html' %}
+    {% endif %}
+    {% if show_calculations %}
+      {% include 'report/part/calculations.html' %}
+    {% endif %}
+    {% if show_business %}
+      {% include 'report/part/business_value.html' %}
+    {% endif %}
+  </main>
+</body>
+</html>

--- a/templates/report/part/insights_metrics.html
+++ b/templates/report/part/insights_metrics.html
@@ -1,0 +1,43 @@
+<section class="section-card">
+  <h2>Insights &amp; Metrics</h2>
+  <div class="two-column">
+    <div>
+      <h3>Highlights</h3>
+      <ul>
+        {% for item in insights.highlights or [] %}
+        <li>{{ item }}</li>
+        {% endfor %}
+      </ul>
+      <h3>Opportunities</h3>
+      <ul>
+        {% for item in insights.opportunities or [] %}
+        <li>{{ item }}</li>
+        {% endfor %}
+        {% if (insights.opportunities or [])|length == 0 %}
+        <li>No urgent opportunities identified.</li>
+        {% endif %}
+      </ul>
+    </div>
+    <div>
+      <h3>Defect Distribution</h3>
+      <table class="data-table">
+        <thead>
+          <tr>
+            <th>Group</th>
+            <th>Count</th>
+            <th>Share</th>
+          </tr>
+        </thead>
+        <tbody>
+          {% for row in (defectDistributions.byDefectCode or [])[:6] %}
+          <tr>
+            <td>{{ row.label }}</td>
+            <td>{{ row.count }}</td>
+            <td>{{ (row.share * 100)|round(1) }}%</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+</section>

--- a/templates/report/part/overview.html
+++ b/templates/report/part/overview.html
@@ -1,0 +1,28 @@
+<section class="section-card">
+  <h2>Part Performance Overview</h2>
+  <p>
+    This section summarises inspection activity for the selected range
+    {{ meta.dateRange[0] or '—' }} to {{ meta.dateRange[1] or '—' }}. The dataset
+    contains {{ meta.totalRecords|default(0) }} findings across
+    {{ meta.uniquePartNumbers|default(0) }} unique part numbers spanning
+    {{ meta.uniqueAssemblies|default(0) }} assemblies.
+  </p>
+  <div class="metric-grid">
+    <div class="metric">
+      <span class="metric-label">Total Findings</span>
+      <span class="metric-value">{{ meta.totalRecords|default(0) }}</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">False Calls</span>
+      <span class="metric-value">{{ meta.totalFalseCalls|default(0) }}</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">Boards Impacted</span>
+      <span class="metric-value">{{ meta.totalBoards|default(0) }}</span>
+    </div>
+    <div class="metric">
+      <span class="metric-label">Active Operators</span>
+      <span class="metric-value">{{ meta.uniqueOperators|default(0) }}</span>
+    </div>
+  </div>
+</section>

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -1,7 +1,10 @@
 import os
+import sys
 
 os.environ.setdefault("USER_PASSWORD", "pw")
 os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
 import json
 from contextlib import contextmanager
@@ -380,6 +383,18 @@ def test_employee_portal_link_hidden_for_non_admin(app_instance):
     assert response.status_code == 200
     html = response.get_data(as_text=True)
     assert 'data-admin-employee-toggle' not in html
+
+
+def test_reports_nav_contains_part_report(app_instance):
+    client = app_instance.test_client()
+
+    _login(client)
+    response = client.get("/home")
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert 'data-feature-slug="reports_part"' in html
+    assert 'Part Report' in html
 
 
 def test_admin_employee_portal_preview_uses_employee_layout(app_instance):

--- a/tests/test_part_report.py
+++ b/tests/test_part_report.py
@@ -1,0 +1,253 @@
+import os
+import sys
+from datetime import date
+
+import pytest
+from werkzeug.exceptions import InternalServerError
+
+os.environ.setdefault("USER_PASSWORD", "pw")
+os.environ.setdefault("ADMIN_PASSWORD", "pw")
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import app as app_module  # noqa: E402
+from app import create_app  # noqa: E402
+from app.main import routes  # noqa: E402
+from app.main.pdf_utils import PdfGenerationError  # noqa: E402
+
+
+@pytest.fixture
+def app_instance(monkeypatch):
+    monkeypatch.setattr(app_module, "create_client", lambda url, key: object())
+    os.environ.setdefault("SECRET_KEY", "test")
+    os.environ.setdefault("SUPABASE_URL", "http://localhost")
+    os.environ.setdefault("SUPABASE_SERVICE_KEY", "service")
+    return create_app()
+
+
+def _login(client, role=None):
+    with client.session_transaction() as session:
+        session["username"] = "tester"
+        if role:
+            session["role"] = role
+
+
+def _sample_part_rows():
+    return [
+        {
+            "inspection_date": "2024-01-01",
+            "part_number": "PN-1",
+            "assembly": "ASM-A",
+            "line": "L1",
+            "program": "ProgramA",
+            "component_family": "BGA",
+            "defect_code": "BRG",
+            "defect_type": "Solder",
+            "operator": "Alice",
+            "operator_disposition": "False Call",
+            "operator_confirmation": "",
+            "offset_x": 0.12,
+            "offset_y": -0.05,
+            "offset_theta": 0.3,
+            "height": 0.15,
+            "defect_density": 1.2,
+            "false_call": True,
+            "board_serial": "B1",
+        },
+        {
+            "inspection_date": "2024-01-01",
+            "part_number": "PN-2",
+            "assembly": "ASM-A",
+            "line": "L1",
+            "program": "ProgramA",
+            "component_family": "BGA",
+            "defect_code": "MST",
+            "defect_type": "Placement",
+            "operator": "Bob",
+            "operator_disposition": "Confirmed",
+            "operator_confirmation": "confirmed",
+            "offset_x": -0.08,
+            "offset_y": 0.02,
+            "offset_theta": 0.1,
+            "height": 0.18,
+            "defect_density": 1.0,
+            "false_call": False,
+            "board_serial": "B2",
+        },
+        {
+            "inspection_date": "2024-01-02",
+            "part_number": "PN-1",
+            "assembly": "ASM-B",
+            "line": "L2",
+            "program": "ProgramB",
+            "component_family": "Connector",
+            "defect_code": "BRG",
+            "defect_type": "Solder",
+            "operator": "Alice",
+            "operator_disposition": "Confirmed",
+            "operator_confirmation": "confirmed",
+            "offset_x": 0.05,
+            "offset_y": 0.01,
+            "offset_theta": 0.2,
+            "height": 0.22,
+            "defect_density": 0.8,
+            "false_call": False,
+            "board_serial": "B3",
+        },
+    ]
+
+
+def test_build_part_report_payload_computes_metrics(app_instance, monkeypatch):
+    rows = _sample_part_rows()
+    captured = {}
+
+    def _fake_fetch(start_date=None, end_date=None, page_size=None):
+        captured["start"] = start_date
+        captured["end"] = end_date
+        captured["page_size"] = page_size
+        return rows, None
+
+    monkeypatch.setattr(routes, "fetch_part_results", _fake_fetch)
+
+    with app_instance.app_context():
+        payload = routes.build_part_report_payload(date(2024, 1, 1), date(2024, 1, 2))
+
+    assert captured == {"start": date(2024, 1, 1), "end": date(2024, 1, 2), "page_size": 1000}
+    assert payload["meta"]["totalRecords"] == 3
+    assert payload["meta"]["totalFalseCalls"] == 1
+    assert payload["defectDistributions"]["byDefectCode"][0]["label"] == "BRG"
+    assert payload["falseCallPatterns"]["byPartNumber"][0]["label"] == "PN-1"
+    assert payload["yieldReliability"]["defectsPerBoard"] == pytest.approx(1.0)
+    assert payload["spatialMetrics"]["offsets"]["meanX"] == pytest.approx((0.12 - 0.08 + 0.05) / 3)
+    alice = payload["operatorLinkages"]["byOperator"][0]
+    assert alice["operator"] == "Alice"
+    assert alice["falseCallRate"] == pytest.approx(0.5)
+    assert payload["timeSeries"]["daily"][0]["defects"] == 2.0
+    assert payload["insights"]["highlights"]
+
+
+def test_build_part_report_payload_raises_on_error(app_instance, monkeypatch):
+    monkeypatch.setattr(routes, "fetch_part_results", lambda **kwargs: (None, "boom"))
+    with app_instance.app_context():
+        with pytest.raises(InternalServerError):
+            routes.build_part_report_payload()
+
+
+def test_part_report_api_requires_login(app_instance):
+    client = app_instance.test_client()
+    resp = client.get("/api/reports/part")
+    assert resp.status_code == 302
+    assert "/login" in resp.headers.get("Location", "")
+
+
+def test_part_report_api_returns_payload(app_instance, monkeypatch):
+    client = app_instance.test_client()
+
+    def _build(start, end):
+        assert start is None
+        assert end is None
+        return {"meta": {"totalRecords": 0}}
+
+    monkeypatch.setattr(routes, "build_part_report_payload", _build)
+    with app_instance.app_context():
+        _login(client)
+        resp = client.get("/api/reports/part")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["meta"]["totalRecords"] == 0
+    assert data["start"] == ""
+    assert data["end"] == ""
+
+
+def test_part_report_page_renders(app_instance):
+    client = app_instance.test_client()
+    with app_instance.app_context():
+        _login(client)
+        resp = client.get("/reports/part")
+    assert resp.status_code == 200
+    assert b"Part Report" in resp.data
+
+
+def test_part_report_export_handles_pdf_error(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    sample_payload = {
+        "meta": {
+            "totalRecords": 0,
+            "totalFalseCalls": 0,
+            "dateRange": [None, None],
+            "uniquePartNumbers": 0,
+            "uniqueAssemblies": 0,
+            "uniquePrograms": 0,
+            "uniqueLines": 0,
+            "uniqueOperators": 0,
+            "totalBoards": 0,
+        },
+        "defectDistributions": {
+            "byDefectCode": [],
+            "byComponentFamily": [],
+            "byAssembly": [],
+            "byLine": [],
+            "byProgram": [],
+        },
+        "spatialMetrics": {
+            "offsets": {"meanX": 0, "meanY": 0, "absMeanX": 0, "absMeanY": 0, "stdevX": 0, "stdevY": 0, "samples": 0},
+            "rotation": {"mean": 0, "stdev": 0, "samples": 0},
+            "height": {"mean": 0, "stdev": 0, "min": 0, "max": 0, "samples": 0},
+        },
+        "falseCallPatterns": {
+            "total": 0,
+            "share": 0,
+            "byPartNumber": [],
+            "byDefectType": [],
+            "byProgram": [],
+            "byFamily": [],
+        },
+        "yieldReliability": {
+            "defectsPerBoard": 0,
+            "falseCallsPerBoard": 0,
+            "criticalPartsPareto": [],
+            "dailyTrend": [],
+            "familyShare": [],
+            "densityMean": 0,
+            "densityStdDev": 0,
+        },
+        "operatorLinkages": {"byOperator": [], "byProcess": []},
+        "timeSeries": {"daily": []},
+        "insights": {"highlights": [], "opportunities": [], "businessValue": []},
+    }
+
+    monkeypatch.setattr(routes, "build_part_report_payload", lambda start, end: sample_payload)
+    monkeypatch.setattr(routes, "_load_report_css", lambda: "")
+    monkeypatch.setattr(
+        routes,
+        "render_html_to_pdf",
+        lambda html, base_url=None: (_ for _ in ()).throw(PdfGenerationError("pdf error")),
+    )
+
+    with app_instance.app_context():
+        _login(client)
+        resp = client.get("/reports/part/export?format=pdf")
+    assert resp.status_code == 503
+    assert resp.get_json() == {"message": "pdf error"}
+
+
+def test_part_report_feature_lock(app_instance, monkeypatch):
+    client = app_instance.test_client()
+    original = routes._compose_feature_state
+
+    def _locked(slug):
+        if slug == "reports_part":
+            return {"slug": slug, "status": "locked", "message": "Locked"}
+        return original(slug)
+
+    monkeypatch.setattr(routes, "_compose_feature_state", _locked)
+
+    with app_instance.app_context():
+        _login(client)
+        resp = client.get("/reports/part")
+        assert resp.status_code == 302
+        assert resp.headers.get("Location", "").endswith("/home")
+
+        resp = client.get("/api/reports/part")
+        assert resp.status_code == 423
+        assert resp.get_json()["error"] == "feature_locked"


### PR DESCRIPTION
## Summary
- add a Supabase helper that normalizes part result records and expose part-report feature toggles
- build part-report analytics payloads, API/export endpoints, HTML layout, and PDF templates
- implement the report UI with charts/styling updates and cover new behaviours with unit tests

## Testing
- pytest tests/test_part_report.py
- pytest tests/test_home_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68dc14f2fdf083259428b6dd92503991