### PR TITLE
Normalize MOAT PPM/DPM access to canonical fields

### DIFF
--- a/config/dpm_saved_charts.json
+++ b/config/dpm_saved_charts.json
@@ -9,7 +9,7 @@
       "y": "window_yield_pct",
       "series": "line"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(windows) AS windows,\n  SUM(ng_windows) AS ng_windows,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(windows) AS windows,\n  SUM(ng_windows) AS ng_windows,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;"
   },
   {
     "id": "weekly_dpm_trend_by_assembly",
@@ -21,7 +21,7 @@
       "y": "dpm",
       "series": "model_name"
     },
-    "sql": "WITH base AS (\n  SELECT\n    date_trunc('week', \"Report Date\")::date AS wk,\n    \"Model Name\" AS model_name,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  wk,\n  model_name,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nGROUP BY 1,2\nORDER BY wk, model_name;"
+    "sql": "WITH base AS (\n  SELECT\n    date_trunc('week', \"Report Date\")::date AS wk,\n    \"Model Name\" AS model_name,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  wk,\n  model_name,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nGROUP BY 1,2\nORDER BY wk, model_name;"
   },
   {
     "id": "top10_assemblies_by_dpm",
@@ -32,7 +32,7 @@
       "x": "dpm",
       "y": "model_name"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Model Name\" AS model_name,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  model_name,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY model_name\nORDER BY dpm DESC NULLS LAST\nLIMIT 10;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Model Name\" AS model_name,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  model_name,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY model_name\nORDER BY dpm DESC NULLS LAST\nLIMIT 10;"
   },
   {
     "id": "line_yield_comparison_for_assembly",
@@ -43,7 +43,7 @@
       "x": "line",
       "y": "window_yield_pct"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    \"Model Name\" AS model_name,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  SUM(windows) AS windows,\n  SUM(ng_windows) AS ng_windows,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE model_name = :model\n  AND report_date >= :from AND report_date < :to\nGROUP BY line\nORDER BY line;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    \"Model Name\" AS model_name,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  SUM(windows) AS windows,\n  SUM(ng_windows) AS ng_windows,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE model_name = :model\n  AND report_date >= :from AND report_date < :to\nGROUP BY line\nORDER BY line;"
   },
   {
     "id": "defects_per_board_by_line_daily",
@@ -55,7 +55,7 @@
       "y": "defects_per_board",
       "series": "line"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    \"Total Boards\" AS boards,\n    \"NG Windows\" AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(boards) AS boards,\n  SUM(ng_windows) AS ngw,\n  SUM(ng_windows) / NULLIF(SUM(boards), 0) AS defects_per_board\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"boards_total\", \"Total Boards\") AS boards,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(boards) AS boards,\n  SUM(ng_windows) AS ngw,\n  SUM(ng_windows) / NULLIF(SUM(boards), 0) AS defects_per_board\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;"
   },
   {
     "id": "windows_per_board_vs_dpm_scatter",
@@ -68,7 +68,7 @@
       "series": "line",
       "label": "model_name"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Model Name\" AS model_name,\n    \"Line\" AS line,\n    \"Total Boards\" AS boards,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  model_name,\n  line,\n  SUM(windows) / NULLIF(SUM(boards), 0) AS windows_per_board,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY model_name, line\nHAVING SUM(boards) > 0 AND SUM(windows) > 0;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Model Name\" AS model_name,\n    \"Line\" AS line,\n    COALESCE(\"boards_total\", \"Total Boards\") AS boards,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  model_name,\n  line,\n  SUM(windows) / NULLIF(SUM(boards), 0) AS windows_per_board,\n  SUM(ng_windows) / NULLIF(SUM(windows), 0) * 1e6 AS dpm\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY model_name, line\nHAVING SUM(boards) > 0 AND SUM(windows) > 0;"
   },
   {
     "id": "yield_heatmap_line_by_assembly",
@@ -80,7 +80,7 @@
       "col": "line",
       "value": "window_yield_pct"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    \"Model Name\" AS model_name,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  model_name,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY line, model_name;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    \"Model Name\" AS model_name,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  model_name,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY line, model_name;"
   },
   {
     "id": "rolling7_window_yield_by_line",
@@ -92,7 +92,7 @@
       "y": "window_yield_pct_roll7",
       "series": "line"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows\n  FROM moat_dpm\n),\nagg AS (\n  SELECT\n    d,\n    line,\n    SUM(windows) AS windows,\n    SUM(ng_windows) AS ng_windows\n  FROM base\n  GROUP BY d, line\n),\nyield AS (\n  SELECT\n    d,\n    line,\n    (windows - ng_windows) / NULLIF(windows, 0) * 100.0 AS window_yield_pct\n  FROM agg\n)\nSELECT\n  d,\n  line,\n  AVG(window_yield_pct) OVER (\n    PARTITION BY line\n    ORDER BY d\n    ROWS BETWEEN 6 PRECEDING AND CURRENT ROW\n  ) AS window_yield_pct_roll7\nFROM yield\nORDER BY d, line;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows\n  FROM moat_dpm\n),\nagg AS (\n  SELECT\n    d,\n    line,\n    SUM(windows) AS windows,\n    SUM(ng_windows) AS ng_windows\n  FROM base\n  GROUP BY d, line\n),\nyield AS (\n  SELECT\n    d,\n    line,\n    (windows - ng_windows) / NULLIF(windows, 0) * 100.0 AS window_yield_pct\n  FROM agg\n)\nSELECT\n  d,\n  line,\n  AVG(window_yield_pct) OVER (\n    PARTITION BY line\n    ORDER BY d\n    ROWS BETWEEN 6 PRECEDING AND CURRENT ROW\n  ) AS window_yield_pct_roll7\nFROM yield\nORDER BY d, line;"
   },
   {
     "id": "throughput_vs_quality_by_line",
@@ -104,7 +104,7 @@
       "y": "window_yield_pct",
       "label": "line"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    \"Total Boards\" AS boards,\n    COALESCE(\"Total Windows\", \"Windows per board\" * \"Total Boards\") AS windows,\n    \"NG Windows\" AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  SUM(boards) AS boards,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY line;"
+    "sql": "WITH base AS (\n  SELECT\n    \"Line\" AS line,\n    COALESCE(\"boards_total\", \"Total Boards\") AS boards,\n    COALESCE(\"opportunities_total\", \"Total Windows\", COALESCE(\"windows_per_board\", \"Windows per board\") * COALESCE(\"boards_total\", \"Total Boards\")) AS windows,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows,\n    \"Report Date\"::date AS report_date\n  FROM moat_dpm\n)\nSELECT\n  line,\n  SUM(boards) AS boards,\n  (SUM(windows) - SUM(ng_windows)) / NULLIF(SUM(windows), 0) * 100.0 AS window_yield_pct\nFROM base\nWHERE report_date >= :from AND report_date < :to\nGROUP BY line;"
   },
   {
     "id": "spc_u_chart_defects_per_board",
@@ -116,7 +116,7 @@
       "y": "u_value",
       "series": "line"
     },
-    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    \"Total Boards\" AS boards,\n    \"NG Windows\" AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(boards) AS boards,\n  SUM(ng_windows) AS ngw,\n  SUM(ng_windows) / NULLIF(SUM(boards), 0) AS u_value -- defects/board\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;",
+    "sql": "WITH base AS (\n  SELECT\n    \"Report Date\"::date AS d,\n    \"Line\" AS line,\n    COALESCE(\"boards_total\", \"Total Boards\") AS boards,\n    COALESCE(\"defect_count_true\", \"NG Windows\") AS ng_windows\n  FROM moat_dpm\n)\nSELECT\n  d,\n  line,\n  SUM(boards) AS boards,\n  SUM(ng_windows) AS ngw,\n  SUM(ng_windows) / NULLIF(SUM(boards), 0) AS u_value -- defects/board\nFROM base\nGROUP BY 1,2\nORDER BY 1,2;",
     "notes": "Compute mean and UCL/LCL per line after fetching results: UCL = ū + 3 * sqrt(ū / n_i), LCL = max(0, ū - 3 * sqrt(ū / n_i)), where n_i is the boards inspected on that day."
   }
 ]

--- a/static/js/dpm.js
+++ b/static/js/dpm.js
@@ -61,15 +61,23 @@ function parseRelativeDate(token) {
 function computeDerived(row, expr) {
   // Safe limited evaluator for expressions like a/b
   const fc = Number(
-    row['FalseCall Windows']
+    row['false_call_count']
+    ?? row['FalseCall Windows']
     ?? row['falsecall_windows']
     ?? row['FalseCall Parts']
     ?? row['falsecall_parts']
     ?? 0,
   );
-  const boards = Number(row['Total Boards'] ?? row['total_boards'] ?? 0);
+  const boards = Number(
+    row['boards_total']
+    ?? row['boards_in']
+    ?? row['Total Boards']
+    ?? row['total_boards']
+    ?? 0,
+  );
   const totalWindows = Number(
-    row['Total Windows']
+    row['opportunities_total']
+    ?? row['Total Windows']
     ?? row['total_windows']
     ?? row['Total Parts']
     ?? row['total_parts']
@@ -681,13 +689,20 @@ async function runChartFlexible() {
     if (yAgg === 'count') return 1;
       if (source === 'avg_false_calls_per_assembly') {
         const fc = Number(
-          row['FalseCall Windows']
+          row['false_call_count']
+          ?? row['FalseCall Windows']
           ?? row['falsecall_windows']
           ?? row['FalseCall Parts']
           ?? row['falsecall_parts']
           ?? 0,
         );
-        const tb = Number(row['Total Boards'] ?? row['total_boards'] ?? 0);
+        const tb = Number(
+          row['boards_total']
+          ?? row['boards_in']
+          ?? row['Total Boards']
+          ?? row['total_boards']
+          ?? 0,
+        );
         return tb ? fc / tb : 0;
       }
     // derived
@@ -865,11 +880,33 @@ function resolveColumns(rows) {
     line: find(['Line','line','Line Name','line_name']),
     assembly: find(['Assembly','assembly','Program','program']),
     rev: find(['Rev','rev','Revision','revision']),
-    ngParts: find(['NG Windows','ng_windows','NG Parts','ng_parts','NG','ng','Defect Parts','defect_parts']),
-    ngPPM: find(['DPM','dpm','NG PPM','ng_ppm','NG_PPM']),
-    fcParts: find(['FalseCall Windows','falsecall_windows','FalseCall Parts','falsecall_parts']),
-    totalBoards: find(['Total Boards','total_boards']),
-    totalParts: find(['Total Windows','total_windows','Total Parts','total_parts']),
+    ngParts: find([
+      'defect_count_true',
+      'NG Windows',
+      'ng_windows',
+      'NG Parts',
+      'ng_parts',
+      'NG',
+      'ng',
+      'Defect Parts',
+      'defect_parts',
+    ]),
+    ngPPM: find(['dpm','DPM','NG PPM','ng_ppm','NG_PPM']),
+    fcParts: find([
+      'false_call_count',
+      'FalseCall Windows',
+      'falsecall_windows',
+      'FalseCall Parts',
+      'falsecall_parts',
+    ]),
+    totalBoards: find(['boards_total','boards_in','Total Boards','total_boards']),
+    totalParts: find([
+      'opportunities_total',
+      'Total Windows',
+      'total_windows',
+      'Total Parts',
+      'total_parts',
+    ]),
   };
 }
 

--- a/static/js/ppm.js
+++ b/static/js/ppm.js
@@ -61,9 +61,24 @@ function parseRelativeDate(token) {
 function computeDerived(row, expr) {
   // Safe limited evaluator for expressions like a/b
   const ctx = {
-    falsecall_parts: Number(row['FalseCall Parts'] ?? row['falsecall_parts'] ?? 0),
-    total_boards: Number(row['Total Boards'] ?? row['total_boards'] ?? 0),
-    total_parts: Number(row['Total Parts'] ?? row['total_parts'] ?? 0),
+    falsecall_parts: Number(
+      row['fc_parts']
+      ?? row['FalseCall Parts']
+      ?? row['falsecall_parts']
+      ?? 0,
+    ),
+    total_boards: Number(
+      row['boards_in']
+      ?? row['Total Boards']
+      ?? row['total_boards']
+      ?? 0,
+    ),
+    total_parts: Number(
+      row['parts_total']
+      ?? row['Total Parts']
+      ?? row['total_parts']
+      ?? 0,
+    ),
   };
   // Only allow identifiers, numbers, spaces, and operators + - * / ( ) .
   const safe = /^[\w\s+\-*/().]+$/.test(expr);
@@ -477,8 +492,18 @@ async function runChartFlexible() {
   const valueFn = (row) => {
     if (yAgg === 'count') return 1;
     if (source === 'avg_false_calls_per_assembly') {
-      const fc = Number(row['FalseCall Parts'] ?? row['falsecall_parts'] ?? 0);
-      const tb = Number(row['Total Boards'] ?? row['total_boards'] ?? 0);
+      const fc = Number(
+        row['fc_parts']
+        ?? row['FalseCall Parts']
+        ?? row['falsecall_parts']
+        ?? 0,
+      );
+      const tb = Number(
+        row['boards_in']
+        ?? row['Total Boards']
+        ?? row['total_boards']
+        ?? 0,
+      );
       return tb ? fc / tb : 0;
     }
     // derived
@@ -630,11 +655,11 @@ function resolveColumns(rows) {
     line: find(['Line','line','Line Name','line_name']),
     assembly: find(['Assembly','assembly','Program','program']),
     rev: find(['Rev','rev','Revision','revision']),
-    ngParts: find(['NG Parts','ng_parts','NG','ng','Defect Parts','defect_parts']),
-    ngPPM: find(['NG PPM','ng_ppm','NG_PPM']),
-    fcParts: find(['FalseCall Parts','falsecall_parts']),
-    totalBoards: find(['Total Boards','total_boards']),
-    totalParts: find(['Total Parts','total_parts']),
+    ngParts: find(['ng_parts_true','NG Parts','ng_parts','NG','ng','Defect Parts','defect_parts']),
+    ngPPM: find(['true_defect_ppm','NG PPM','ng_ppm','NG_PPM']),
+    fcParts: find(['fc_parts','FalseCall Parts','falsecall_parts']),
+    totalBoards: find(['boards_in','Total Boards','total_boards']),
+    totalParts: find(['parts_total','Total Parts','total_parts']),
   };
 }
 


### PR DESCRIPTION
## Summary
- normalize fetched MOAT PPM/DPM rows to include canonical board, part, and opportunity fields
- update server-side aggregations, exports, and saved chart SQL to use canonical aliases for PPM and DPM metrics
- refresh PPM/DPM front-end helpers to read canonical columns while preserving legacy fallbacks

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3c6aa414c83258fbef17562ef754f